### PR TITLE
cmd.c: corrected condition

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -120,7 +120,7 @@ static int cmd_cpphfs2phfs(phfs_conf_t *src, phfs_conf_t *dst)
 	u8 buff[MSG_BUFF_SZ];
 
 	if (src->handle.offs != 0) {
-		if (src->datasz == 0 && src->datasz == 0) {
+		if (src->datasz == 0 && dst->datasz == 0) {
 			size = 0;
 		}
 		else {


### PR DESCRIPTION
I have two comments:
1. instead of going throught loop
```
		if (src->datasz == 0 && src->datasz == 0) {
			size = 0;
		}
```
give e.g. this
```
		if (src->datasz == 0 && src->datasz == 0) {
			return 0;
		}
```
2. after
```
		if ((res = phfs_read(src->dn, src->handle, &src->dataOffs, buff, chunk)) < 0) {
			plostd_printf(ATTR_ERROR, "\nCan't read segment data\n");
			return ERR_PHFS_FILE;
		}
```
add
```
		if ((res == 0) { // end of file
			break;
		}
```
