### PR TITLE
imxrt: add separate uart console flag for plo

### DIFF
--- a/armv7m7-imxrt106x/peripherals.h
+++ b/armv7m7-imxrt106x/peripherals.h
@@ -87,6 +87,11 @@
 #define UART8_HW_FLOWCTRL 0
 #endif
 
+#ifdef UART_CONSOLE_PLO
+#undef UART_CONSOLE
+#define UART_CONSOLE UART_CONSOLE_PLO
+#endif
+
 #ifndef UART_CONSOLE
 #define UART_CONSOLE 1
 #endif


### PR DESCRIPTION
The flag UART_CONSOLE_PLO is optional. Should be
used when it is necessary to split up system console
with one for plo. If flag is not defined UART_CONSOLE
takes effect.