### PR TITLE
imxrt117x: fixed array index checking

### DIFF
--- a/armv7m7-imxrt117x/Makefile
+++ b/armv7m7-imxrt117x/Makefile
@@ -21,5 +21,3 @@ CFLAGS+= -mfloat-abi=soft
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
 OBJS += $(addprefix $(PREFIX_O)$(TARGET)/, _startup.o low.o imxrt.o serial.o cmd.o timer.o flashdrv.o rom_api.o flashcfg.o phfs-flash.o syspage.o)
-
-

--- a/armv7m7-imxrt117x/cmd.c
+++ b/armv7m7-imxrt117x/cmd.c
@@ -29,4 +29,3 @@ void cmd_flexram(char *args)
 {
 	//TODO
 }
-

--- a/armv7m7-imxrt117x/imxrt.c
+++ b/armv7m7-imxrt117x/imxrt.c
@@ -433,8 +433,10 @@ int _imxrt_systickInit(u32 interval)
 
 void _imxrt_systickSet(u8 state)
 {
-	*(imxrt_common.stk + stk_ctrl) &= ~(!state);
-	*(imxrt_common.stk + stk_ctrl) |= !!state;
+	state = !state;
+	*(imxrt_common.stk + stk_ctrl) &= ~state;
+	state = !state;
+	*(imxrt_common.stk + stk_ctrl) |= state;
 }
 
 

--- a/armv7m7-imxrt117x/low.c
+++ b/armv7m7-imxrt117x/low.c
@@ -324,7 +324,6 @@ int low_launch(void)
 }
 
 
-
 /* Opeartions on interrupts */
 
 void low_cli(void)
@@ -358,7 +357,7 @@ void low_maskirq(u16 n, u8 v)
 
 int low_irqinst(u16 irq, int (*isr)(u16, void *), void *data)
 {
-	if (irq > SIZE_INTERRUPTS)
+	if (irq >= SIZE_INTERRUPTS)
 		return ERR_ARG;
 
 	low_cli();

--- a/armv7m7-imxrt117x/serial.c
+++ b/armv7m7-imxrt117x/serial.c
@@ -148,7 +148,7 @@ int serial_read(unsigned int pn, u8 *buff, u16 len, u16 timeout)
 
 	--pn;
 
-	if (pn > UART_MAX_CNT || !serialConfig[pn])
+	if (pn >= (sizeof(serialConfig) / sizeof(serialConfig[0])) || !serialConfig[pn])
 		return ERR_ARG;
 
 	serial = &serial_common.serials[serialPos[pn]];
@@ -184,7 +184,7 @@ int serial_write(unsigned int pn, const u8 *buff, u16 len)
 
 	--pn;
 
-	if (pn > UART_MAX_CNT || !serialConfig[pn])
+	if (pn >= (sizeof(serialConfig) / sizeof(serialConfig[0])) || !serialConfig[pn])
 		return ERR_ARG;
 
 	serial = &serial_common.serials[serialPos[pn]];


### PR DESCRIPTION
Fixed array index chaecking:
```
low_irqinst()
serial_read()
serial_write()
``` 
These bugs are also in imxrt106x.

Additionally:
- `_imxrt_systickSet()`: compiler warnings have been eliminated
- removed whitespaces.


