### PR TITLE
armv7m7: Add `app` command executable flag `-x`

### DIFF
--- a/armv7a9-zynq7000/syspage.c
+++ b/armv7a9-zynq7000/syspage.c
@@ -5,8 +5,8 @@
  *
  * Syspage
  *
- * Copyright 2020 - 2021 Phoenix Systems
- * Authors: Hubert Buczynski
+ * Copyright 2020-2021 Phoenix Systems
+ * Authors: Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -435,11 +435,12 @@ void syspage_addEntries(u32 start, u32 sz)
 
 /* Program's functions */
 
-int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, const char *name)
+int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, const char *name, u32 flags)
 {
 	u8 imapID, dmapID;
 	unsigned int pos, len;
 	u32 progID = syspage_common.progsCnt;
+	const u32 isExec = (flags & flagSyspageExec) != 0;
 
 	if ((syspage_getMapID(imap, &imapID) < 0) || (syspage_getMapID(dmap, &dmapID) < 0)) {
 		plostd_printf(ATTR_ERROR, "\nMAPS for %s does not exist!\n", name);
@@ -448,7 +449,7 @@ int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, 
 
 	len = plostd_strlen(name);
 
-	if (syspage_common.argCnt + 1 + len + 1 + 1 > MAX_ARGS_SIZE) {
+	if (syspage_common.argCnt + isExec + len + 1 + 1 > MAX_ARGS_SIZE) {
 		plostd_printf(ATTR_ERROR, "\nMAX_ARGS_SIZE for %s exceeded!\n", name);
 		return -1;
 	}
@@ -468,7 +469,9 @@ int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, 
 	syspage_common.progs[progID].dmap = dmapID;
 	syspage_common.progs[progID].imap = imapID;
 
-	syspage_common.args[syspage_common.argCnt++] = 'X';
+	if (isExec)
+		syspage_common.args[syspage_common.argCnt++] = 'X';
+
 	low_memcpy((void *)&syspage_common.args[syspage_common.argCnt], name, len);
 
 	syspage_common.argCnt += len;

--- a/armv7m7-imxrt106x/syspage.c
+++ b/armv7m7-imxrt106x/syspage.c
@@ -5,8 +5,8 @@
  *
  * Syspage
  *
- * Copyright 2020 Phoenix Systems
- * Authors: Hubert Buczynski
+ * Copyright 2020-2021 Phoenix Systems
+ * Authors: Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -436,11 +436,12 @@ void syspage_addEntries(u32 start, u32 sz)
 
 /* Program's functions */
 
-int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, const char *name)
+int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, const char *name, u32 flags)
 {
 	u8 imapID, dmapID;
 	unsigned int pos, len;
 	u32 progID = syspage_common.progsCnt;
+	const u32 isExec = (flags & flagSyspageExec) != 0;
 
 	if ((syspage_getMapID(imap, &imapID) < 0) || (syspage_getMapID(dmap, &dmapID) < 0)) {
 		plostd_printf(ATTR_ERROR, "\nMAPS for %s does not exist!\n", name);
@@ -449,7 +450,7 @@ int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, 
 
 	len = plostd_strlen(name);
 
-	if (syspage_common.argCnt + 1 + len + 1 + 1 > MAX_ARGS_SIZE) {
+	if (syspage_common.argCnt + isExec + len + 1 + 1 > MAX_ARGS_SIZE) {
 		plostd_printf(ATTR_ERROR, "\nMAX_ARGS_SIZE for %s exceeded!\n", name);
 		return -1;
 	}
@@ -469,7 +470,9 @@ int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, 
 	syspage_common.progs[progID].dmap = dmapID;
 	syspage_common.progs[progID].imap = imapID;
 
-	syspage_common.args[syspage_common.argCnt++] = 'X';
+	if (isExec)
+		syspage_common.args[syspage_common.argCnt++] = 'X';
+
 	low_memcpy((void *)&syspage_common.args[syspage_common.argCnt], name, len);
 
 	syspage_common.argCnt += len;

--- a/armv7m7-imxrt117x/syspage.c
+++ b/armv7m7-imxrt117x/syspage.c
@@ -5,8 +5,8 @@
  *
  * Syspage
  *
- * Copyright 2020 Phoenix Systems
- * Authors: Hubert Buczynski
+ * Copyright 2020-2021 Phoenix Systems
+ * Authors: Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -436,11 +436,12 @@ void syspage_addEntries(u32 start, u32 sz)
 
 /* Program's functions */
 
-int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, const char *name)
+int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, const char *name, u32 flags)
 {
 	u8 imapID, dmapID;
 	unsigned int pos, len;
 	u32 progID = syspage_common.progsCnt;
+	const u32 isExec = (flags & flagSyspageExec) != 0;
 
 	if ((syspage_getMapID(imap, &imapID) < 0) || (syspage_getMapID(dmap, &dmapID) < 0)) {
 		plostd_printf(ATTR_ERROR, "\nMAPS for %s does not exist!\n", name);
@@ -449,7 +450,7 @@ int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, 
 
 	len = plostd_strlen(name);
 
-	if (syspage_common.argCnt + 1 + len + 1 + 1 > MAX_ARGS_SIZE) {
+	if (syspage_common.argCnt + isExec + len + 1 + 1 > MAX_ARGS_SIZE) {
 		plostd_printf(ATTR_ERROR, "\nMAX_ARGS_SIZE for %s exceeded!\n", name);
 		return -1;
 	}
@@ -469,7 +470,9 @@ int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, 
 	syspage_common.progs[progID].dmap = dmapID;
 	syspage_common.progs[progID].imap = imapID;
 
-	syspage_common.args[syspage_common.argCnt++] = 'X';
+	if (isExec)
+		syspage_common.args[syspage_common.argCnt++] = 'X';
+
 	low_memcpy((void *)&syspage_common.args[syspage_common.argCnt], name, len);
 
 	syspage_common.argCnt += len;

--- a/syspage.h
+++ b/syspage.h
@@ -5,8 +5,8 @@
  *
  * Syspage
  *
- * Copyright 2020 Phoenix Systems
- * Authors: Hubert Buczynski
+ * Copyright 2020-2021 Phoenix Systems
+ * Authors: Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -21,9 +21,12 @@
 
 /* TODO: Make it compatible with Phoenix-RTOS kernel;
  *       take into account map's attributes while data is written to them */
-enum { mAttrRead = 0x01, mAttrWrite = 0x02, maAttrExec = 0x04, mAttrShareable = 0x08,
+enum { mAttrRead = 0x01, mAttrWrite = 0x02, mAttrExec = 0x04, mAttrShareable = 0x08,
 	   mAttrCacheable = 0x10, mAttrBufferable = 0x20 };
 
+
+/* syspage_addProg bitflags */
+enum { flagSyspageExec = 0x01 };
 
 
 /* Initialization function */
@@ -71,7 +74,7 @@ extern void syspage_addEntries(u32 start, u32 sz);
 
 /* Program's functions */
 
-extern int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, const char *name);
+extern int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, const char *name, u32 flags);
 
 
 /* Setting kernel's data */


### PR DESCRIPTION
This change adds the ability to choose whether the `app` specified in the `plo` script or on the command line is to be started (`-x` flag) by the kernel at startup or not.

Usage examples, applications that will be started by the kernel:
```
(plo)% app flash0 -x @dummyfs xip1 dtcm
(plo)% app flash0 -x @imxrt-multi xip1 dtcm
(plo)% app flash0 -x @psh xip1
(plo)% app flash0 -x @mserver;cfg=/dev/xmsg xip1 ocram2
```

Apps that will not be started by the kernel:
```
(plo)% app flash0 @app1 xip1
(plo)% app flash0 @app2
```
Those applications (`app1`, `app2`) may be later started with `psh` command `sysexec`:
```
(psh)% sysexec ocram2 app1
(psh)% sysexec ocram2 app2 arg1 arg2 arg3
```
