### PR TITLE
low.c: optimization low_memcpy()

### DIFF
--- a/armv7m7-imxrt106x/low.c
+++ b/armv7m7-imxrt106x/low.c
@@ -218,29 +218,26 @@ void low_copyfrom(u16 segm, u16 offs, void *dst, unsigned int l)
 void low_memcpy(void *dst, const void *src, unsigned int l)
 {
 	asm volatile(" \
-		mov r1, %2; \
-		mov r3, %1; \
-		mov r4, %0; \
-		orr r2, r3, r4; \
-		ands r2, #3; \
+		orr r3, %0, %1; \
+		ands r3, #3; \
 		bne 2f; \
 	1: \
-		cmp r1, #4; \
+		cmp %2, #4; \
 		ittt hs; \
-		ldrhs r2, [r3], #4; \
-		strhs r2, [r4], #4; \
-		subshs r1, #4; \
+		ldrhs r3, [%1], #4; \
+		strhs r3, [%0], #4; \
+		subshs %2, #4; \
 		bhs 1b; \
 	2: \
-		cmp r1, #0; \
+		cmp %2, #0; \
 		ittt ne; \
-		ldrbne r2, [r3], #1; \
-		strbne r2, [r4], #1; \
-		subsne r1, #1; \
+		ldrbne r3, [%1], #1; \
+		strbne r3, [%0], #1; \
+		subsne %2, #1; \
 		bne 2b"
+	: "+l" (dst), "+l" (src), "+l" (l)
 	:
-	: "r" (dst), "r" (src), "r" (l)
-	: "r1", "r2", "r3", "r4", "memory", "cc");
+	: "r3", "memory", "cc");
 }
 
 


### PR DESCRIPTION
Change of register usage in inline assembly.

Code disassembly:

- **current version**
```
00000000 <low_memcpy>:
   0:   b470            push    {r4, r5, r6}
   2:   460d            mov     r5, r1
   4:   4616            mov     r6, r2
   6:   4631            mov     r1, r6
   8:   462b            mov     r3, r5
   a:   4604            mov     r4, r0
   c:   ea43 0204       orr.w   r2, r3, r4
  10:   f012 0203       ands.w  r2, r2, #3
  14:   d108            bne.n   28 <low_memcpy+0x28>
  16:   2904            cmp     r1, #4
  18:   bf22            ittt    cs
  1a:   f853 2b04       ldrcs.w r2, [r3], #4
  1e:   f844 2b04       strcs.w r2, [r4], #4
  22:   f1b1 0104       subscs.w        r1, r1, #4
  26:   d2f6            bcs.n   16 <low_memcpy+0x16>
  28:   2900            cmp     r1, #0
  2a:   bf1e            ittt    ne
  2c:   f813 2b01       ldrbne.w        r2, [r3], #1
  30:   f804 2b01       strbne.w        r2, [r4], #1
  34:   f1b1 0101       subsne.w        r1, r1, #1
  38:   d1f6            bne.n   28 <low_memcpy+0x28>
  3a:   bc70            pop     {r4, r5, r6}
  3c:   4770            bx      lr
  3e:   bf00            nop
```

- **my proposition**
```
00000000 <low_memcpy>:
   0:   ea40 0301       orr.w   r3, r0, r1
   4:   f013 0303       ands.w  r3, r3, #3
   8:   d108            bne.n   1c <low_memcpy+0x1c>
   a:   2a04            cmp     r2, #4
   c:   bf22            ittt    cs
   e:   f851 3b04       ldrcs.w r3, [r1], #4
  12:   f840 3b04       strcs.w r3, [r0], #4
  16:   f1b2 0204       subscs.w        r2, r2, #4
  1a:   d2f6            bcs.n   a <low_memcpy+0xa>
  1c:   2a00            cmp     r2, #0
  1e:   bf1e            ittt    ne
  20:   f811 3b01       ldrbne.w        r3, [r1], #1
  24:   f800 3b01       strbne.w        r3, [r0], #1
  28:   f1b2 0201       subsne.w        r2, r2, #1
  2c:   d1f6            bne.n   1c <low_memcpy+0x1c>
  2e:   4770            bx      lr
```
