### PR TITLE
Support serial console by parameter

### DIFF
--- a/ia32/Makefile
+++ b/ia32/Makefile
@@ -19,7 +19,9 @@ $(error "No BCC nor NCC found in PATH. Consider apt-get install bcc.")
 endif
 
 CFLAGS = -ansi -I.
-#CFLAGS += -DCONSOLE_SERIAL
+ifneq ($(CONSOLE), vga)
+	CFLAGS += -DCONSOLE_SERIAL
+endif
 
 AS = as86
 LD = ld86


### PR DESCRIPTION
Change is supposed to make possible building plo in serial mode by setting variable explicitly:

TARGET=ia32-generic CONSOLE=serial phoenix-rtos-build/build.sh ...

Referenced by:
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/175
https://github.com/phoenix-rtos/phoenix-rtos-project/pull/46