### PR TITLE
Enable jtag/debugger and some fixes

### DIFF
--- a/armv7m7-imxrt106x/imxrt.c
+++ b/armv7m7-imxrt106x/imxrt.c
@@ -1898,6 +1898,9 @@ void _imxrt_init(void)
 	*(imxrt_common.ccm + ccm_ccgr5) = 0xf00f330f;
 	*(imxrt_common.ccm + ccm_ccgr6) = 0x00fc0f0f;
 
+	imxrt_dataSyncBarrier();
+	imxrt_dataInstrBarrier();
+
 	/* Remain in run mode on wfi */
 	_imxrt_ccmSetMode(0);
 
@@ -1906,6 +1909,9 @@ void _imxrt_init(void)
 	_imxrt_ccmDeinitEnetPll();
 
 	_imxrt_ccmDeinitUsb2Pll();
+
+	/* Wait for any pending CCM div/mux handshake process to complete */
+	while (*(imxrt_common.ccm + ccm_cdhipr) & 0x1002b);
 
 	/* Allow userspace applications to access hardware registers */
 	for (i = 0; i < sizeof(imxrt_common.aips) / sizeof(imxrt_common.aips[0]); ++i) {

--- a/armv7m7-imxrt106x/imxrt.c
+++ b/armv7m7-imxrt106x/imxrt.c
@@ -1891,9 +1891,9 @@ void _imxrt_init(void)
 
 	/* Disable unused clocks */
 	*(imxrt_common.ccm + ccm_ccgr0) = 0x00c0ffff;
-	*(imxrt_common.ccm + ccm_ccgr1) = 0x30000000;
+	*(imxrt_common.ccm + ccm_ccgr1) = 0x300c0000;
 	*(imxrt_common.ccm + ccm_ccgr2) = 0xfffff03f;
-	*(imxrt_common.ccm + ccm_ccgr3) = 0xf00c3fff;
+	*(imxrt_common.ccm + ccm_ccgr3) = 0xf00c3fcf;
 	*(imxrt_common.ccm + ccm_ccgr4) = 0x0000ff3c;
 	*(imxrt_common.ccm + ccm_ccgr5) = 0xf00f330f;
 	*(imxrt_common.ccm + ccm_ccgr6) = 0x00fc0f0f;

--- a/armv7m7-imxrt106x/imxrt.c
+++ b/armv7m7-imxrt106x/imxrt.c
@@ -1885,7 +1885,7 @@ void _imxrt_init(void)
 	_imxrt_ccmSetDiv(clk_div_ahb, 0x0);
 	_imxrt_ccmSetDiv(clk_div_ipg, 0x3);
 
-	/* Now CPU runs again on ARM PLL at 600M (with divider 2) */
+	/* Now CPU runs again on ARM PLL at 528M (with divider 2) */
 	_imxrt_ccmSetMux(clk_mux_prePeriph, 0x3);
 	_imxrt_ccmSetMux(clk_mux_periph, 0x0);
 


### PR DESCRIPTION
This commit is analogous to https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/178 because of the same procedure.

* The debugger functionality has been checked against to use J-Link (jtag / swd) and [pyOCD](https://github.com/pyocd/pyOCD) (using CMSIS-DAP available on the mimixrt1064-evk board).
* Also a minor update in the comment about clock freq.