### PR TITLE
ia32: fix indentation error

### DIFF
--- a/ia32/Makefile
+++ b/ia32/Makefile
@@ -11,11 +11,11 @@
 #
 
 ifneq (, $(shell which ncc))
-	BCC ?= ncc
+BCC ?= ncc
 else ifneq (, $(shell which bcc))
-	BCC ?= bcc
+BCC ?= bcc
 else
-	$(error "No BCC nor NCC found in PATH. Consider apt-get install bcc.")
+$(error "No BCC nor NCC found in PATH. Consider apt-get install bcc.")
 endif
 
 CFLAGS = -ansi -I.


### PR DESCRIPTION
There is a wrong indent in if clause in ia32 Makefile which causes build to break.