### PR TITLE
imxrt106x: fix spontaneous freezes of the uart

### DIFF
--- a/armv7m7-imxrt106x/low.c
+++ b/armv7m7-imxrt106x/low.c
@@ -26,6 +26,7 @@
 #include "../plostd.h"
 #include "../errors.h"
 #include "../serial.h"
+#include "../timer.h"
 #include "../syspage.h"
 #include "../phoenixd.h"
 
@@ -315,6 +316,15 @@ int low_mmget(unsigned int n, low_mmitem_t *mmitem)
 int low_launch(void)
 {
 	syspage_save();
+
+	/* Give the LPUART transmitters some time */
+	timer_wait(100, TIMER_EXPIRE, NULL, 0);
+
+	/* Tidy up */
+	serial_done();
+	timer_done();
+
+	low_done();
 
 	_imxrt_cleanDCache();
 

--- a/armv7m7-imxrt106x/serial.c
+++ b/armv7m7-imxrt106x/serial.c
@@ -480,9 +480,21 @@ void serial_done(void)
 
 		serial = &serial_common.serials[i++];
 
-		/* disable TX and RX */
+		/* Disable TX and RX */
 		*(serial->base + ctrlr) &= ~((1 << 19) | (1 << 18));
+		imxrt_dataBarrier();
+
+		/* Disable TX and RX interrupts */
 		*(serial->base + ctrlr) &= ~((1 << 23) | (1 << 21));
+
+		/* Flush TX and RX fifo */
+		*(serial->base + fifor) |= (1 << 15) | (1 << 14);
+
+		/* Safely perform LPUART software reset procedure */
+		*(serial->base + globalr) |= (1 << 1);
+		imxrt_dataBarrier();
+		*(serial->base + globalr) &= ~(1 << 1);
+		imxrt_dataBarrier();
 
 		low_irquninst(serial->irq);
 	}

--- a/plostd.c
+++ b/plostd.c
@@ -316,5 +316,9 @@ void plostd_printf(char attr, const char *fmt, ...)
 	}
 	va_end(ap);
 
+	/* CSI normal: all attributes off */
+	if (attr != ATTR_NONE)
+		plostd_puts("\033[0m");
+
 	return;
 }


### PR DESCRIPTION
The plo uses two uarts: 
- uart1: the console
- uart3: for communication with phoenixd.

When using the uart3 with different settings than those set by the plo, I've observed spontaneous freezing of the uart3 in Phoenix-RTOS (imxrt-multi and libtty), after changing the baud rate from that set by plo (115200) to a different speeds (9600, 230400, 460800) and setting raw mode.

The TX fifo of uart3 seemed not to be flushed before a jump to the system. I've added a cleanup routine and a sleep time of ~100ms additionally, because a quick reset of (uart1), which is used by the console, leads to the loss of the last messages from plo before jump to the system.