### PR TITLE
phfs.c: fixed array index check

### DIFF
--- a/armv7m7-imxrt106x/phfs.c
+++ b/armv7m7-imxrt106x/phfs.c
@@ -25,70 +25,69 @@
 #define TEMP 2
 
 struct {
-    s32 (*open)(u16, char *, u32);
-    s32 (*read)(u16, s32, u32 *, u8 *, u32);
-    s32 (*write)(u16, s32, u32 *, u8 *, u32, u8);
-    s32 (*close)(u16, s32);
-    unsigned int dn;
+	s32 (*open)(u16, char *, u32);
+	s32 (*read)(u16, s32, u32 *, u8 *, u32);
+	s32 (*write)(u16, s32, u32 *, u8 *, u32, u8);
+	s32 (*close)(u16, s32);
+	unsigned int dn;
 } phfs_handlers[PDN_NB];
 
 
 
 s32 phfs_open(u16 pdn, char *name, u32 flags)
 {
-    if (pdn > PDN_NB)
-        return ERR_ARG;
+	if (pdn >= PDN_NB)
+		return ERR_ARG;
 
-    return phfs_handlers[pdn].open(phfs_handlers[pdn].dn, name, flags);
+	return phfs_handlers[pdn].open(phfs_handlers[pdn].dn, name, flags);
 }
 
 
 s32 phfs_read(u16 pdn, s32 handle, u32 *pos, u8 *buff, u32 len)
 {
-    if (pdn > PDN_NB)
-        return ERR_ARG;
+	if (pdn >= PDN_NB)
+		return ERR_ARG;
 
-    return phfs_handlers[pdn].read(phfs_handlers[pdn].dn, handle, pos, buff, len);
+	return phfs_handlers[pdn].read(phfs_handlers[pdn].dn, handle, pos, buff, len);
 }
 
 
 s32 phfs_write(u16 pdn, s32 handle, u32 *pos, u8 *buff, u32 len, u8 sync)
 {
-    if (pdn > PDN_NB)
-        return ERR_ARG;
+	if (pdn >= PDN_NB)
+		return ERR_ARG;
 
-    return phfs_handlers[pdn].write(phfs_handlers[pdn].dn, handle, pos, buff, len, sync);
+	return phfs_handlers[pdn].write(phfs_handlers[pdn].dn, handle, pos, buff, len, sync);
 }
 
 
 s32 phfs_close(u16 pdn, s32 handle)
 {
-    if (pdn > PDN_NB)
-        return ERR_ARG;
+	if (pdn >= PDN_NB)
+		return ERR_ARG;
 
-    return phfs_handlers[pdn].close(phfs_handlers[pdn].dn, handle);
+	return phfs_handlers[pdn].close(phfs_handlers[pdn].dn, handle);
 }
 
 
 void phfs_init(void)
 {
-    int i;
+	int i;
 
-    /* Handlers for flash memories */
-    for (i = 0; i < 2; ++i) {
-        phfs_handlers[PDN_FLASH0 + i].open = flash_open;
-        phfs_handlers[PDN_FLASH0 + i].read = flash_read;
-        phfs_handlers[PDN_FLASH0 + i].write = flash_write;
-        phfs_handlers[PDN_FLASH0 + i].close = flash_close;
-        phfs_handlers[PDN_FLASH0 + i].dn = i;
-    }
+	/* Handlers for flash memories */
+	for (i = 0; i < 2; ++i) {
+		phfs_handlers[PDN_FLASH0 + i].open = flash_open;
+		phfs_handlers[PDN_FLASH0 + i].read = flash_read;
+		phfs_handlers[PDN_FLASH0 + i].write = flash_write;
+		phfs_handlers[PDN_FLASH0 + i].close = flash_close;
+		phfs_handlers[PDN_FLASH0 + i].dn = i;
+	}
 
-    phfs_handlers[PDN_COM1].open = phoenixd_open;
-    phfs_handlers[PDN_COM1].read = phoenixd_read;
-    phfs_handlers[PDN_COM1].write = phoenixd_write;
-    phfs_handlers[PDN_COM1].close = phoenixd_close;
-    phfs_handlers[PDN_COM1].dn = UART_LOADER_ID;
+	phfs_handlers[PDN_COM1].open = phoenixd_open;
+	phfs_handlers[PDN_COM1].read = phoenixd_read;
+	phfs_handlers[PDN_COM1].write = phoenixd_write;
+	phfs_handlers[PDN_COM1].close = phoenixd_close;
+	phfs_handlers[PDN_COM1].dn = UART_LOADER_ID;
 
-
-    return;
+	return;
 }


### PR DESCRIPTION
For `pdn == PDN_NB` array index is out of range.
I also changed the indentation from spaces to tabs.

### My propositions:

**1.** 
instead
```
	if (pdn >= PDN_NB)
		return ERR_ARG;

	return phfs_handlers[pdn].open(phfs_handlers[pdn].dn, name, flags);
```
better will be
```
	if (pdn < sizeof(phfs_handlers) / sizeof(phfs_handlers[0]))
		return phfs_handlers[pdn].open(phfs_handlers[pdn].dn, name, flags);
	return ERR_ARG;
```

**2.** 
instead
```
void phfs_init(void)
{
	int i;

	/* Handlers for flash memories */
	for (i = 0; i < 2; ++i) {
		phfs_handlers[PDN_FLASH0 + i].open = flash_open;
		phfs_handlers[PDN_FLASH0 + i].read = flash_read;
		phfs_handlers[PDN_FLASH0 + i].write = flash_write;
		phfs_handlers[PDN_FLASH0 + i].close = flash_close;
		phfs_handlers[PDN_FLASH0 + i].dn = i;
	}

	phfs_handlers[PDN_COM1].open = phoenixd_open;
	phfs_handlers[PDN_COM1].read = phoenixd_read;
	phfs_handlers[PDN_COM1].write = phoenixd_write;
	phfs_handlers[PDN_COM1].close = phoenixd_close;
	phfs_handlers[PDN_COM1].dn = UART_LOADER_ID;

	return;
}
```
the more readable array initialization
```
void phfs_init(void)
{
	/* Handlers for flash memories */
	phfs_handlers[PDN_FLASH0].open = flash_open;
	phfs_handlers[PDN_FLASH0].read = flash_read;
	phfs_handlers[PDN_FLASH0].write = flash_write;
	phfs_handlers[PDN_FLASH0].close = flash_close;
	phfs_handlers[PDN_FLASH0].dn = 0;

	phfs_handlers[PDN_FLASH1].open = flash_open;
	phfs_handlers[PDN_FLASH1].read = flash_read;
	phfs_handlers[PDN_FLASH1].write = flash_write;
	phfs_handlers[PDN_FLASH1].close = flash_close;
	phfs_handlers[PDN_FLASH1].dn = 1;

	phfs_handlers[PDN_COM1].open = phoenixd_open;
	phfs_handlers[PDN_COM1].read = phoenixd_read;
	phfs_handlers[PDN_COM1].write = phoenixd_write;
	phfs_handlers[PDN_COM1].close = phoenixd_close;
	phfs_handlers[PDN_COM1].dn = UART_LOADER_ID;

	return;
}
```
