### PR TITLE
armv7m7: Fix syspage arguments parsing

### DIFF
--- a/armv7m7-imxrt106x/syspage.c
+++ b/armv7m7-imxrt106x/syspage.c
@@ -23,6 +23,7 @@
 #define MAX_MAPS_NB             16
 #define MAX_ARGS_SIZE           256
 #define MAX_ENTRIES_NB          6     /* 3 of kernel's sections, 2 of plo's sections and syspage */
+#define MAX_CMDLINE_SIZE        16
 
 #define MAX_SYSPAGE_SIZE     (sizeof(syspage_t) + MAX_ARGS_SIZE * sizeof(char) + MAX_PROGRAMS_NB * sizeof(syspage_program_t) + MAX_MAPS_NB * sizeof(syspage_map_t))
 
@@ -46,7 +47,7 @@ typedef struct syspage_program_t {
 	u8 dmap;
 	u8 imap;
 
-	char cmdline[16];
+	char cmdline[MAX_CMDLINE_SIZE];
 } syspage_program_t;
 
 
@@ -266,7 +267,7 @@ void syspage_save(void)
 /* TODO: align text and show map's attributes as string based on integer */
 void syspage_show(void)
 {
-	int i = 0;
+	int i;
 	plostd_printf(ATTR_LOADER, "\nSyspage addres: 0x%p\n", syspage_getAddress());
 	plostd_printf(ATTR_NONE, "--------------------------\n");
 
@@ -336,7 +337,7 @@ int syspage_getMapTop(const char *map, void **addr)
 	u8 id;
 
 	if (syspage_getMapID(map, &id) < 0) {
-		plostd_printf(ATTR_ERROR, "\nMAPS for %s doesn not exist!\n", map);
+		plostd_printf(ATTR_ERROR, "\nMAPS for %s does not exist!\n", map);
 		return -1;
 	}
 
@@ -352,14 +353,16 @@ int syspage_alignMapTop(const char *map)
 	u32 newTop;
 
 	if (syspage_getMapID(map, &id) < 0) {
-		plostd_printf(ATTR_ERROR, "\nMAPS for %s doesn not exist!\n", map);
+		plostd_printf(ATTR_ERROR, "\nMAPS for %s does not exist!\n", map);
 		return -1;
 	}
 
 	newTop = (syspage_common.maps[id].top + PAGE_SIZE - 1) & ~(PAGE_SIZE - 1);
 
-	if (newTop > syspage_common.maps[id].map.end)
+	if (newTop > syspage_common.maps[id].map.end) {
+		plostd_printf(ATTR_ERROR, "\nMap %s is full!\n", map);
 		return -1;
+	}
 
 	syspage_common.maps[id].top = newTop;
 
@@ -372,7 +375,7 @@ int syspage_getFreeSize(const char *map, u32 *sz)
 	u8 id;
 
 	if (syspage_getMapID(map, &id) < 0) {
-		plostd_printf(ATTR_ERROR, "\nMAPS for %s doesn not exist!\n", map);
+		plostd_printf(ATTR_ERROR, "\nMAPS for %s does not exist!\n", map);
 		return -1;
 	}
 
@@ -388,7 +391,7 @@ int syspage_write2Map(const char *map, const u8 *buff, u32 len)
 	u32 freesz;
 
 	if (syspage_getMapID(map, &id) < 0) {
-		plostd_printf(ATTR_ERROR, "\nMAPS for %s doesn not exist!\n", map);
+		plostd_printf(ATTR_ERROR, "\nMAPS for %s does not exist!\n", map);
 		return -1;
 	}
 
@@ -436,11 +439,28 @@ void syspage_addEntries(u32 start, u32 sz)
 int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, const char *name)
 {
 	u8 imapID, dmapID;
-	unsigned int pos = 0, len = 0;
+	unsigned int pos, len;
 	u32 progID = syspage_common.progsCnt;
 
 	if ((syspage_getMapID(imap, &imapID) < 0) || (syspage_getMapID(dmap, &dmapID) < 0)) {
-		plostd_printf(ATTR_ERROR, "\nMAPS for %s doesn not exist!\n", name);
+		plostd_printf(ATTR_ERROR, "\nMAPS for %s does not exist!\n", name);
+		return -1;
+	}
+
+	len = plostd_strlen(name);
+
+	if (syspage_common.argCnt + 1 + len + 1 + 1 > MAX_ARGS_SIZE) {
+		plostd_printf(ATTR_ERROR, "\nMAX_ARGS_SIZE for %s exceeded!\n", name);
+		return -1;
+	}
+
+	for (pos = 0; pos < len; pos++) {
+		if (name[pos] == ';')
+			break;
+	}
+
+	if (pos >= MAX_CMDLINE_SIZE) {
+		plostd_printf(ATTR_ERROR, "\nSyspage program %s, name is too long!\n", name);
 		return -1;
 	}
 
@@ -450,21 +470,17 @@ int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, 
 	syspage_common.progs[progID].imap = imapID;
 
 	syspage_common.args[syspage_common.argCnt++] = 'X';
-	low_memcpy((void *)&syspage_common.args[syspage_common.argCnt], name, plostd_strlen(name));
+	low_memcpy((void *)&syspage_common.args[syspage_common.argCnt], name, len);
 
-	syspage_common.argCnt += plostd_strlen(name);
+	syspage_common.argCnt += len;
 	syspage_common.args[syspage_common.argCnt++] = ' ';
 	syspage_common.args[syspage_common.argCnt] = '\0';
 
-	while (len < plostd_strlen(name)) {
-		if (name[len] == ';')
-			break;
-		++len;
-	}
-	low_memcpy(syspage_common.progs[progID].cmdline, name, len);
+	/* copy only program name, without (;) args) */
+	low_memcpy(syspage_common.progs[progID].cmdline, name, pos);
 
-	for (pos = len; pos < 16; ++pos)
-		syspage_common.progs[progID].cmdline[pos] = 0;
+	while (pos < MAX_CMDLINE_SIZE)
+		syspage_common.progs[progID].cmdline[pos++] = '\0';
 
 	syspage_common.progsCnt++;
 


### PR DESCRIPTION
This change fixes parsing of arguments passed to syspage and error checking in plo app command. Prior to this change arguments were truncated e.g `app flash0 @lwip;pppou:/dev/uart3:460800:up xip1 ocram2` was resolved as process name `lwip` with argv[1]= `pppou:/dev/` but expected was argv[1]=`pppou:/dev/uart3:460800:up`.

Working examples based on correct syntax:
```
app flash0 @lwip;pppou:/dev/uart3:460800:up xip1
app flash0 @ps_g3_mac_srv;msg=/dev/sap1;band=cen_a;run=3 xip1 ocram2
```
and downloading app to internal ram through auxiliary uart (using phoenixd):
```
app com1 g3adp_test;log7;m=/dev/sap1;testcase=2:8:0:18
```
JIRA: RTOS-4 , RTOS-5