### PR TITLE
armv7m7: fixed some bugs

### DIFF
--- a/armv7m7-imxrt106x/low.c
+++ b/armv7m7-imxrt106x/low.c
@@ -373,7 +373,7 @@ void low_maskirq(u16 n, u8 v)
 
 int low_irqinst(u16 irq, int (*isr)(u16, void *), void *data)
 {
-	if (irq > SIZE_INTERRUPTS)
+	if (irq >= SIZE_INTERRUPTS)
 		return ERR_ARG;
 
 	low_cli();

--- a/armv7m7-imxrt117x/serial.c
+++ b/armv7m7-imxrt117x/serial.c
@@ -98,7 +98,7 @@ int serial_rxEmpty(unsigned int pn)
 	serial_t *serial;
 	--pn;
 
-	if (pn > (sizeof(serialConfig) / sizeof(serialConfig[0])) || !serialConfig[pn])
+	if (pn >= (sizeof(serialConfig) / sizeof(serialConfig[0])) || !serialConfig[pn])
 		return ERR_ARG;
 
 	serial = &serial_common.serials[serialPos[pn]];

--- a/cmd.c
+++ b/cmd.c
@@ -486,7 +486,7 @@ void cmd_copy(char *s)
 	phfs_conf_t phfses[2];
 
 	u16 cmdArgsc = 0, argsID = 0;
-	char cmdArgs[7][LINESZ + 1];
+	char cmdArgs[MAX_CMD_ARGS_NB][LINESZ + 1];
 
 	phfses[0].datasz = phfses[1].datasz = 0;
 	phfses[0].dataOffs = phfses[1].dataOffs = 0;
@@ -801,12 +801,15 @@ void cmd_app(char *s)
 	low_setDefaultDMAP(dmap);
 
 	/* Get map for code section */
-	if ((argID + 1) < cmdArgsc)
+	if ((argID + 1) < cmdArgsc) {
 		low_memcpy(cmap, cmdArgs[++argID], 8);
-
+		cmap[sizeof(cmap) - 1] = '\0';
+	}
 	/* Get map for data section */
-	if ((argID + 1) < cmdArgsc)
+	if ((argID + 1) < cmdArgsc) {
 		low_memcpy(dmap, cmdArgs[++argID], 8);
+		dmap[sizeof(dmap) - 1] = '\0';
+	}
 
 
 	if (phfs.dataOffs != 0 && phfs.datasz != 0)


### PR DESCRIPTION
1. `low_irqinst()` and `serial_rxEmpty()` - corrected index checking.
2. `cmd_copy()` - array size is to small.
in `cmd_parseArgs()` index could be `< MAX_CMD_ARGS_NB`.
3. `cmd_app()` - fixed buffer overflow.


