### PR TITLE
usb driver, phfs interafce and modification of phoenixd & msg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ KERNEL=1
 include ../phoenix-rtos-build/Makefile.common
 include ../phoenix-rtos-build/Makefile.$(TARGET_SUFF)
 
+include lib/Makefile
+include devices/Makefile
 include $(TARGET_FAMILY)-$(TARGET_SUBFAMILY)/Makefile
 
 CFLAGS += $(BOARD_CONFIG)

--- a/armv7a9-zynq7000/Makefile
+++ b/armv7a9-zynq7000/Makefile
@@ -19,4 +19,4 @@ CFLAGS += -DVADDR_KERNEL_INIT=$(VADDR_KERNEL_INIT)
 
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
-OBJS += $(addprefix $(PREFIX_O)$(TARGET_FAMILY)-$(TARGET_SUBFAMILY)/, _startup.o low.o zynq.o serial.o timer.o syspage.o cmd.o interrupts.o)
+OBJS += $(addprefix $(PREFIX_O)$(TARGET_FAMILY)-$(TARGET_SUBFAMILY)/, _startup.o low.o zynq.o serial.o timer.o syspage.o cmd.o interrupts.o usbphy.o)

--- a/armv7a9-zynq7000/config.h
+++ b/armv7a9-zynq7000/config.h
@@ -44,14 +44,18 @@ extern void plo_bss(void);
 
 
 /* PHFS sources  */
-#define PDN_NB                   1
+#define PDN_NB                   2
 #define PDN_COM1                 0
+#define PDN_ACM0                 1
 
-#define PHFS_SERIAL_LOADER_ID    0
+#define PHFS_ACM_PORTS_NB        1    /* Number of ports define by CDC driver; min = 1, max = 2               */
+#define PHFS_SERIAL_LOADER_ID    0    /* UART ID on which data exchange is established with phoenixd host app */
 
 
 /* Types extensions */
 typedef u32 addr_t;
+
+typedef unsigned int size_t;
 
 
 #endif

--- a/armv7a9-zynq7000/interrupts.c
+++ b/armv7a9-zynq7000/interrupts.c
@@ -135,7 +135,7 @@ void interrupts_dispatch(void)
 
 int interrupts_setHandler(u16 n, int (*f)(u16, void *), void *data)
 {
-	if (f == NULL || data == NULL || n >= SIZE_INTERRUPTS)
+	if (f == NULL || n >= SIZE_INTERRUPTS)
 		return ERR_ARG;
 
 	interrupts_common.handlers[n].n = n;

--- a/armv7a9-zynq7000/peripherals.h
+++ b/armv7a9-zynq7000/peripherals.h
@@ -57,4 +57,13 @@
 #define TTC1_2_IRQ       70
 #define TTC1_3_IRQ       71
 
+
+/* USB OTG */
+#define USB0_BASE_ADDR   ((void *)0xE0002000)
+#define USB1_BASE_ADDR   ((void *)0xE0003000)
+
+#define USB0_IRQ         53
+#define USB1_IRQ         76
+
+
 #endif

--- a/armv7a9-zynq7000/serial.c
+++ b/armv7a9-zynq7000/serial.c
@@ -314,7 +314,13 @@ static void serial_initCtrlClock(void)
 }
 
 
-void serial_init(u32 baud, u32 *st)
+u32 serial_getBaudrate(void)
+{
+	return UART_BAUDRATE;
+}
+
+
+void serial_init(void)
 {
 	int i;
 	serial_t *serial;

--- a/armv7a9-zynq7000/usbphy.c
+++ b/armv7a9-zynq7000/usbphy.c
@@ -1,0 +1,137 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * usb physical layer controller
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#include "client.h"
+#include "usbphy.h"
+
+#include "zynq.h"
+#include "peripherals.h"
+
+
+/* Memory size for endpoints and setup data */
+#define BUFF_SIZE (ENDPOINTS_DIR_NB * ENDPOINTS_NUMBER + 1) * USB_BUFFER_SIZE
+
+
+struct {
+	__attribute__((aligned(USB_BUFFER_SIZE))) u8 data[BUFF_SIZE];
+	u32 buffCounter;
+} phyusb_common;
+
+
+void *usbclient_allocBuff(u32 size)
+{
+	void *mem;
+
+	if ((size % USB_BUFFER_SIZE) || (USB_BUFFER_SIZE * phyusb_common.buffCounter + size) >= BUFF_SIZE)
+		return NULL;
+
+	mem = (void *)(&phyusb_common.data[USB_BUFFER_SIZE * phyusb_common.buffCounter]);
+	phyusb_common.buffCounter += size / USB_BUFFER_SIZE;
+
+	return mem;
+}
+
+
+void usbclient_buffReset(void)
+{
+	phyusb_common.buffCounter = 0;
+}
+
+
+void *phy_getBase(void)
+{
+	return (void *)USB0_BASE_ADDR;
+}
+
+
+u32 phy_getIrq(void)
+{
+	return USB0_IRQ;
+}
+
+
+static void phy_setClock(void)
+{
+	_zynq_setAmbaClk(amba_usb0_clk, clk_enable);
+}
+
+
+static void phy_setPins(void)
+{
+	ctl_mio_t ctl;
+
+	/* Set default configuration for USB pins */
+	ctl.l0 = ctl.l2 = ctl.l3 = 0;
+	ctl.l1 = 1;
+	ctl.speed = 1;
+	ctl.ioType = 1;
+	ctl.pullup = 0;
+	ctl.disableRcvr = 0;
+
+	/* Set data I/O pins */
+	ctl.triEnable = 0;
+
+	/* USB ULPI DATA4 */
+	ctl.pin = mio_pin_28;
+	_zynq_setMIO(&ctl);
+
+	/* USB ULPI STP */
+	ctl.pin = mio_pin_30;
+	_zynq_setMIO(&ctl);
+
+	/* USB ULPI DATA0 - DATA7 */
+	for (u32 pin = mio_pin_32; pin <= mio_pin_39; ++pin) {
+		if (pin == mio_pin_36)
+			continue;
+
+		ctl.pin = pin;
+		_zynq_setMIO(&ctl);
+	}
+
+	/* Set input pins */
+	ctl.triEnable = 1;
+
+	/* USB ULPI CLK */
+	ctl.pin = mio_pin_36;
+	_zynq_setMIO(&ctl);
+
+	/* USB ULPI NXT */
+	ctl.pin = mio_pin_31;
+	_zynq_setMIO(&ctl);
+
+	/* USB ULPI DIR */
+	ctl.pin = mio_pin_29;
+	_zynq_setMIO(&ctl);
+
+}
+
+
+void phy_init(void)
+{
+	phyusb_common.buffCounter = 0;
+
+	phy_reset();
+	phy_setPins();
+	phy_setClock();
+}
+
+
+/* TODO: reset USB physical layer - handle PL */
+void phy_reset(void)
+{
+	phyusb_common.buffCounter = 0;
+	_zynq_setAmbaClk(amba_usb0_clk, clk_disable);
+}

--- a/armv7m7-imxrt106x/Makefile
+++ b/armv7m7-imxrt106x/Makefile
@@ -9,8 +9,8 @@
 INIT_RAM = 0x0
 INIT_FLASH = 0x70000000
 
-BSS=-Tbss=20011000
-LDFLAGS+=--defsym=plo_bss=0x20011000
+BSS=-Tbss=20010000
+LDFLAGS+=--defsym=plo_bss=0x20010000
 
 LDFLAGS:=$(filter-out -Tbss% , $(LDFLAGS))
 LDFLAGS:=$(filter-out -Tdata% , $(LDFLAGS))
@@ -20,4 +20,4 @@ CFLAGS+= -mfloat-abi=soft
 
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
-OBJS += $(addprefix $(PREFIX_O)$(TARGET_FAMILY)-$(TARGET_SUBFAMILY)/, _startup.o low.o imxrt.o serial.o cmd.o timer.o flashdrv.o rom_api.o flashcfg.o phfs-flash.o syspage.o)
+OBJS += $(addprefix $(PREFIX_O)$(TARGET_FAMILY)-$(TARGET_SUBFAMILY)/, _startup.o low.o imxrt.o serial.o cmd.o timer.o flashdrv.o rom_api.o flashcfg.o phfs-flash.o syspage.o usbphy.o)

--- a/armv7m7-imxrt106x/config.h
+++ b/armv7m7-imxrt106x/config.h
@@ -46,19 +46,22 @@ extern void plo_bss(void);
 
 
 /* PHFS sources  */
-#define PDN_NB                   3
+#define PDN_NB                   4
 
 #define PDN_FLASH0               0
 #define PDN_FLASH1               1
 #define PDN_COM1                 2
+#define PDN_USB0                 3
 
-#define PHFS_SERIAL_LOADER_ID    3
+
+#define PHFS_ACM_PORTS_NB        1    /* Number of ports define by CDC driver; min = 1, max = 2               */
+#define PHFS_SERIAL_LOADER_ID    3    /* UART ID on which data exchange is established with phoenixd host app */
 
 
 /* Types extensions */
 
 typedef u32 addr_t;
-
+typedef unsigned int size_t;
 
 
 #endif

--- a/armv7m7-imxrt106x/peripherals.h
+++ b/armv7m7-imxrt106x/peripherals.h
@@ -96,7 +96,8 @@
 #define UART_CONSOLE 1
 #endif
 
-#define UART_CLK 80000000
+#define UART_CLK         80000000
+#define UART_BAUDRATE    115200
 
 #define UART1_BASE ((void *)0x40184000)
 #define UART2_BASE ((void *)0x40188000)
@@ -231,5 +232,14 @@
 #define GPT2_BASE           ((void *)0x401f0000)
 #define GPT2_CLK            pctl_clk_gpt2_bus
 #define GPT2_IRQ            101 + 16
+
+
+/* USB OTG */
+
+#define USB0_BASE_ADDR       ((void *)0x402E0000)
+#define USB0_PHY_BASE_ADDR   ((void *)0x400D9000)
+
+#define USB0_IRQ             usb_otg1_irq
+
 
 #endif

--- a/armv7m7-imxrt106x/serial.c
+++ b/armv7m7-imxrt106x/serial.c
@@ -409,9 +409,13 @@ static void serial_initPins(void)
 	}
 }
 
+u32 serial_getBaudrate(void)
+{
+	return UART_BAUDRATE;
+}
 
-/* TODO: set baudrate using 'baud' argument */
-void serial_init(u32 baud, u32 *st)
+
+void serial_init(void)
 {
 	u32 t;
 	int i, dev;
@@ -433,15 +437,10 @@ void serial_init(u32 baud, u32 *st)
 		{ UART8_BASE, UART8_CLK, UART8_IRQ }
 	};
 
-	*st = 115200;
 	serial_initPins();
-
-
 
 	_imxrt_ccmSetMux(clk_mux_uart, 0);
 	_imxrt_ccmSetDiv(clk_div_uart, 0);
-
-
 
 	for (i = 0, dev = 0; dev < sizeof(serialConfig) / sizeof(serialConfig[0]); ++dev) {
 		if (!serialConfig[dev])
@@ -471,7 +470,7 @@ void serial_init(u32 baud, u32 *st)
 
 		/* Set 115200 default baudrate */
 		t = *(serial->base + baudr) & ~((0x1f << 24) | (1 << 17) | 0x1fff);
-		*(serial->base + baudr) = t | calculate_baudrate(115200);
+		*(serial->base + baudr) = t | calculate_baudrate(UART_BAUDRATE);
 
 		/* Set 8 bit and no parity mode */
 		*(serial->base + ctrlr) &= ~0x117;

--- a/armv7m7-imxrt106x/usbphy.c
+++ b/armv7m7-imxrt106x/usbphy.c
@@ -1,0 +1,125 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * usb physical layer controller
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#include "client.h"
+#include "usbphy.h"
+
+#include "imxrt.h"
+#include "peripherals.h"
+
+/* Memory size for endpoints and setup data */
+#define BUFF_SIZE (ENDPOINTS_DIR_NB * ENDPOINTS_NUMBER + 1) * USB_BUFFER_SIZE
+
+
+enum {
+	/* Power-Down Register */
+	usbphy_pwd, usbphy_pwd_set, usbphy_pwd_clr, usbphy_pwd_tog,
+	/* Transmitter & Receiver Control Registers */
+	usbphy_tx, usbphy_tx_set, usbphy_tx_clr, usbphy_tx_tog,
+	usbphy_rx, usbphy_rx_set, usbphy_rx_clr, usbphy_rx_tog,
+	/* General Control Register */
+	usbphy_ctrl, usbphy_ctrl_set, usbphy_ctrl_clr, usbphy_ctrl_tog,
+	/* USB Status & Debug Registers */
+	usbphy_status,
+	usbphy_debug = 20, usbphy_debug_set, usbphy_debug_clr, usbphy_debug_tog,
+	/* UTMI Status & Debug Registers */
+	usbphy_debug0_status, usbphy_debug1 = 28,
+	usbphy_debug1_set, usbphy_debug1_clr, usbphy_debug1_tog,
+	/* UTMI RTL */
+	usbphy_version
+};
+
+
+struct {
+	__attribute__((aligned(USB_BUFFER_SIZE))) u8 data[BUFF_SIZE];
+	u32 buffCounter;
+} phyusb_common;
+
+
+void *usbclient_allocBuff(u32 size)
+{
+	void *mem;
+
+	if ((size % USB_BUFFER_SIZE) || (USB_BUFFER_SIZE * phyusb_common.buffCounter + size) > BUFF_SIZE)
+		return NULL;
+
+	mem = (void *)(&phyusb_common.data[USB_BUFFER_SIZE * phyusb_common.buffCounter]);
+	phyusb_common.buffCounter += size / USB_BUFFER_SIZE;
+
+	return mem;
+}
+
+
+void  usbclient_buffReset(void)
+{
+	phyusb_common.buffCounter = 0;
+}
+
+void *phy_getBase(void)
+{
+	return (void *)USB0_BASE_ADDR;
+}
+
+
+u32 phy_getIrq(void)
+{
+	return USB0_IRQ;
+}
+
+
+static void phy_setClock(void)
+{
+	_imxrt_setDevClock(pctl_clk_iomuxc, clk_state_run_wait);
+	_imxrt_setDevClock(pctl_clk_usboh3, clk_state_run_wait);
+}
+
+
+static void phy_initPad(void)
+{
+	/* USB_OTG1_ID is an instance of anatop */
+	_imxrt_setIOisel(pctl_isel_anatop_usb_otg1_id, 0);
+
+	/* GPIO_AD_B0_01 is configured as USB_OTG1_ID (input) ALT3 */
+	_imxrt_setIOmux(pctl_mux_gpio_ad_b0_01, 0, 3);
+
+	/* IOMUXC_SW_PAD_CTL_PAD_GPIO_AD_B0_01 = 0x10b0 */
+	_imxrt_setIOpad(pctl_mux_gpio_ad_b0_01, 0, 0, 0, 1, 0, 2, 6, 0);
+}
+
+
+void phy_reset(void)
+{
+	volatile u32 *usbphy = (u32 *)USB0_PHY_BASE_ADDR;
+
+	/* Reset PHY */
+	*(usbphy + usbphy_ctrl_set) = (1 << 31);
+
+	/* Enable clock and release the PHY from reset */
+	*(usbphy + usbphy_ctrl_clr) = (1 << 31) | (1 << 30);
+
+	/* Power up the PHY */
+	*(usbphy + usbphy_pwd) = 0;
+}
+
+
+void phy_init(void)
+{
+	phyusb_common.buffCounter = 0;
+
+	phy_setClock();
+	phy_initPad();
+	phy_reset();
+}

--- a/armv7m7-imxrt117x/config.h
+++ b/armv7m7-imxrt117x/config.h
@@ -52,11 +52,13 @@ extern void plo_bss(void);
 #define PDN_COM1                 1
 
 #define PHFS_SERIAL_LOADER_ID    12
+#define PHFS_ACM_PORTS_NB        1    /* Number of ports define by CDC driver; min = 1, max = 2 */
 
 
 /* Types extensions */
 
 typedef u32 addr_t;
+typedef unsigned int size_t;
 
 
 

--- a/armv7m7-imxrt117x/peripherals.h
+++ b/armv7m7-imxrt117x/peripherals.h
@@ -75,7 +75,8 @@
 #define UART_CONSOLE 11
 #endif
 
-#define UART_CLK 24000000
+#define UART_CLK         24000000
+#define UART_BAUDRATE    115200
 
 #define UART1_BASE  ((void *)0x4007c000)
 #define UART2_BASE  ((void *)0x40080000)

--- a/armv7m7-imxrt117x/serial.c
+++ b/armv7m7-imxrt117x/serial.c
@@ -491,8 +491,13 @@ static void serial_initPins(void)
 }
 
 
-/* TODO: set baudrate using 'baud' argument */
-void serial_init(u32 baud, u32 *st)
+u32 serial_getBaudrate(void)
+{
+	return UART_BAUDRATE;
+}
+
+
+void serial_init(void)
 {
 	u32 t;
 	int i, dev;
@@ -518,7 +523,6 @@ void serial_init(u32 baud, u32 *st)
 		{ UART12_BASE, UART12_CLK, UART12_IRQ }
 	};
 
-	*st = 115200;
 	serial_initPins();
 
 	for (i = 0, dev = 0; dev < sizeof(serialConfig) / sizeof(serialConfig[0]); ++dev) {
@@ -550,7 +554,7 @@ void serial_init(u32 baud, u32 *st)
 
 		/* Set 115200 default baudrate */
 		t = *(serial->base + baudr) & ~((0x1f << 24) | (1 << 17) | 0xfff);
-		*(serial->base + baudr) = t | calculate_baudrate(115200);
+		*(serial->base + baudr) = t | calculate_baudrate(UART_BAUDRATE);
 
 		/* Set 8 bit and no parity mode */
 		*(serial->base + ctrlr) &= ~0x117;

--- a/devices/Makefile
+++ b/devices/Makefile
@@ -1,0 +1,14 @@
+#
+# Makefile for plo devices
+#
+# Copyright 2020 Phoenix Systems
+#
+# %LICENSE%
+#
+
+
+CFLAGS += -I../plo/devices
+
+include devices/usbc/Makefile
+
+OBJS += $(addprefix $(PREFIX_O)devices/, phfs-usb.o phfs-serial.o)

--- a/devices/phfs-serial.c
+++ b/devices/phfs-serial.c
@@ -1,0 +1,71 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * Interface for phfs serial
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include "../errors.h"
+
+#include "../phoenixd.h"
+#include "../serial.h"
+#include "../low.h"
+
+
+struct {
+	phfs_clbk_t cblks;
+} phfs_serialCommon;
+
+
+
+int phfs_serialInit(void)
+{
+	serial_init();
+
+	phfs_serialCommon.cblks.read = serial_read;
+	phfs_serialCommon.cblks.write = serial_safewrite;
+
+	return ERR_NONE;
+}
+
+
+void phfs_serialDeinit(void)
+{
+	phfs_serialCommon.cblks.read = NULL;
+	phfs_serialCommon.cblks.write = NULL;
+
+	serial_done();
+}
+
+
+handle_t phfs_serialOpen(u16 dn, const char *name, u32 flags)
+{
+	return phoenixd_open(dn, name, flags, &phfs_serialCommon.cblks);
+}
+
+
+s32 phfs_serialWrite(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len, u8 sync)
+{
+	return phoenixd_write(dn, handle, pos, buff, len, sync,  &phfs_serialCommon.cblks);
+}
+
+
+s32 phfs_serialRead(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len)
+{
+	return phoenixd_read(dn, handle, pos, buff, len, &phfs_serialCommon.cblks);
+}
+
+
+s32 phfs_serialClose(u16 dn, handle_t handle)
+{
+	return phoenixd_close(dn, handle, &phfs_serialCommon.cblks);
+}
+

--- a/devices/phfs-serial.h
+++ b/devices/phfs-serial.h
@@ -1,0 +1,42 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * Interface for phfs serial
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#ifndef _PHFS_SERIAL_H_
+#define _PHFS_SERIAL_H_
+
+#include "../types.h"
+#include "../phfs.h"
+
+
+extern int phfs_serialInit(void);
+
+
+extern void phfs_serialDeinit(void);
+
+
+extern handle_t phfs_serialOpen(u16 dn, const char *name, u32 flags);
+
+
+extern s32 phfs_serialWrite(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len, u8 sync);
+
+
+extern s32 phfs_serialRead(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len);
+
+
+extern s32 phfs_serialClose(u16 dn, handle_t handle);
+
+
+#endif

--- a/devices/phfs-usb.c
+++ b/devices/phfs-usb.c
@@ -1,0 +1,82 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * Interface for phfs USB
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#include "phfs-usb.h"
+#include "cdc-client.h"
+
+#include "../phoenixd.h"
+#include "../errors.h"
+
+
+struct {
+	phfs_clbk_t cblks;
+} phfs_usbCommon;
+
+
+
+static int phfs_safeWrite(unsigned int dn, const u8 *buff, u16 len)
+{
+	return cdc_send(dn, (const char *)buff, len);
+}
+
+
+static int phfs_safeRead(unsigned int dn, u8 *buff, u16 len, u16 timeout)
+{
+	return cdc_recv(dn, (char *)buff, len);
+}
+
+
+void phfs_usbInit(void)
+{
+	cdc_init();
+
+	phfs_usbCommon.cblks.read = phfs_safeRead;
+	phfs_usbCommon.cblks.write = phfs_safeWrite;
+}
+
+
+void phfs_usbDeinit(void)
+{
+	phfs_usbCommon.cblks.read = NULL;
+	phfs_usbCommon.cblks.write = NULL;
+
+	cdc_destroy();
+}
+
+
+handle_t phfs_usbOpen(u16 dn, const char *name, u32 flags)
+{
+	return phoenixd_open(dn, name, flags, &phfs_usbCommon.cblks);
+}
+
+
+s32 phfs_usbWrite(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len, u8 sync)
+{
+
+    return phoenixd_write(dn, handle, pos, buff, len, sync,  &phfs_usbCommon.cblks);
+}
+
+
+s32 phfs_usbRead(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len)
+{
+    return phoenixd_read(dn, handle, pos, buff, len, &phfs_usbCommon.cblks);
+}
+
+
+s32 phfs_usbClose(u16 dn, handle_t handle)
+{
+    return phoenixd_close(dn, handle, &phfs_usbCommon.cblks);
+}

--- a/devices/phfs-usb.h
+++ b/devices/phfs-usb.h
@@ -1,0 +1,42 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * Interface for phfs USB
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#ifndef _PHFS_USB_H_
+#define _PHFS_USB_H_
+
+#include "../types.h"
+#include "../phfs.h"
+
+
+extern void phfs_usbInit(void);
+
+
+extern void phfs_usbDeinit(void);
+
+
+extern handle_t phfs_usbOpen(u16 dn, const char *name, u32 flags);
+
+
+extern s32 phfs_usbWrite(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len, u8 sync);
+
+
+extern s32 phfs_usbRead(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len);
+
+
+extern s32 phfs_usbClose(u16 dn, handle_t handle);
+
+
+#endif

--- a/devices/usbc/Makefile
+++ b/devices/usbc/Makefile
@@ -1,0 +1,11 @@
+#
+# Makefile for usbc
+#
+# Copyright 2021 Phoenix Systems
+#
+# %LICENSE%
+#
+
+CFLAGS += -I../plo/devices/usbc
+
+OBJS += $(addprefix $(PREFIX_O)devices/usbc/, client.o ctrl.o desc.o cdc-client.o)

--- a/devices/usbc/cdc-client.c
+++ b/devices/usbc/cdc-client.c
@@ -1,0 +1,421 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * cdc - USB Communication Device Class
+ *
+ * Copyright 2019, 2021 Phoenix Systems
+ * Author: Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#include "usbclient.h"
+#include "cdc-client.h"
+
+#include "list.h"
+#include "config.h"
+#include "../errors.h"
+
+
+struct {
+	usb_desc_list_t *descList;
+
+	usb_desc_list_t dev;
+	usb_desc_list_t conf;
+
+	struct {
+		usb_desc_list_t iad;
+
+		usb_desc_list_t comIface;
+		usb_desc_list_t header;
+		usb_desc_list_t call;
+		usb_desc_list_t acm;
+		usb_desc_list_t unio;
+		usb_desc_list_t comEp;
+
+		usb_desc_list_t dataIface;
+		usb_desc_list_t dataEpOUT;
+		usb_desc_list_t dataEpIN;
+	} ports[PHFS_ACM_PORTS_NB];
+
+	usb_desc_list_t str0;
+	usb_desc_list_t strman;
+	usb_desc_list_t strprod;
+} cdc_common;
+
+
+/* Device descriptor */
+const usb_device_desc_t dDev = {
+	.bLength = sizeof(usb_device_desc_t),
+	.bDescriptorType = USB_DESC_DEVICE,
+	.bcdUSB = 0x0002,
+	.bDeviceClass = 0x0,
+	.bDeviceSubClass = 0,
+	.bDeviceProtocol = 0,
+	.bMaxPacketSize0 = 64,
+	.idVendor = 0x16f9,
+	.idProduct = 0x0003,
+	.bcdDevice = 0x0200,
+	.iManufacturer = 1,
+	.iProduct = 2,
+	.iSerialNumber = 0,
+	.bNumConfigurations = 1
+};
+
+
+/* Configuration descriptor */
+const usb_configuration_desc_t dConfig = {
+	.bLength = 9, .bDescriptorType = USB_DESC_CONFIG,
+	.wTotalLength = sizeof(usb_configuration_desc_t) + (sizeof(usb_interface_desc_t) + sizeof(usb_desc_cdc_header_t) + sizeof(usb_desc_cdc_call_t)
+				+ sizeof(usb_desc_cdc_acm_t) + sizeof(usb_desc_cdc_union_t) + sizeof(usb_endpoint_desc_t) + sizeof(usb_interface_desc_t)
+				+ sizeof(usb_endpoint_desc_t) + sizeof(usb_endpoint_desc_t)) * PHFS_ACM_PORTS_NB,
+	.bNumInterfaces = 2 * PHFS_ACM_PORTS_NB,
+	.bConfigurationValue = 1,
+	.iConfiguration = 0,
+	.bmAttributes = 0xc0,
+	.bMaxPower = 5
+};
+
+
+const usb_interface_association_desc_t dIad[]= {
+	{
+		.bLength = 0x08,
+		.bDescriptorType = 0x0b,
+		.bFirstInterface = 0,
+		.bInterfaceCount = 2,
+		.bFunctionClass = 2,
+		.bFunctionSubClass = 2,
+		.bFunctionProtocol = 1,
+		.iFunction = 0,
+	},
+#if PHFS_ACM_PORTS_NB == 2
+	{
+		.bLength = 0x08,
+		.bDescriptorType = 0x0b,
+		.bFirstInterface = 0x2,
+		.bInterfaceCount = 2,
+		.bFunctionClass = 2,
+		.bFunctionSubClass = 2,
+		.bFunctionProtocol = 1,
+		.iFunction = 0,
+	}
+#endif
+};
+
+/* Communication Interface Descriptor */
+const usb_interface_desc_t dComIntf[] = {
+	{
+		.bLength = 9,
+		.bDescriptorType = USB_DESC_INTERFACE,
+		.bInterfaceNumber = 0,
+		.bAlternateSetting = 0,
+		.bNumEndpoints = 1,
+		.bInterfaceClass = 0x02,
+		.bInterfaceSubClass = 0x02,
+		.bInterfaceProtocol = 0x00,
+		.iInterface = 4
+	},
+#if PHFS_ACM_PORTS_NB == 2
+	{
+		.bLength = 9,
+		.bDescriptorType = USB_DESC_INTERFACE,
+		.bInterfaceNumber = 2,
+		.bAlternateSetting = 0,
+		.bNumEndpoints = 1,
+		.bInterfaceClass = 0x02,
+		.bInterfaceSubClass = 0x02,
+		.bInterfaceProtocol = 0x00,
+		.iInterface = 4
+	}
+#endif
+};
+
+
+const usb_desc_cdc_header_t dHeader[] = {
+	{
+		.bLength = 5,
+		.bType = USB_DESC_TYPE_CDC_CS_INTERFACE,
+		.bSubType = 0,
+		.bcdCDC = 0x0110
+	},
+#if PHFS_ACM_PORTS_NB == 2
+	{
+		.bLength = 5,
+		.bType = USB_DESC_TYPE_CDC_CS_INTERFACE,
+		.bSubType = 0,
+		.bcdCDC = 0x0110
+	}
+#endif
+};
+
+
+const usb_desc_cdc_call_t dCall[] = {
+	{
+		.bLength = 5,
+		.bType = USB_DESC_TYPE_CDC_CS_INTERFACE,
+		.bSubType = 0x01,
+		.bmCapabilities = 0x01,
+		.bDataInterface = 0x1
+	},
+#if PHFS_ACM_PORTS_NB == 2
+	{
+		.bLength = 5,
+		.bType = USB_DESC_TYPE_CDC_CS_INTERFACE,
+		.bSubType = 0x01,
+		.bmCapabilities = 0x01,
+		.bDataInterface = 0x1
+	}
+#endif
+};
+
+
+const usb_desc_cdc_acm_t dAcm[] = {
+	{
+		.bLength = 4,
+		.bType = USB_DESC_TYPE_CDC_CS_INTERFACE,
+		.bSubType = 0x02,
+		.bmCapabilities = 0x03
+	},
+#if PHFS_ACM_PORTS_NB == 2
+	{
+		.bLength = 4,
+		.bType = USB_DESC_TYPE_CDC_CS_INTERFACE,
+		.bSubType = 0x02,
+		.bmCapabilities = 0x03
+	}
+#endif
+};
+
+
+const usb_desc_cdc_union_t dUnion[] = {
+	{
+		.bLength = 5,
+		.bType = USB_DESC_TYPE_CDC_CS_INTERFACE,
+		.bSubType = 0x06,
+		.bControlInterface = 0x0,
+		.bSubordinateInterface = 0x1
+	},
+#if PHFS_ACM_PORTS_NB == 2
+	{
+		.bLength = 5,
+		.bType = USB_DESC_TYPE_CDC_CS_INTERFACE,
+		.bSubType = 0x06,
+		.bControlInterface = 0x2,
+		.bSubordinateInterface = 0x3
+	}
+#endif
+};
+
+
+/* Communication Interrupt Endpoint IN */
+const usb_endpoint_desc_t dComEp[] = {
+	{
+		.bLength = 7,
+		.bDescriptorType = USB_DESC_ENDPOINT,
+		.bEndpointAddress = 0x80 | endpt_irq_acm0, /* direction IN */
+		.bmAttributes = 0x03,
+		.wMaxPacketSize = 0x20,
+		.bInterval = 0x08
+	},
+#if PHFS_ACM_PORTS_NB == 2
+	{
+		.bLength = 7,
+		.bDescriptorType = USB_DESC_ENDPOINT,
+		.bEndpointAddress = 0x80 | endpt_irq_acm1, /* direction IN */
+		.bmAttributes = 0x03,
+		.wMaxPacketSize = 0x20,
+		.bInterval = 0x08
+	}
+#endif
+};
+
+
+/* CDC Data Interface Descriptor */
+const usb_interface_desc_t dDataIntf[] = {
+	{
+		.bLength = 9,
+		.bDescriptorType = USB_DESC_INTERFACE,
+		.bInterfaceNumber = 1,
+		.bAlternateSetting = 0,
+		.bNumEndpoints = 2,
+		.bInterfaceClass = 0x0a,
+		.bInterfaceSubClass = 0x00,
+		.bInterfaceProtocol = 0x00,
+		.iInterface = 0
+	},
+#if PHFS_ACM_PORTS_NB == 2
+	{
+		.bLength = 9,
+		.bDescriptorType = USB_DESC_INTERFACE,
+		.bInterfaceNumber = 3,
+		.bAlternateSetting = 0,
+		.bNumEndpoints = 2,
+		.bInterfaceClass = 0x0a,
+		.bInterfaceSubClass = 0x00,
+		.bInterfaceProtocol = 0x00,
+		.iInterface = 0
+	}
+#endif
+};
+
+
+/* Data Bulk Endpoint OUT */
+const usb_endpoint_desc_t dEpOUT[] = {
+	{
+		.bLength = 7,
+		.bDescriptorType = USB_DESC_ENDPOINT,
+		.bEndpointAddress = endpt_bulk_acm0, /* direction OUT */
+		.bmAttributes = 0x02,
+		.wMaxPacketSize = 0x0200,
+		.bInterval = 0
+	},
+#if PHFS_ACM_PORTS_NB == 2
+	{
+		.bLength = 7,
+		.bDescriptorType = USB_DESC_ENDPOINT,
+		.bEndpointAddress = endpt_bulk_acm1, /* direction OUT */
+		.bmAttributes = 0x02,
+		.wMaxPacketSize = 0x0200,
+		.bInterval = 0
+	}
+#endif
+};
+
+
+/* Data Bulk Endpoint IN */
+const usb_endpoint_desc_t dEpIN[] = {
+	{
+		.bLength = 7,
+		.bDescriptorType = USB_DESC_ENDPOINT,
+		.bEndpointAddress = 0x80 | endpt_bulk_acm0, /* direction IN */
+		.bmAttributes = 0x02,
+		.wMaxPacketSize = 0x0200,
+		.bInterval = 1
+	},
+#if PHFS_ACM_PORTS_NB == 2
+	{
+		.bLength = 7,
+		.bDescriptorType = USB_DESC_ENDPOINT,
+		.bEndpointAddress = 0x80 | endpt_bulk_acm1, /* direction IN */
+		.bmAttributes = 0x02,
+		.wMaxPacketSize = 0x0200,
+		.bInterval = 1
+	}
+#endif
+};
+
+
+/* String Data */
+const usb_string_desc_t dStrman = {
+	.bLength = 2 * 15 + 2,
+	.bDescriptorType = USB_DESC_STRING,
+	.wData = { 'P', 0, 'h', 0, 'o', 0, 'e', 0, 'n', 0, 'i', 0, 'x', 0, ' ', 0, 'S', 0, 'y', 0, 's', 0, 't', 0, 'e', 0, 'm', 0, 's', 0 }
+};
+
+
+const usb_string_desc_t dStr0 = {
+	.bLength = 4,
+	.bDescriptorType = USB_DESC_STRING,
+	.wData = { 0x09, 0x04 } /* English */
+};
+
+
+const usb_string_desc_t dStrprod = {
+	.bLength = 2 * 11 + 2,
+	.bDescriptorType = USB_DESC_STRING,
+	.wData = {'p', 0, 'l', 0, 'o', 0, ' ', 0, 'C', 0, 'D', 0, 'C',  0, ' ', 0, 'A', 0, 'C', 0, 'M',  0 }
+};
+
+
+int cdc_recv(int endpt, char *data, unsigned int len)
+{
+	if (endpt > PHFS_ACM_PORTS_NB * 2)
+		return ERR_ARG;
+
+	return usbclient_receive(endpt, data, len);
+}
+
+
+int cdc_send(int endpt, const char *data, unsigned int len)
+{
+	if (endpt > PHFS_ACM_PORTS_NB * 2)
+		return ERR_ARG;
+
+	return usbclient_send(endpt, data, len);
+}
+
+
+void cdc_destroy(void)
+{
+	usbclient_destroy();
+}
+
+
+int cdc_init(void)
+{
+	int i = 0;
+	int res = ERR_NONE;
+
+	if (PHFS_ACM_PORTS_NB < 1 || PHFS_ACM_PORTS_NB > 2)
+		return ERR_ARG;
+
+	cdc_common.descList = NULL;
+	cdc_common.dev.descriptor = (usb_functional_desc_t *)&dDev;
+	LIST_ADD(&cdc_common.descList, &cdc_common.dev);
+
+	cdc_common.conf.descriptor = (usb_functional_desc_t *)&dConfig;
+	LIST_ADD(&cdc_common.descList, &cdc_common.conf);
+
+	for (i = 0; i < PHFS_ACM_PORTS_NB; ++i) {
+		cdc_common.ports[i].iad.descriptor = (usb_functional_desc_t *)&dIad[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].iad);
+
+		cdc_common.ports[i].comIface.descriptor = (usb_functional_desc_t *)&dComIntf[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].comIface);
+
+		cdc_common.ports[i].header.descriptor = (usb_functional_desc_t *)&dHeader[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].header);
+
+		cdc_common.ports[i].call.descriptor = (usb_functional_desc_t *)&dCall[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].call);
+
+		cdc_common.ports[i].acm.descriptor = (usb_functional_desc_t *)&dAcm[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].acm);
+
+		cdc_common.ports[i].unio.descriptor = (usb_functional_desc_t *)&dUnion[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].unio);
+
+		cdc_common.ports[i].comEp.descriptor = (usb_functional_desc_t *)&dComEp[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].comEp);
+
+		cdc_common.ports[i].dataIface.descriptor = (usb_functional_desc_t *)&dDataIntf[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].dataIface);
+
+		cdc_common.ports[i].dataEpOUT.descriptor = (usb_functional_desc_t *)&dEpOUT[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].dataEpOUT);
+
+		cdc_common.ports[i].dataEpIN.descriptor = (usb_functional_desc_t *)&dEpIN[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].dataEpIN);
+	}
+
+	cdc_common.str0.descriptor = (usb_functional_desc_t *)&dStr0;
+	LIST_ADD(&cdc_common.descList, &cdc_common.str0);
+
+	cdc_common.strman.descriptor = (usb_functional_desc_t *)&dStrman;
+	LIST_ADD(&cdc_common.descList, &cdc_common.strman);
+
+	cdc_common.strprod.descriptor = (usb_functional_desc_t *)&dStrprod;
+	LIST_ADD(&cdc_common.descList, &cdc_common.strprod);
+
+	cdc_common.strprod.next = NULL;
+
+	if ((res = usbclient_init(cdc_common.descList)) != ERR_NONE)
+		return res;
+
+	return res;
+}

--- a/devices/usbc/cdc-client.h
+++ b/devices/usbc/cdc-client.h
@@ -1,0 +1,43 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * cdc - USB Communication Device Class
+ *
+ * Copyright 2019, 2021 Phoenix Systems
+ * Author: Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#ifndef _CDC_CLIENT_H_
+#define _CDC_CLIENT_H_
+
+#include <cdc.h>
+
+
+/* Endpoints available in a CDC driver */
+enum { endpt_irq_acm0 = 0x01, endpt_bulk_acm0, endpt_irq_acm1, endpt_bulk_acm1 };
+
+
+/* Function initialize a USB controller and setup descriptors. */
+int cdc_init(void);
+
+
+/* Function receives data on an given endpoint */
+int cdc_recv(int endpt, char *data, unsigned int len);
+
+
+/* Function sends data on an given endpoint. */
+int cdc_send(int endpt, const char *data, unsigned int len);
+
+
+/* Functions resets a USB controller and a physicall layer */
+void cdc_destroy(void);
+
+
+#endif

--- a/devices/usbc/cdc.h
+++ b/devices/usbc/cdc.h
@@ -1,0 +1,106 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * USB Communications Device Class definitions
+ *
+ * Copyright 2018, 2020-2021 Phoenix Systems
+ * Author: Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#ifndef _USB_CDC_H_
+#define _USB_CDC_H_
+
+#include "../types.h"
+
+
+/* endpoints descriptions */
+#define ENDPOINT_ACM0  0x2
+#define ENDPOINT_ACM1  0x4
+
+
+/* device class code */
+#define USB_CLASS_CDC 0x2
+
+
+/* interface class code */
+#define USB_INTERFACE_COMMUNICATIONS  0x2
+#define USB_INTERFACE_DATA            0xA
+
+
+/* communications class subclass codes */
+#define USB_SUBCLASS_DLCM      0x1	/* direct line control model */
+#define USB_SUBCLASS_ACM       0x2	/* abstract control model */
+#define USB_SUBCLASS_TCM       0x3	/* telephone control model */
+#define USB_SUBCLASS_MCCM      0x4	/* multi-channel control model */
+#define USB_SUBCLASS_CAPI      0x5	/* CAPI control model */
+#define USB_SUBCLASS_ECM       0x6	/* ethernet networking control model */
+#define USB_SUBCLASS_ATM       0x7	/* ATM networking control model */
+#define USB_SUBCLASS_WIRELESS  0x8	/* wireless handset control model */
+#define USB_SUBCLASS_DEV_MGMT  0x9	/* device management */
+#define USB_SUBCLASS_MDLM      0xa	/* mobile direct line model */
+#define USB_SUBCLASS_OBEX      0xb	/* OBEX */
+#define USB_SUBCLASS_EEM       0xc	/* ethernet emulation model */
+#define USB_SUBCLASS_NCM       0xd	/* network control model */
+
+
+/* descriptors subclassses for communications class (CC)*/
+#define USB_DESC_SUBTYPE_CC_HEADER    0x0
+#define USB_DESC_SUBTYPE_CC_CALL_MGMT 0x1
+#define USB_DESC_SUBTYPE_CC_ACM       0x2
+
+
+/* CDC Header functional descriptor  */
+typedef struct _usb_desc_cdc_header {
+	u8 bLength;
+	u8 bType;
+	u8 bSubType;
+	u16 bcdCDC;
+} __attribute__((packed)) usb_desc_cdc_header_t;
+
+
+/* CDC ACM functional descriptor  */
+typedef struct _usb_desc_cdc_acm {
+	u8 bLength;
+	u8 bType;
+	u8 bSubType;
+	u8 bmCapabilities;
+} __attribute__((packed)) usb_desc_cdc_acm_t;
+
+
+/* CDC Union functional descriptor  */
+typedef struct _usb_desc_cdc_union {
+	u8 bLength;
+	u8 bType;
+	u8 bSubType;
+	u8 bControlInterface;
+	u8 bSubordinateInterface;
+} __attribute__((packed)) usb_desc_cdc_union_t;
+
+
+/* CDC Call management functional descriptor  */
+typedef struct _usb_desc_cdc_call {
+	u8 bLength;
+	u8 bType;
+	u8 bSubType;
+	u8 bmCapabilities;
+	u8 bDataInterface;
+} __attribute__((packed)) usb_desc_cdc_call_t;
+
+
+/* CDC Line Coding Request */
+typedef struct _usb_cdc_line_coding {
+	u32 dwDTERate;
+	u8 bCharFormat;
+	u8 bParityType;
+	u8 bDataBits;
+} __attribute__((packed)) usb_cdc_line_coding_t;
+
+
+#endif

--- a/devices/usbc/client.c
+++ b/devices/usbc/client.c
@@ -1,0 +1,168 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * usb client
+ *
+ * Copyright 2019-2021 Phoenix Systems
+ * Author: Kamil Amanowicz, Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include "../low.h"
+#include "../errors.h"
+
+#include "usbphy.h"
+#include "client.h"
+
+
+struct {
+	usb_dc_t dc;
+	usb_common_data_t data;
+} imx_common;
+
+
+int usbclient_send(int endpt, const void *data, unsigned int len)
+{
+	dtd_t *res;
+
+	if (len > USB_BUFFER_SIZE)
+		return -1;
+
+	if (!imx_common.data.endpts[endpt].caps[USB_ENDPT_DIR_IN].init)
+		return -1;
+
+	low_memcpy(imx_common.data.endpts[endpt].buf[USB_ENDPT_DIR_IN].buffer, data, len);
+	res = ctrl_execTransfer(endpt, (u32)imx_common.data.endpts[endpt].buf[USB_ENDPT_DIR_IN].buffer, len, USB_ENDPT_DIR_IN);
+
+	if (DTD_ERROR(res))
+		return -1;
+
+	return len - DTD_SIZE(res);
+}
+
+
+int usbclient_rcvEndp0(void *data, unsigned int len)
+{
+	int res = -1;
+
+	while (imx_common.dc.op != DC_OP_RCV_ENDP0)
+		;
+
+	res = imx_common.data.endpts[0].buf[USB_ENDPT_DIR_OUT].len;
+	low_memcpy(data, (const char *)imx_common.data.endpts[0].buf[USB_ENDPT_DIR_OUT].buffer, res); /* copy data to buffer */
+	imx_common.dc.op = DC_OP_NONE;
+
+	ctrl_execTransfer(0, (u32)imx_common.data.endpts[0].buf[USB_ENDPT_DIR_IN].buffer, 0, USB_ENDPT_DIR_IN); /* ACK */
+
+	return res;
+}
+
+
+int usbclient_receive(int endpt, void *data, unsigned int len)
+{
+	dtd_t *dtd;
+	int res = -1;
+
+	if (len > USB_BUFFER_SIZE)
+		return -1;
+
+	if (!imx_common.data.endpts[endpt].caps[USB_ENDPT_DIR_OUT].init)
+		return -1;
+
+	if (endpt) {
+		dtd = ctrl_execTransfer(endpt, (u32)imx_common.data.endpts[endpt].buf[USB_ENDPT_DIR_OUT].buffer, USB_BUFFER_SIZE, USB_ENDPT_DIR_OUT);
+
+		if (!DTD_ERROR(dtd)) {
+			res = USB_BUFFER_SIZE - DTD_SIZE(dtd);
+			if (res > len)
+				res = len;
+
+			low_memcpy(data, (const char *)imx_common.data.endpts[endpt].buf[USB_ENDPT_DIR_OUT].buffer, res);
+		}
+		else {
+			res = -1;
+		}
+	}
+	else {
+		res = usbclient_rcvEndp0(data, len);
+	}
+
+	return res;
+}
+
+
+
+int usbclient_intr(u16 irq, void *buff)
+{
+	ctrl_hfIrq();
+
+	/* Low frequency interrupts, handle for OUT control endpoint */
+	if (imx_common.dc.setupstat & 0x1)
+		desc_classSetup(&imx_common.dc.setup);
+
+	ctrl_lfIrq();
+
+	return 0;
+}
+
+
+int usbclient_init(usb_desc_list_t *desList)
+{
+	int i;
+	int res = 0;
+
+	imx_common.dc.dev_addr = 0;
+	imx_common.dc.base = (void *)phy_getBase();
+
+	phy_init();
+
+	if ((imx_common.data.setupMem = (char *)usbclient_allocBuff(USB_BUFFER_SIZE)) == NULL)
+		return -1;
+
+	for (i = 1; i < ENDPOINTS_NUMBER; ++i) {
+		imx_common.data.endpts[i].caps[USB_ENDPT_DIR_OUT].init = 0;
+		imx_common.data.endpts[i].caps[USB_ENDPT_DIR_IN].init = 0;
+	}
+
+	if (desc_init(desList, &imx_common.data, &imx_common.dc) < 0) {
+		usbclient_buffReset();
+		return -1;
+	}
+
+	if (ctrl_init(&imx_common.data, &imx_common.dc) < 0) {
+		usbclient_buffReset();
+		return -1;
+	}
+
+	low_irqinst(phy_getIrq(), usbclient_intr, (void *)NULL);
+
+	while (imx_common.dc.op != DC_OP_EXIT) {
+		if (imx_common.dc.op == DC_OP_INIT) {
+			for (i = 1; i < ENDPOINTS_NUMBER; ++i) {
+				if ((res = ctrl_endptInit(i, &imx_common.data.endpts[i])) != ERR_NONE) {
+					usbclient_destroy();
+					return res;
+				}
+			}
+			return res;
+		}
+	}
+
+	return ERR_NONE;
+}
+
+
+int usbclient_destroy(void)
+{
+	ctrl_reset();
+	usbclient_buffReset();
+
+	phy_reset();
+
+	return 0;
+}

--- a/devices/usbc/client.h
+++ b/devices/usbc/client.h
@@ -1,0 +1,179 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * usb client
+ *
+ * Copyright 2019-2021 Phoenix Systems
+ * Author: Kamil Amanowicz, Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef _CLIENT_H_
+#define _CLIENT_H_
+
+#include "../types.h"
+
+#include "usbclient.h"
+
+
+#define USB_BUFFER_SIZE 0x1000
+
+#define ENDPOINTS_NUMBER 7
+#define ENDPOINTS_DIR_NB 2
+
+#define MIN(X, Y)           (((X) < (Y)) ? (X) : (Y))
+
+#define DTD_SIZE(dtd)       ((dtd->dtd_token >> 16) & 0x7fff)
+#define DTD_ERROR(dtd)      (dtd->dtd_token & (0xd << 3))
+#define DTD_ACTIVE(dtd)     (dtd->dtd_token & (1 << 7))
+
+
+/* device controller structures */
+
+/* data transfer descriptor */
+typedef struct _dtd_t {
+	u32 dtd_next;
+	u32 dtd_token;
+	u32 buff_ptr[5];
+	u8  padding[4];
+} __attribute__((packed)) dtd_t;
+
+
+/* endpoint queue head */
+typedef struct _dqh_t {
+	u32 caps;
+	u32 dtd_current;
+
+	/* overlay area for dtd */
+	u32 dtd_next;
+	u32 dtd_token;
+	u32 buff_ptr[5];
+
+	u32 reserved;
+
+	/* setup packet buffer */
+	u32 setup_buff[2];
+
+	/* head and tail for dtd list */
+	dtd_t *head;
+	dtd_t *tail;
+	u32 base;
+	u32 size;
+} __attribute__((packed)) dqh_t;
+
+
+/* dcd structures */
+
+/* dc states */
+enum {
+	DC_POWERED,
+	DC_ATTACHED,
+	DC_DEFAULT,
+	DC_ADDRESS,
+	DC_CONFIGURED
+};
+
+
+/* dc operation */
+enum {
+	DC_OP_NONE,
+	DC_OP_RCV_ENDP0,
+	DC_OP_RCV_ERR,
+	DC_OP_EXIT,
+	DC_OP_INIT
+};
+
+
+typedef struct _usb_dc_t {
+	volatile u32 *base;
+	void *dtdMem;
+	volatile dqh_t *endptqh;
+	u32 status;
+	u32 dev_addr;
+
+	volatile u8 op;
+	usb_setup_packet_t setup;
+
+	volatile u32 setupstat;
+} usb_dc_t;
+
+
+/* usb spec related stuff */
+typedef struct _endpt_caps_t {
+	u8  mult;
+	u8  zlt;
+	u16 max_pkt_len;
+	u8  ios;
+	u8 init;
+} endpt_caps_t;
+
+
+typedef struct _endpt_ctrl_t {
+	u8 type;
+	u8 data_toggle;
+	u8 data_inhibit;
+	u8 stall;
+} endpt_ctrl_t;
+
+
+typedef struct _usb_buffer_t {
+	u8 *buffer;
+	s16 len;
+} usb_buffer_t;
+
+
+typedef struct _endpt_data_t {
+	endpt_caps_t caps[ENDPOINTS_DIR_NB];
+	endpt_ctrl_t ctrl[ENDPOINTS_DIR_NB];
+
+	usb_buffer_t buf[ENDPOINTS_DIR_NB];
+} endpt_data_t;
+
+
+typedef struct{
+	char *setupMem;
+	endpt_data_t endpts[ENDPOINTS_NUMBER];
+} usb_common_data_t;
+
+
+/* Descriptors Manager's functions */
+
+extern int desc_init(usb_desc_list_t *desList, usb_common_data_t *usb_data_in, usb_dc_t *dc_in);
+
+
+extern int desc_classSetup(const usb_setup_packet_t *setup);
+
+
+extern int desc_setup(const usb_setup_packet_t *setup);
+
+
+
+/* Controller's functions */
+
+extern int ctrl_init(usb_common_data_t *usb_data_in, usb_dc_t *dc_in);
+
+
+extern void ctrl_setAddress(u32 addr);
+
+
+extern int ctrl_endptInit(int endpt, endpt_data_t *ctrl_endptInit);
+
+
+extern int ctrl_lfIrq(void);
+
+
+extern int ctrl_hfIrq(void);
+
+
+extern dtd_t *ctrl_execTransfer(int endpt, u32 paddr, u32 sz, int dir);
+
+
+extern void ctrl_reset(void);
+
+
+#endif /* _CLIENT_H_ */

--- a/devices/usbc/ctrl.c
+++ b/devices/usbc/ctrl.c
@@ -1,0 +1,407 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * usb device controller driver
+ *
+ * Copyright 2019-2021 Phoenix Systems
+ * Author: Kamil Amanowicz, Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include "../low.h"
+#include "../errors.h"
+
+#include "client.h"
+#include "usbphy.h"
+
+
+struct {
+	u32 qtdOffs;
+
+	usb_dc_t *dc;
+	usb_common_data_t *data;
+} ctrl_common;
+
+
+/* device cotroller register offsets */
+enum {
+	/* identification regs */
+	id = 0x0, hwgeneral, hwhost, hwdevice, hwtxbuf, hwrxbuf,
+
+	/* operational regs */
+	gptimer0ld  = 0x20, gptimer0ctrl, gptimer1ld, gptimer1ctrl, sbuscfg,
+
+	/* capability regs */
+	caplength = 0x40, hciversion = 0x40, hcsparams, hccparams,
+	dciversion = 0x48, dccparams,
+
+	/* operational regs cont. */
+	usbcmd = 0x50, usbsts, usbintr, frindex,
+	periodiclistbase = 0x55, deviceaddr = 0x55, asynclistaddr = 0x56,
+	endpointlistaddr = 0x56, burstsize = 0x58, txfilltunning, endptnak = 0x5E,
+	endptnaken, configflag, portsc1, otgsc = 0x69, usbmode, endptsetupstat,
+	endptprime, endptflush, endptstat, endptcomplete, endptctrl0, endptctrl1,
+	endptctrl2, endptctrl3, endptctrl4, endptctrl5, endptctrl6, endptctrl7
+};
+
+
+static int ctrl_allocBuff(int endpt, int dir)
+{
+	ctrl_common.data->endpts[endpt].buf[dir].buffer = usbclient_allocBuff(USB_BUFFER_SIZE);
+
+	if (ctrl_common.data->endpts[endpt].buf[dir].buffer == NULL)
+		return ERR_MEM;
+
+	ctrl_common.data->endpts[endpt].buf[dir].len = 0;
+
+	return ERR_NONE;
+}
+
+
+static void *ctrl_allocQtdMem(void)
+{
+	int i;
+
+	if (!ctrl_common.qtdOffs) {
+		ctrl_common.dc->dtdMem = usbclient_allocBuff(USB_BUFFER_SIZE);
+
+		if (ctrl_common.dc->dtdMem == NULL)
+			return NULL;
+
+		for (i = 0; i < USB_BUFFER_SIZE; ++i)
+			((char *)ctrl_common.dc->dtdMem)[i] = 0;
+	}
+
+	return  (void *)(ctrl_common.dc->dtdMem + 0x40 * (ctrl_common.qtdOffs++));
+}
+
+
+static int ctrl_dtdInit(int endpt, int inQH, int outQh)
+{
+	dtd_t *dtd;
+	int qh = endpt * 2;
+
+	if (!endpt)
+		return -1;
+
+	/* initialize dtd for selected endpoints */
+	if (outQh) {
+		dtd = ctrl_allocQtdMem();
+		if (dtd == NULL)
+			return ERR_MEM;
+
+		ctrl_common.dc->endptqh[qh].base = (((u32)dtd) & ~0xfff);
+		ctrl_common.dc->endptqh[qh].size = 0x40;
+		ctrl_common.dc->endptqh[qh].head = dtd;
+		ctrl_common.dc->endptqh[qh].tail = dtd;
+	}
+
+	if (inQH) {
+		dtd = ctrl_allocQtdMem();
+		if (dtd == NULL)
+			return ERR_MEM;
+
+		ctrl_common.dc->endptqh[++qh].base = (((u32)dtd) & ~0xfff) + (64 * sizeof(dtd_t));
+		ctrl_common.dc->endptqh[qh].size = 0x40;
+		ctrl_common.dc->endptqh[qh].head = dtd + 64;
+		ctrl_common.dc->endptqh[qh].tail = dtd + 64;
+	}
+
+	return ERR_NONE;
+}
+
+
+static int ctrl_initEndptQh(int endpt, int dir, endpt_data_t *endpt_init)
+{
+	u32 setup = 0, tmp;
+	int qh = endpt * 2 + dir;
+
+	ctrl_allocBuff(endpt, dir);
+
+	tmp = endpt_init->caps[dir].max_pkt_len << 16;
+	tmp |= endpt_init->caps[dir].ios << 15;
+	tmp |= endpt_init->caps[dir].zlt << 29;
+	tmp |= endpt_init->caps[dir].mult << 30;
+	ctrl_common.dc->endptqh[qh].caps = tmp;
+	ctrl_common.dc->endptqh[qh].dtd_next = 1;
+
+	setup |= endpt_init->ctrl[dir].data_toggle << (6 + dir * 16);
+	setup |= endpt_init->ctrl[dir].type << (2 + dir * 16);
+
+	return setup;
+}
+
+
+int ctrl_endptInit(int endpt, endpt_data_t *endpt_init)
+{
+	s8 i;
+	int res = ERR_NONE;
+	u32 setup = 0;
+
+	if (endpt == 0)
+		return -1;
+
+	if ((res = ctrl_dtdInit(endpt, endpt_init->caps[USB_ENDPT_DIR_IN].init, endpt_init->caps[USB_ENDPT_DIR_OUT].init)) != ERR_NONE)
+		return res;
+
+	for (i = 0; i < ENDPOINTS_DIR_NB; ++i) {
+		if (endpt_init->caps[i].init)
+			setup |= ctrl_initEndptQh(endpt, i, endpt_init);
+	}
+
+	*(ctrl_common.dc->base + endptctrl0 + endpt) = setup;
+
+	for (i = 0; i < ENDPOINTS_DIR_NB; ++i) {
+		if (endpt_init->caps[i].init)
+			*(ctrl_common.dc->base + endptctrl0 + endpt) |= 1 << (7 + i * 16);
+	}
+
+	return res;
+}
+
+
+int ctrl_endpt0Init(void)
+{
+	int i;
+	u32 qh_addr, tmp;
+
+	if (ctrl_allocBuff(0, USB_ENDPT_DIR_IN) < 0)
+		return ERR_MEM;
+
+	if (ctrl_allocBuff(0, USB_ENDPT_DIR_OUT) < 0)
+		return ERR_MEM;
+
+	ctrl_common.data->endpts[0].caps[USB_ENDPT_DIR_IN].init = 1;
+	ctrl_common.data->endpts[0].caps[USB_ENDPT_DIR_OUT].init = 1;
+
+	/* map queue head list */
+	ctrl_common.dc->endptqh = usbclient_allocBuff(USB_BUFFER_SIZE);
+
+	if (ctrl_common.dc->endptqh == NULL)
+		return ERR_MEM;
+
+	for (i = 0; i < USB_BUFFER_SIZE; ++i)
+		((char *)ctrl_common.dc->endptqh)[i] = 0;
+
+	qh_addr = ((u32)((void *)ctrl_common.dc->endptqh)) & ~0xfff;
+
+	tmp =  0x40 << 16 /* max 64 bytes */ | 0x1 << 29 | 0x1 << 15 /* ios */;
+	ctrl_common.dc->endptqh[0].caps = tmp;
+	ctrl_common.dc->endptqh[0].dtd_next = 0x1; /* invalid */
+	ctrl_common.dc->endptqh[1].caps = tmp;
+	ctrl_common.dc->endptqh[1].dtd_next = 1;
+
+	ctrl_common.dc->endptqh[0].base = qh_addr + (32 * sizeof(dqh_t));
+	ctrl_common.dc->endptqh[0].size = 0x40;
+	ctrl_common.dc->endptqh[0].head = (dtd_t *)(ctrl_common.dc->endptqh + 32);
+	ctrl_common.dc->endptqh[0].tail = (dtd_t *)(ctrl_common.dc->endptqh + 32);
+
+	ctrl_common.dc->endptqh[1].base = qh_addr + (48 * sizeof(dqh_t));
+	ctrl_common.dc->endptqh[1].size = 0x10;
+	ctrl_common.dc->endptqh[1].head = (dtd_t *)(ctrl_common.dc->endptqh + 48);
+	ctrl_common.dc->endptqh[1].tail = (dtd_t *)(ctrl_common.dc->endptqh + 48);
+
+	*(ctrl_common.dc->base + endpointlistaddr) = qh_addr;
+	*(ctrl_common.dc->base + endptprime) |= 1;
+	*(ctrl_common.dc->base + endptprime) |= 1 << 16;
+
+
+	return ERR_NONE;
+}
+
+
+static dtd_t *ctrl_getDtd(int endpt, int dir)
+{
+	int qh = endpt * 2 + dir;
+	u32 base_addr;
+	dtd_t *ret;
+
+	base_addr = ((u32)ctrl_common.dc->endptqh[qh].head & ~((ctrl_common.dc->endptqh[qh].size * sizeof(dtd_t)) - 1));
+
+	ret = ctrl_common.dc->endptqh[qh].tail++;
+	ctrl_common.dc->endptqh[qh].tail = (dtd_t *)(base_addr | ((u32)ctrl_common.dc->endptqh[qh].tail & (((ctrl_common.dc->endptqh[qh].size) * sizeof(dtd_t)) - 1)));
+
+	return ret;
+}
+
+
+static int ctrl_buildDtd(dtd_t *dtd, u32 paddr, u32 size)
+{
+	int i = 0;
+	int tempSize = size;
+
+	if (size > USB_BUFFER_SIZE)
+		return -1;
+
+	dtd->dtd_next = 1;
+	dtd->dtd_token = size << 16;
+	dtd->dtd_token |= 1 << 7;
+
+	/* TODO: allow to use additional dtd within the same dQH */
+	while (tempSize > 0) {
+		dtd->buff_ptr[i++] = paddr;
+		tempSize -= 0x1000;
+		paddr += 0x1000;
+	}
+
+	return ERR_NONE;
+}
+
+
+dtd_t *ctrl_execTransfer(int endpt, u32 paddr, u32 sz, int dir)
+{
+	int shift;
+	u32 offs;
+	volatile dtd_t *dtd;
+
+	int qh = (endpt << 1) + dir;
+
+	dtd = ctrl_getDtd(endpt, dir);
+
+	ctrl_buildDtd((dtd_t *)dtd, paddr, sz);
+
+	shift = endpt + ((qh & 1) ? 16 : 0);
+	offs = (u32)dtd & (((ctrl_common.dc->endptqh[qh].size) * sizeof(dtd_t)) - 1);
+
+	ctrl_common.dc->endptqh[qh].dtd_next = (ctrl_common.dc->endptqh[qh].base + offs) & ~1;
+	ctrl_common.dc->endptqh[qh].dtd_token &= ~(1 << 6);
+	ctrl_common.dc->endptqh[qh].dtd_token &= ~(1 << 7);
+
+	while ((*(ctrl_common.dc->base + endptprime) & (1 << shift)))
+		;
+
+	*(ctrl_common.dc->base + endptprime) |= 1 << shift;
+
+	/* prime the endpoint and wait for it to prime */
+	while ((*(ctrl_common.dc->base + endptprime) & (1 << shift)))
+		;
+	*(ctrl_common.dc->base + endptprime) |= 1 << shift;
+	while (!(*(ctrl_common.dc->base + endptprime) & (1 << shift)) && (*(ctrl_common.dc->base + endptstat) & (1 << shift)))
+		;
+
+	/* wait to finish transaction */
+	while (DTD_ACTIVE(dtd) && !DTD_ERROR(dtd))
+		;
+
+	return (dtd_t *)dtd;
+}
+
+
+int ctrl_hfIrq(void)
+{
+	int endpt = 0;
+
+	if ((ctrl_common.dc->setupstat = *(ctrl_common.dc->base + endptsetupstat)) & 0x1) {
+		/* trip winre set */
+		while (!((ctrl_common.dc->setupstat >> endpt) & 1)) {
+			if (++endpt > 15)
+				return -1;
+		}
+
+		do {
+			*(ctrl_common.dc->base + usbcmd) |= 1 << 13;
+			low_memcpy(&ctrl_common.dc->setup, (void *)ctrl_common.dc->endptqh[endpt].setup_buff, sizeof(usb_setup_packet_t));
+		} while (!(*(ctrl_common.dc->base + usbcmd) & 1 << 13));
+
+		*(ctrl_common.dc->base + endptsetupstat) |= 1 << endpt;
+		*(ctrl_common.dc->base + usbcmd) &= ~(1 << 13);
+		*(ctrl_common.dc->base + usbsts) |= 1;
+
+		ctrl_common.dc->endptqh[0].head = ctrl_common.dc->endptqh[0].tail;
+		ctrl_common.dc->endptqh[1].head = ctrl_common.dc->endptqh[1].tail;
+
+		while (*(ctrl_common.dc->base + endptsetupstat) & 1)
+			;
+
+		desc_setup(&ctrl_common.dc->setup);
+	}
+
+	return 1;
+}
+
+
+int ctrl_lfIrq(void)
+{
+	if ((*(ctrl_common.dc->base + usbsts) & 1 << 6)) {
+
+		*(ctrl_common.dc->base + endptsetupstat) = *(ctrl_common.dc->base + endptsetupstat);
+		*(ctrl_common.dc->base + endptcomplete) = *(ctrl_common.dc->base + endptcomplete);
+
+		while (*(ctrl_common.dc->base + endptprime))
+			;
+
+		*(ctrl_common.dc->base + endptflush) = 0xffffffff;
+
+		while (*(ctrl_common.dc->base + portsc1) & 1 << 8)
+			;
+
+		*(ctrl_common.dc->base + usbsts) |= 1 << 6;
+		ctrl_common.dc->status = DC_DEFAULT;
+	}
+
+	return 1;
+}
+
+
+static void ctrl_devInit(void)
+{
+	*(ctrl_common.dc->base + endptflush) = 0xffffffff;
+	/* Run/Stop bit */
+	*(ctrl_common.dc->base + usbcmd) &= ~1;
+	/* Controller resets its internal pipelines, timers etc. */
+	*(ctrl_common.dc->base + usbcmd) |= 1 << 1;
+	ctrl_common.dc->status = DC_POWERED;
+
+	/* Run/Stop register is set to 0 when the reset process is complete. */
+	while (*(ctrl_common.dc->base + usbcmd) & (1 << 1))
+		;
+
+	/* set usb mode to device */
+	*(ctrl_common.dc->base + usbmode) |= 2;
+	/* trip wire mode (setup lockout mode disabled) */
+	*(ctrl_common.dc->base + usbmode) |= 1 << 3;
+
+	*(ctrl_common.dc->base + usbintr) |= 0x57;
+	*(ctrl_common.dc->base + usbintr) |= 3 << 18;
+	*(ctrl_common.dc->base + usbintr) |= 1 << 6;
+
+	*(ctrl_common.dc->base + usbsts) |= 1;
+
+	ctrl_common.dc->status = DC_ATTACHED;
+	*(ctrl_common.dc->base + usbcmd) |= 1;
+}
+
+
+int ctrl_init(usb_common_data_t *usb_data_in, usb_dc_t *dc_in)
+{
+	ctrl_common.dc = dc_in;
+	ctrl_common.qtdOffs = 0;
+	ctrl_common.data = usb_data_in;
+
+	ctrl_devInit();
+
+	return ctrl_endpt0Init();
+}
+
+
+void ctrl_setAddress(u32 addr)
+{
+	*(ctrl_common.dc->base + deviceaddr) = addr;
+}
+
+
+void ctrl_reset(void)
+{
+	/* stop controller */
+	*(ctrl_common.dc->base + endptflush) = 0xffffffff;
+	*(ctrl_common.dc->base + usbintr) = 0;
+
+	/* reset controller */
+	*(ctrl_common.dc->base + usbcmd) &= ~1;
+	*(ctrl_common.dc->base + usbcmd) |= 2;
+}

--- a/devices/usbc/desc.c
+++ b/devices/usbc/desc.c
@@ -1,0 +1,349 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * descriptor manager
+ *
+ * Copyright 2019-2021 Phoenix Systems
+ * Author: Kamil Amanowicz, Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include "../low.h"
+#include "../errors.h"
+
+#include "client.h"
+
+
+struct {
+	volatile u32 dev;
+	volatile u32 cfg;
+
+	volatile u32 str_0;
+	volatile u32 str_man;
+	volatile u32 str_prod;
+
+	volatile u32 hid_reports;
+
+	volatile usb_dc_t *dc;
+	volatile usb_common_data_t *data;
+} desc_common;
+
+
+static void desc_endptInit(usb_endpoint_desc_t *endpt)
+{
+	int endNb = endpt->bEndpointAddress & 0x7;
+	int dir = (endpt->bEndpointAddress & (1 << 7)) ? 1 : 0;
+
+	desc_common.data->endpts[endNb].caps[dir].mult = 0;
+	desc_common.data->endpts[endNb].caps[dir].zlt = 1;
+	desc_common.data->endpts[endNb].caps[dir].max_pkt_len = endpt->wMaxPacketSize;
+	desc_common.data->endpts[endNb].caps[dir].ios = 1;
+	desc_common.data->endpts[endNb].caps[dir].init = 1;
+
+	desc_common.data->endpts[endNb].ctrl[dir].type = endpt->bmAttributes & 0x03;
+	desc_common.data->endpts[endNb].ctrl[dir].data_toggle = 1;
+	desc_common.data->endpts[endNb].ctrl[dir].data_inhibit = 0;
+	desc_common.data->endpts[endNb].ctrl[dir].stall = 0;
+}
+
+
+static void desc_strInit(usb_desc_list_t *desList, int *localOffset, int strOrder)
+{
+	switch (strOrder) {
+		case 0:
+			desc_common.str_0 = (u32)(desc_common.data->setupMem + *localOffset);
+			low_memcpy((void *)desc_common.str_0, desList->descriptor, sizeof(usb_string_desc_t));
+			*localOffset += desList->descriptor->bFunctionLength;
+			break;
+
+		case 1:
+			desc_common.str_man = (u32)(desc_common.data->setupMem + *localOffset);
+			low_memcpy((void *)desc_common.str_man, desList->descriptor, desList->descriptor->bFunctionLength);
+			*localOffset += desList->descriptor->bFunctionLength;
+			break;
+
+		case 2:
+			desc_common.str_prod = (u32)(desc_common.data->setupMem + *localOffset);
+			low_memcpy((void *)desc_common.str_prod, desList->descriptor, desList->descriptor->bFunctionLength);
+			*localOffset += desList->descriptor->bFunctionLength;
+			break;
+
+		default:
+			break;
+	}
+}
+
+
+int desc_init(usb_desc_list_t *desList, usb_common_data_t *usb_data_in, usb_dc_t *dc_in)
+{
+	int i, localOffset = 0;
+	u32 string_desc_count = 0;
+
+	desc_common.dc = dc_in;
+	desc_common.data = usb_data_in;
+
+	for (i = 0; i < USB_BUFFER_SIZE; ++i)
+		desc_common.data->setupMem[i] = 0;
+
+	/* Extract mandatory descriptors to mapped memory */
+	for (; desList != NULL; desList = desList->next) {
+
+		if (localOffset > USB_BUFFER_SIZE)
+			return -1;
+
+		switch (desList->descriptor->bDescriptorType) {
+			case USB_DESC_DEVICE:
+				desc_common.dev = (u32)(desc_common.data->setupMem + localOffset);
+				low_memcpy((void *)desc_common.dev, desList->descriptor, sizeof(usb_device_desc_t));
+				localOffset += desList->descriptor->bFunctionLength;
+				break;
+
+			case USB_DESC_CONFIG:
+				desc_common.cfg = (u32)(desc_common.data->setupMem + localOffset);
+				low_memcpy((void *)desc_common.cfg, desList->descriptor, sizeof(usb_configuration_desc_t));
+				localOffset += desList->descriptor->bFunctionLength;
+				break;
+
+			case USB_DESC_INTERFACE:
+				low_memcpy(desc_common.data->setupMem + localOffset, desList->descriptor, desList->descriptor->bFunctionLength);
+				localOffset += desList->descriptor->bFunctionLength;
+				break;
+
+			case USB_DESC_ENDPOINT:
+				low_memcpy(desc_common.data->setupMem + localOffset, desList->descriptor, desList->descriptor->bFunctionLength);
+				localOffset += desList->descriptor->bFunctionLength;
+				desc_endptInit((usb_endpoint_desc_t *)desList->descriptor);
+				break;
+
+			case USB_DESC_TYPE_HID:
+				low_memcpy(desc_common.data->setupMem + localOffset, desList->descriptor, desList->descriptor->bFunctionLength);
+				localOffset += desList->descriptor->bFunctionLength;
+				break;
+
+			case USB_DESC_TYPE_CDC_CS_INTERFACE:
+				low_memcpy(desc_common.data->setupMem + localOffset, desList->descriptor, desList->descriptor->bFunctionLength);
+				localOffset += desList->descriptor->bFunctionLength;
+				break;
+
+			case USB_DESC_TYPE_HID_REPORT:
+				desc_common.hid_reports = (u32)(desc_common.data->setupMem + localOffset);
+				low_memcpy((void *)desc_common.hid_reports, &desList->descriptor->bDescriptorSubtype, desList->descriptor->bFunctionLength - 2);
+				localOffset += desList->descriptor->bFunctionLength - 2;
+				break;
+
+			case USB_DESC_STRING:
+				desc_strInit(desList, &localOffset, string_desc_count++);
+				break;
+
+			case USB_DESC_TYPE_DEV_QUAL:
+			case USB_DESC_TYPE_OTH_SPD_CFG:
+			case USB_DESC_TYPE_INTF_PWR:
+				/* Not implemented yet */
+				break;
+
+			default:
+				break;
+		}
+	}
+
+	return ERR_NONE;
+}
+
+
+static void desc_ReqSetAddress(const usb_setup_packet_t *setup)
+{
+	if (setup->wValue) {
+		desc_common.dc->status = DC_ADDRESS;
+
+		desc_common.dc->dev_addr = setup->wValue << 25;
+		desc_common.dc->dev_addr |= 1 << 24;
+
+		ctrl_setAddress(desc_common.dc->dev_addr);
+
+		desc_common.dc->op = DC_OP_INIT;
+		ctrl_execTransfer(0, (u32)desc_common.data->endpts[0].buf[USB_ENDPT_DIR_IN].buffer, 0, USB_ENDPT_DIR_IN);
+	}
+	else if (desc_common.dc->status != DC_CONFIGURED) {
+		desc_common.dc->status = DC_DEFAULT;
+	}
+}
+
+
+static void desc_ReqSetConfig(void)
+{
+	if (desc_common.dc->status == DC_ADDRESS) {
+		desc_common.dc->status = DC_CONFIGURED;
+		ctrl_execTransfer(0, (u32)desc_common.data->endpts[0].buf[USB_ENDPT_DIR_IN].buffer, 0, USB_ENDPT_DIR_IN);
+	}
+}
+
+
+static int desc_ReqGetConfig(const usb_setup_packet_t *setup)
+{
+	if (setup->wValue != 0 || setup->wIndex != 0 || setup->wLength != 1)
+		return ERR_NONE;
+
+	if (desc_common.dc->status != DC_CONFIGURED)
+		desc_common.data->endpts[0].buf[USB_ENDPT_DIR_OUT].buffer[0] = 0;
+	else
+		desc_common.data->endpts[0].buf[USB_ENDPT_DIR_OUT].buffer[1] = 1;
+
+	ctrl_execTransfer(0, (u32)desc_common.data->endpts[0].buf[USB_ENDPT_DIR_OUT].buffer, setup->wLength, USB_ENDPT_DIR_OUT);
+
+	return ERR_NONE;
+}
+
+
+static void desc_ReqGetDescriptor(const usb_setup_packet_t *setup)
+{
+	usb_string_desc_t *strdesc;
+
+	if (setup->wValue >> 8 == USB_DESC_DEVICE) {
+		ctrl_execTransfer(0, desc_common.dev, sizeof(usb_device_desc_t), USB_ENDPT_DIR_IN);
+	}
+	else if (setup->wValue >> 8 == USB_DESC_CONFIG) {
+		ctrl_execTransfer(0, desc_common.cfg, setup->wLength, USB_ENDPT_DIR_IN);
+	}
+	else if (setup->wValue >> 8 == USB_DESC_STRING) {
+		if ((setup->wValue & 0xff) == 0) {
+			strdesc = (usb_string_desc_t *)desc_common.str_0;
+			ctrl_execTransfer(0, desc_common.str_0, MIN(strdesc->bLength, setup->wLength), USB_ENDPT_DIR_IN);
+		}
+		else if ((setup->wValue & 0xff) == 1) {
+			strdesc = (usb_string_desc_t *)desc_common.str_man;
+			ctrl_execTransfer(0, desc_common.str_man, MIN(strdesc->bLength, setup->wLength), USB_ENDPT_DIR_IN);
+		}
+		else if ((setup->wValue & 0xff) == 2) {
+			strdesc = (usb_string_desc_t *)desc_common.str_prod;
+			ctrl_execTransfer(0, desc_common.str_prod, MIN(strdesc->bLength, setup->wLength), USB_ENDPT_DIR_IN);
+		}
+		else if ((setup->wValue & 0xff) == 4) {
+			ctrl_execTransfer(0, (u32)desc_common.data->endpts[0].buf[USB_ENDPT_DIR_IN].buffer, 0, USB_ENDPT_DIR_IN);
+			ctrl_execTransfer(0, (u32)desc_common.data->endpts[0].buf[USB_ENDPT_DIR_OUT].buffer, 71, USB_ENDPT_DIR_OUT);
+			return;
+		}
+	}
+	else if (setup->wValue >> 8 == USB_DESC_TYPE_HID_REPORT) {
+		ctrl_execTransfer(0, desc_common.hid_reports, 76, USB_ENDPT_DIR_IN);
+	}
+
+	ctrl_execTransfer(0, (u32)desc_common.data->endpts[0].buf[USB_ENDPT_DIR_OUT].buffer, 0x40, USB_ENDPT_DIR_OUT);
+}
+
+
+static void desc_defaultSetup(const usb_setup_packet_t *setup)
+{
+	if (*(u32 *)setup == 0xdeadc0de) {
+		desc_common.dc->op = DC_OP_EXIT;
+	}
+	else {
+		ctrl_execTransfer(0, (u32)desc_common.data->endpts[0].buf[USB_ENDPT_DIR_OUT].buffer, setup->wLength, USB_ENDPT_DIR_OUT);
+		ctrl_execTransfer(0, (u32)desc_common.data->endpts[0].buf[USB_ENDPT_DIR_IN].buffer, 0, USB_ENDPT_DIR_IN);
+		desc_common.data->endpts[0].buf[USB_ENDPT_DIR_OUT].buffer[0] = 0;
+
+		ctrl_execTransfer(1, (u32)desc_common.data->endpts[0].buf[USB_ENDPT_DIR_OUT].buffer, 0x80, USB_ENDPT_DIR_OUT);
+		desc_common.dc->op = DC_OP_RCV_ENDP0;
+	}
+}
+
+
+int desc_setup(const usb_setup_packet_t *setup)
+{
+	int res = ERR_NONE;
+
+
+	if (EXTRACT_REQ_TYPE(setup->bmRequestType) != REQUEST_TYPE_STANDARD)
+		return ERR_NONE;
+
+	switch (setup->bRequest) {
+		case REQ_SET_ADDRESS:
+			desc_ReqSetAddress(setup);
+			break;
+
+		case REQ_SET_CONFIGURATION:
+			desc_ReqSetConfig();
+			break;
+
+		case REQ_GET_DESCRIPTOR:
+			desc_ReqGetDescriptor(setup);
+			break;
+
+		case REQ_CLEAR_FEATURE:
+		case REQ_GET_STATUS:
+		case REQ_GET_INTERFACE:
+		case REQ_SET_INTERFACE:
+		case REQ_SET_FEATURE:
+		case REQ_SET_DESCRIPTOR:
+		case REQ_SYNCH_FRAME:
+			break;
+
+		case REQ_GET_CONFIGURATION:
+			desc_ReqGetConfig(setup);
+			break;
+
+		default:
+			desc_defaultSetup(setup);
+			break;
+	}
+
+	return res;
+}
+
+
+static void desc_ClassReqSetReport(const usb_setup_packet_t *setup)
+{
+	dtd_t *dtd = ctrl_execTransfer(0, (u32)desc_common.data->endpts[0].buf[USB_ENDPT_DIR_OUT].buffer, 64 + setup->wLength, USB_ENDPT_DIR_OUT); /* read data to buffer with URB struct*/
+
+	if (!DTD_ERROR(dtd)) {
+		desc_common.dc->op = DC_OP_RCV_ENDP0;  /* mark that data is ready */
+		desc_common.data->endpts[0].buf[USB_ENDPT_DIR_OUT].len = 64 + setup->wLength - DTD_SIZE(dtd);
+	}
+	else {
+		desc_common.dc->op = DC_OP_RCV_ERR;    /* mark that data is uncomplete */
+		desc_common.data->endpts[0].buf[USB_ENDPT_DIR_OUT].len = -1;
+	}
+}
+
+
+int desc_classSetup(const usb_setup_packet_t *setup)
+{
+	int res = ERR_NONE;
+
+	if (EXTRACT_REQ_TYPE(setup->bmRequestType) != REQUEST_TYPE_CLASS)
+		return ERR_NONE;
+
+	switch (setup->bRequest) {
+		case CLASS_REQ_SET_IDLE:
+			ctrl_execTransfer(0, (u32)desc_common.data->endpts[0].buf[USB_ENDPT_DIR_IN].buffer, 0, USB_ENDPT_DIR_IN);
+			break;
+
+		case CLASS_REQ_SET_REPORT:
+			desc_ClassReqSetReport(setup);
+			break;
+
+		case CLASS_REQ_GET_IDLE:
+		case CLASS_REQ_GET_PROTOCOL:
+		case CLASS_REQ_GET_REPORT:
+		case CLASS_REQ_SET_PROTOCOL:
+			break;
+
+		case CLASS_REQ_SET_LINE_CODING:
+			ctrl_execTransfer(0, (u32)desc_common.data->endpts[0].buf[USB_ENDPT_DIR_OUT].buffer, 64 + setup->wLength, USB_ENDPT_DIR_OUT); /* read data to buffer with URB struct*/
+			ctrl_execTransfer(0, (u32)desc_common.data->endpts[0].buf[USB_ENDPT_DIR_IN].buffer, 0, USB_ENDPT_DIR_IN); /* ACK */
+			break;
+
+		case CLASS_REQ_SET_CONTROL_LINE_STATE:
+			ctrl_execTransfer(0, (u32)desc_common.data->endpts[0].buf[USB_ENDPT_DIR_IN].buffer, 0, USB_ENDPT_DIR_IN); /* ACK */
+			break;
+
+		default:
+			break;
+	}
+
+	return res;
+}

--- a/devices/usbc/usb.h
+++ b/devices/usbc/usb.h
@@ -1,0 +1,200 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * USB Data
+ *
+ * Copyright 2018-2020 Phoenix Systems
+ * Author: Jan Sikorski, Kamil Amanowicz, Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#ifndef _USB_DESCRIPTORS_H_
+#define _USB_DESCRIPTORS_H_
+
+#include "../types.h"
+
+#define REQUEST_DIR_HOST2DEV  (0 << 7)
+#define REQUEST_DIR_DEV2HOST  (1 << 7)
+#define REQUEST_DIR_MASK      (1 << 7)
+
+#define REQUEST_TYPE_STANDARD  (0 << 5)
+#define REQUEST_TYPE_CLASS     (1 << 5)
+#define REQUEST_TYPE_VENDOR    (2 << 5)
+
+#define REQUEST_RECIPIENT_DEVICE    0
+#define REQUEST_RECIPIENT_INTERFACE 1
+#define REQUEST_RECIPIENT_ENDPOINT  2
+#define REQUEST_RECIPIENT_OTHER     3
+
+#define EXTRACT_REQ_TYPE(req_type) ((0x3 << 5) & req_type)
+
+/* request types */
+#define REQ_GET_STATUS         0
+#define REQ_CLEAR_FEATURE      1
+#define REQ_SET_FEATURE        3
+#define REQ_SET_ADDRESS        5
+#define REQ_GET_DESCRIPTOR     6
+#define REQ_SET_DESCRIPTOR     7
+#define REQ_GET_CONFIGURATION  8
+#define REQ_SET_CONFIGURATION  9
+#define REQ_GET_INTERFACE      10
+#define REQ_SET_INTERFACE      11
+#define REQ_SYNCH_FRAME        12
+
+
+/* class request codes */
+#define CLASS_REQ_GET_REPORT   1
+#define CLASS_REQ_GET_IDLE     2
+#define CLASS_REQ_GET_PROTOCOL 3
+#define CLASS_REQ_SET_REPORT   9
+#define CLASS_REQ_SET_IDLE     10
+#define CLASS_REQ_SET_PROTOCOL 11
+#define CLASS_REQ_SET_LINE_CODING 0x20
+#define CLASS_REQ_SET_CONTROL_LINE_STATE 0x22
+
+
+/* descriptor types */
+#define USB_DESC_DEVICE 1
+#define USB_DESC_CONFIG 2
+#define USB_DESC_STRING 3
+#define USB_DESC_INTERFACE 4
+#define USB_DESC_ENDPOINT 5
+#define USB_DESC_TYPE_DEV_QUAL 6
+#define USB_DESC_TYPE_OTH_SPD_CFG 7
+#define USB_DESC_TYPE_INTF_PWR 8
+#define USB_DESC_INTERFACE_ASSOCIATION 11
+#define USB_DESC_TYPE_HID  0x21
+#define USB_DESC_TYPE_HID_REPORT 0x22
+#define USB_DESC_TYPE_CDC_CS_INTERFACE 0x24
+
+
+/* endpoint types */
+#define USB_ENDPT_TYPE_CONTROL 0
+#define USB_ENDPT_TYPE_ISO     1
+#define USB_ENDPT_TYPE_BULK    2
+#define USB_ENDPT_TYPE_INTR    3
+
+
+/* endpoint direction */
+#define USB_ENDPT_DIR_OUT 0
+#define USB_ENDPT_DIR_IN  1
+
+
+/* endpoint feature */
+#define USB_ENDPOINT_HALT 0
+
+/* class specific desctriptors */
+#define USB_DESC_CS_INTERFACE 0x24
+#define USB_DESC_CS_ENDPOINT 0x25
+
+#define USB_TIMEOUT 5000000
+
+enum { pid_out = 0xe1, pid_in = 0x69, pid_setup = 0x2d };
+
+
+enum { out_token = 0, in_token, setup_token };
+
+
+typedef struct usb_setup_packet {
+	u8  bmRequestType;
+	u8  bRequest;
+	u16 wValue;
+	u16 wIndex;
+	u16 wLength;
+} __attribute__((packed)) usb_setup_packet_t;
+
+
+struct usb_desc_header {
+	u8 bLength;                /* size of descriptor */
+	u8 bDescriptorType;        /* descriptor type */
+};
+
+
+typedef struct usb_device_desc {
+	u8  bLength;               /* size of descriptor */
+	u8  bDescriptorType;       /* descriptor type */
+	u16 bcdUSB;                /* usb specification in BCD */
+	u8  bDeviceClass;          /* device class code (USB-IF)*/
+	u8  bDeviceSubClass;       /* device subclass code (USB-IF)*/
+	u8  bDeviceProtocol;       /* protocol code  (USB-IF)*/
+	u8  bMaxPacketSize0;       /* max packet size for endpoint0 */
+	u16 idVendor;              /* vendor id (USB-IF) */
+	u16 idProduct;             /* product id */
+	u16 bcdDevice;             /* device release number in BCD */
+	u8  iManufacturer;         /* manufacturer string index */
+	u8  iProduct;              /* product string index */
+	u8  iSerialNumber;         /* serial number string index */
+	u8  bNumConfigurations;    /* number of possible configurations */
+} __attribute__((packed)) usb_device_desc_t;
+
+
+typedef struct usb_configuration_desc {
+	u8  bLength;               /* size of descriptor */
+	u8  bDescriptorType;       /* descriptor type */
+	u16 wTotalLength;          /* total bytes returned for this configuration */
+	u8  bNumInterfaces;        /* number of interfaces supported */
+	u8  bConfigurationValue;   /* value to use for SET_CONFIGURATION request */
+	u8  iConfiguration;        /* configuration string index */
+	u8  bmAttributes;          /* attributes bitmap */
+	u8  bMaxPower;             /* maximum power consumption */
+} __attribute__((packed)) usb_configuration_desc_t;
+
+
+typedef struct usb_interface_desc {
+	u8 bLength;                /* size of descriptor */
+	u8 bDescriptorType;        /* descriptor type */
+	u8 bInterfaceNumber;       /* number of this interface */
+	u8 bAlternateSetting;      /* value for the alternate setting */
+	u8 bNumEndpoints;          /* number of endpoints */
+	u8 bInterfaceClass;        /* interface class code */
+	u8 bInterfaceSubClass;     /* interface subclass code */
+	u8 bInterfaceProtocol;     /* interface protocol code */
+	u8 iInterface;             /* interface string index */
+} __attribute__((packed)) usb_interface_desc_t;
+
+
+typedef struct usb_interface_association_desc {
+	u8 bLength;
+	u8 bDescriptorType;
+	u8 bFirstInterface;
+	u8 bInterfaceCount;
+	u8 bFunctionClass;
+	u8 bFunctionSubClass;
+	u8 bFunctionProtocol;
+	u8 iFunction;
+} __attribute__((packed)) usb_interface_association_desc_t;
+
+
+typedef struct usb_string_desc {
+	u8 bLength;
+	u8 bDescriptorType;
+	u8 wData[256];
+} __attribute__((packed)) usb_string_desc_t;
+
+
+typedef struct usb_endpoint_desc {
+	u8  bLength;               /* size of descriptor */
+	u8  bDescriptorType;       /* descriptor type */
+	u8  bEndpointAddress;      /* endpoint address */
+	u8  bmAttributes;          /* attributes bitmap */
+	u16 wMaxPacketSize;        /* maximum packet size */
+	u8  bInterval;             /* polling interval for data transfers */
+} __attribute__((packed)) usb_endpoint_desc_t;
+
+
+/* generic descriptor
+ * used when there is no defined descriptor (e.g. HID descriptor or Report descriptor) */
+typedef struct usb_functional_desc {
+	u8 bFunctionLength;
+	u8 bDescriptorType;
+	u8 bDescriptorSubtype;
+} __attribute__((packed)) usb_functional_desc_t;
+
+
+#endif

--- a/devices/usbc/usbclient.h
+++ b/devices/usbc/usbclient.h
@@ -1,0 +1,46 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * usb device controller driver
+ *
+ * Copyright 2019-2021 Phoenix Systems
+ * Author: Kamil Amanowicz, Bartosz Ciesla, Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef _USBCLIENT_H_
+#define _USBCLIENT_H_
+
+#include "../types.h"
+#include "usb.h"
+
+
+/* Library configuration structure */
+typedef struct _usb_desc_list_t {
+	struct _usb_desc_list_t *next, *prev;
+	usb_functional_desc_t *descriptor;
+} usb_desc_list_t;
+
+
+/* Initialize library with given configuration */
+extern int usbclient_init(usb_desc_list_t *desList);
+
+
+/* Cleanup data */
+extern int usbclient_destroy(void);
+
+
+/* Send data on given endpoint - blocking */
+extern int usbclient_send(int endpt, const void *data, unsigned int len);
+
+
+/* Receive data from given endpoint - blocking */
+extern int usbclient_receive(int endpt, void *data, unsigned int len);
+
+
+#endif /* _USBCLIENT_H_ */

--- a/devices/usbc/usbphy.h
+++ b/devices/usbc/usbphy.h
@@ -1,0 +1,48 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * USB physical layer
+ *
+ * Copyright 2020-2021 Phoenix Systems
+ * Author: Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#ifndef _PHY_H_
+#define _PHY_H_
+
+#include "../types.h"
+
+
+/* Function returns buffer which is a multiple of USB_BUFFER_SIZE.
+ * Otherwise it returns null.                                               */
+extern void *usbclient_allocBuff(u32 size);
+
+
+/* Function cleans the whole memory assigned to endpoints and setup memory. */
+extern void  usbclient_buffReset(void);
+
+
+/* Function returns ID of USB controller interrupt.                         */
+extern u32 phy_getIrq(void);
+
+
+/* Function returns physical address of USB controller.                     */
+extern void *phy_getBase(void);
+
+
+/* Function initializes pins and clocks associated with USB controller.     */
+extern void phy_init(void);
+
+
+/* Function resets physical layer of USB controller.                        */
+extern void phy_reset(void);
+
+
+#endif

--- a/errors.h
+++ b/errors.h
@@ -19,6 +19,7 @@
 
 #define ERR_NONE             0
 #define ERR_ARG             -1
+#define ERR_MEM             -2
 
 #define ERR_LOW_BIOS        -16
 #define ERR_LOW_MMSIZE      -17

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,0 +1,12 @@
+#
+# Makefile for lib
+#
+# Copyright 2021 Phoenix Systems
+#
+# %LICENSE%
+#
+
+
+CFLAGS += -I../plo/lib
+
+OBJS += $(addprefix $(PREFIX_O)lib/, list.o)

--- a/lib/list.c
+++ b/lib/list.c
@@ -1,0 +1,53 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * Standard routines - doubly-linked list
+ *
+ * Copyright 2017, 2018, 2021 Phoenix Systems
+ * Author: Pawel Pisarczyk, Jan Sikorski, Aleksander Kaminski, Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#include "list.h"
+
+
+void lib_listAdd(void **list, void *t, size_t noff, size_t poff)
+{
+	if (t == NULL)
+		return;
+	if (*list == NULL) {
+		*((addr_t *)(t + noff)) = (addr_t)t;
+		*((addr_t *)(t + poff)) = (addr_t)t;
+		*list = t;
+	}
+	else {
+		*((addr_t *)(t + poff)) = *((addr_t *)(*list + poff));
+		*((addr_t *)((void *)*((addr_t *)(*list + poff)) + noff)) = (addr_t)t;
+		*((addr_t *)(t + noff)) = *((addr_t *)list);
+		*((addr_t *)(*list + poff)) = (addr_t)t;
+	}
+}
+
+
+void lib_listRemove(void **list, void *t, size_t noff, size_t poff)
+{
+	if (t == NULL)
+		return;
+	if (*((addr_t *)(t + noff)) == (addr_t)t && *((addr_t *)(t + poff)) == (addr_t)t) {
+		*list = NULL;
+	}
+	else {
+		*((addr_t *)((void *)(*((addr_t *)(t + poff))) + noff)) = *((addr_t *)(t + noff));
+		*((addr_t *)((void *)(*((addr_t *)(t + noff))) + poff)) = *((addr_t *)(t + poff));
+		if (t == *list)
+			*list = (void *)*((addr_t *)(t + noff));
+	}
+	*((addr_t *)(t + noff)) = NULL;
+	*((addr_t *)(t + poff)) = NULL;
+}

--- a/lib/list.h
+++ b/lib/list.h
@@ -1,0 +1,42 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * Standard routines - doubly-linked list
+ *
+ * Copyright 2017, 2018, 2021 Phoenix Systems
+ * Author: Pawel Pisarczyk, Jan Sikorski, Aleksander Kaminski, Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef _LIB_LIST_H_
+#define _LIB_LIST_H_
+
+#include "config.h"
+
+
+extern void lib_listAdd(void **list, void *t, size_t noff, size_t poff);
+
+
+extern void lib_listRemove(void **list, void *t, size_t noff, size_t poff);
+
+
+#define LIST_ADD_EX(list, t, next, prev) \
+	lib_listAdd((void **)(list), (void *)(t), (size_t)&(((typeof(t))0)->next), (size_t)&(((typeof(t))0)->prev))
+
+
+#define LIST_ADD(list, t) LIST_ADD_EX(list, t, next, prev)
+
+
+#define LIST_REMOVE_EX(list, t, next, prev) \
+	lib_listRemove((void **)(list), (void *)(t), (size_t)&(((typeof(t))0)->next), (size_t)&(((typeof(t))0)->prev))
+
+
+#define LIST_REMOVE(list, t) LIST_REMOVE_EX(list, t, next, prev)
+
+
+#endif

--- a/msg.c
+++ b/msg.c
@@ -26,136 +26,130 @@
 
 static u32 msg_csum(msg_t *msg)
 {
-    u32 k;
-    u16 csum;
+	u32 k;
+	u16 csum;
 
-    csum = 0;
-    for (k = 0; k < MSG_HDRSZ + msg_getlen(msg); k++) {
-        if (k >= sizeof(msg->csum))
-            csum += *((u8 *)msg + k);
-    }
-    csum += msg_getseq(msg);
-    return csum;
+	csum = 0;
+	for (k = 0; k < MSG_HDRSZ + msg_getlen(msg); k++) {
+		if (k >= sizeof(msg->csum))
+			csum += *((u8 *)msg + k);
+	}
+	csum += msg_getseq(msg);
+	return csum;
 }
 
 
-int msg_safewrite(u16 pn, u8 *buff, u16 len)
+static int msg_write(u16 pn, msg_t *msg)
 {
-    int l;
+	u8 *p = (u8 *)msg;
+	char cs[2];
+	u16 k;
+	int res;
 
-    for (l = 0; len;) {
-        if ((l = serial_write(pn, buff, len)) < 0)
-            return ERR_MSG_IO;
-        buff += l;
-        len -= l;
-    }
-    return 0;
+	/* Frame start */
+	cs[0] = MSG_MARK;
+	if ((res = msg->write(pn, (u8 *)cs, 1)) < 0)
+		return res;
+
+	for (k = 0; k < MSG_HDRSZ + msg_getlen(msg); k++) {
+		if ((p[k] == MSG_MARK) || (p[k] == MSG_ESC)) {
+			cs[0] = MSG_ESC;
+			if (p[k] == MSG_MARK)
+				cs[1] = MSG_ESCMARK;
+			else
+				cs[1] = MSG_ESCESC;
+			if ((res = msg->write(pn, (u8 *)cs, 2)) < 0)
+				return res;
+		}
+		else {
+			if ((res = msg->write(pn, (u8 *)&p[k], 1)) < 0)
+				return res;
+		}
+	}
+	return k;
 }
 
 
-int msg_write(u16 pn, msg_t *msg)
+static int msg_read(u16 pn, msg_t *msg, u16 timeout, int *state)
 {
-    u8 *p = (u8 *)msg;
-    char cs[2];
-    u16 k;
-    int res;
+	u8 c;
+	u8 buff[MSG_HDRSZ + MSG_MAXLEN];
+	int i, escfl = 0, res = 0;
+	unsigned int l = 0;
 
-    /* Frame start */
-    cs[0] = MSG_MARK;
-    if ((res = msg_safewrite(pn, (u8 *)cs, 1)) < 0)
-        return res;
+	for (;;) {
+		if ((res = msg->read(pn, buff, sizeof(buff), timeout)) < 0)
+			break;
 
-    for (k = 0; k < MSG_HDRSZ + msg_getlen(msg); k++) {
-        if ((p[k] == MSG_MARK) || (p[k] == MSG_ESC)) {
-            cs[0] = MSG_ESC;
-            if (p[k] == MSG_MARK)
-                cs[1] = MSG_ESCMARK;
-            else
-                cs[1] = MSG_ESCESC;
-            if ((res = msg_safewrite(pn, (u8 *)cs, 2)) < 0)
-                return res;
-        }
-        else {
-            if ((res = msg_safewrite(pn, (u8 *)&p[k], 1)) < 0)
-                return res;
-        }
-    }
-    return k;
-}
+		for (i = 0; i < res; ++i) {
+			c = buff[i];
 
+			if (*state == MSGREAD_FRAME) {
+				/* Return error if frame is to long */
+				if (l == MSG_HDRSZ + MSG_MAXLEN) {
+					*state = MSGREAD_DESYN;
+					return ERR_MSG_IO;
+				}
 
-int msg_read(u16 pn, msg_t *msg, u16 timeout, int *state)
-{
-    int escfl = 0;
-    unsigned int l = 0;
-    u8 c;
+				/* Return error if terminator discovered */
+				if (c == MSG_MARK)
+					return ERR_MSG_IO;
 
-    for (;;) {
-        if (serial_read(pn, &c, 1, timeout) < 0) {
-            *state = MSGREAD_DESYN;
-            return ERR_MSG_IO;
-        }
+				if (!escfl && (c == MSG_ESC)) {
+					escfl = 1;
+					continue;
+				}
+				if (escfl) {
+					if (c == MSG_ESCMARK)
+						c = MSG_MARK;
+					if (c == MSG_ESCESC)
+						c = MSG_ESC;
+					escfl = 0;
+				}
+				*((u8 *)msg + l++) = c;
 
-        if (*state == MSGREAD_FRAME) {
+				/* Frame received */
+				if ((l >= MSG_HDRSZ) && (l == msg_getlen(msg) + MSG_HDRSZ)) {
+					*state = MSGREAD_DESYN;
 
-            /* Return error if frame is to long */
-            if (l == MSG_HDRSZ + MSG_MAXLEN) {
-                *state = MSGREAD_DESYN;
-                return ERR_MSG_IO;
-            }
+					/* Verify received message */
+					if (msg_getcsum(msg) != msg_csum(msg))
+						return ERR_MSG_IO;
 
-            /* Return error if terminator discovered */
-            if (c == MSG_MARK)
-                return ERR_MSG_IO;
+					return l;
+				}
+			}
+			else {
+				/* Synchronize */
+				if (c == MSG_MARK)
+					*state = MSGREAD_FRAME;
+			}
+		}
+	}
 
-            if (!escfl && (c == MSG_ESC)) {
-                escfl = 1;
-                continue;
-            }
-            if (escfl) {
-                if (c == MSG_ESCMARK)
-                    c = MSG_MARK;
-                if (c == MSG_ESCESC)
-                    c = MSG_ESC;
-                escfl = 0;
-            }
-            *((u8 *)msg + l++) = c;
+	*state = MSGREAD_DESYN;
 
-            /* Frame received */
-            if ((l >= MSG_HDRSZ) && (l == msg_getlen(msg) + MSG_HDRSZ)) {
-                *state = MSGREAD_DESYN;
-                break;
-            }
-        }
-        else {
-            /* Synchronize */
-            if (c == MSG_MARK)
-                *state = MSGREAD_FRAME;
-        }
-    }
-
-    /* Verify received message */
-    if (msg_getcsum(msg) != msg_csum(msg))
-        return ERR_MSG_IO;
-
-    return l;
+	return ERR_MSG_IO;
 }
 
 
 int msg_send(u16 pn, msg_t *smsg, msg_t *rmsg)
 {
-    unsigned int retr;
-    int state = MSGREAD_DESYN;
+	unsigned int retr;
+	int state = MSGREAD_DESYN;
 
-    msg_setcsum(smsg, msg_csum(smsg));
-    for (retr = 0; retr < MSGRECV_MAXRETR; retr++) {
-        if (msg_write(pn, smsg) < 0)
-            continue;
+	if (smsg->write == NULL || rmsg->read == NULL)
+		return ERR_ARG;
 
-        if ((msg_read(pn, rmsg, MSGRECV_TIMEOUT, &state)) > 0) {
-            return 0;
-        }
-    }
+	msg_setcsum(smsg, msg_csum(smsg));
+	for (retr = 0; retr < MSGRECV_MAXRETR; retr++) {
+		if (msg_write(pn, smsg) < 0)
+			continue;
 
-    return ERR_MSG_IO;
+		if ((msg_read(pn, rmsg, MSGRECV_TIMEOUT, &state)) > 0) {
+			return ERR_NONE;
+		}
+	}
+
+	return ERR_MSG_IO;
 }

--- a/msg.h
+++ b/msg.h
@@ -16,6 +16,7 @@
 #ifndef _MSG_H_
 #define _MSG_H_
 
+#include "types.h"
 
 /* Special characters */
 #define MSG_MARK      0x7e
@@ -37,6 +38,10 @@ typedef struct _msg_t {
 	u32 csum;
 	u32 type;
 	u8  data[MSG_MAXLEN];
+	union {
+		int (*read)(unsigned int, u8 *, u16, u16);
+		int (*write)(unsigned int, const u8 *, u16);
+	};
 } msg_t;
 
 

--- a/phoenixd.c
+++ b/phoenixd.c
@@ -22,11 +22,24 @@
 #include "phoenixd.h"
 
 
-handle_t phoenixd_open(u16 dn, const char *name, u32 flags)
+typedef struct _msg_phoenixd_t {
+	u32 handle;
+	u32 pos;
+	u32 len;
+	u8  data[MSG_MAXLEN - 3 * sizeof(u32)];
+} msg_phoenixd_t;
+
+
+handle_t phoenixd_open(u16 dn, const char *name, u32 flags, phfs_clbk_t *cblk)
 {
 	u16 l;
 	msg_t smsg, rmsg;
 	handle_t handle;
+
+	if (cblk == NULL) {
+		handle.h = ERR_PHFS_IO;
+		return handle;
+	}
 
 	handle.offs = 0;
 	l = plostd_strlen(name) + 1;
@@ -37,6 +50,9 @@ handle_t phoenixd_open(u16 dn, const char *name, u32 flags)
 
 	msg_settype(&smsg, MSG_OPEN);
 	msg_setlen(&smsg, l);
+
+	smsg.write = cblk->write;
+	rmsg.read = cblk->read;
 
 	if (msg_send(dn, &smsg, &rmsg) < 0)
 		handle.h = ERR_PHFS_IO;
@@ -51,7 +67,7 @@ handle_t phoenixd_open(u16 dn, const char *name, u32 flags)
 }
 
 
-s32 phoenixd_read(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len)
+s32 phoenixd_read(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len, phfs_clbk_t *cblk)
 {
 	msg_t smsg, rmsg;
 	msg_phoenixd_t *io;
@@ -62,7 +78,7 @@ s32 phoenixd_read(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len)
 	io = (msg_phoenixd_t *)smsg.data;
 	hdrsz = (u16)((u32)io->data - (u32)io);
 
-	if ((handle.h <= 0) || (len > MSG_MAXLEN - hdrsz))
+	if ((handle.h <= 0) || (len > MSG_MAXLEN - hdrsz) || cblk == NULL)
 		return ERR_ARG;
 
 	io->handle = handle.h;
@@ -72,6 +88,8 @@ s32 phoenixd_read(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len)
 	msg_settype(&smsg, MSG_READ);
 	msg_setlen(&smsg, hdrsz);
 
+	smsg.write = cblk->write;
+	rmsg.read = cblk->read;
 
 	if (msg_send(dn, &smsg, &rmsg) < 0)
 		return ERR_PHFS_IO;
@@ -93,13 +111,15 @@ s32 phoenixd_read(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len)
 }
 
 
-s32 phoenixd_write(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len, u8 sync)
+s32 phoenixd_write(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len, u8 sync, phfs_clbk_t *cblk)
 {
+	/* TODO */
 	return ERR_NONE;
 }
 
 
-s32 phoenixd_close(u16 dn, handle_t handle)
+s32 phoenixd_close(u16 dn, handle_t handle, phfs_clbk_t *cblk)
 {
+	/* TODO */
 	return ERR_NONE;
 }

--- a/phoenixd.h
+++ b/phoenixd.h
@@ -17,6 +17,8 @@
 #define _PHOENIXD_H_
 
 #include "msg.h"
+#include "phfs.h"
+
 
 /* Message types */
 #define MSG_OPEN    1
@@ -25,24 +27,22 @@
 #define MSG_COPY    4
 
 
-typedef struct _msg_phoenixd_t {
-  u32 handle;
-  u32 pos;
-  u32 len;
-  u8  data[MSG_MAXLEN - 3 * sizeof(u32)];
-} msg_phoenixd_t;
+typedef struct {
+	int (*read)(unsigned int, u8 *, u16, u16);
+	int (*write)(unsigned int, const u8 *, u16);
+} phfs_clbk_t;
 
 
-extern handle_t phoenixd_open(u16 dn, const char *name, u32 flags);
+extern handle_t phoenixd_open(u16 dn, const char *name, u32 flags, phfs_clbk_t *cblk);
 
 
-extern s32 phoenixd_read(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len);
+extern s32 phoenixd_read(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len, phfs_clbk_t *cblk);
 
 
-extern s32 phoenixd_write(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len, u8 sync);
+extern s32 phoenixd_write(u16 dn, handle_t handle, addr_t *pos, u8 *buff, u32 len, u8 sync, phfs_clbk_t *cblk);
 
 
-extern s32 phoenixd_close(u16 dn, handle_t handle);
+extern s32 phoenixd_close(u16 dn, handle_t handle, phfs_clbk_t *cblk);
 
 
 #endif

--- a/plo.c
+++ b/plo.c
@@ -5,7 +5,7 @@
  *
  * Loader console
  *
- * Copyright 2012, 2017, 2020 Phoenix Systems
+ * Copyright 2012, 2017, 2020-2021 Phoenix Systems
  * Copyright 2001, 2005 Pawel Pisarczyk
  * Authors: Pawel Pisarczyk, Lukasz Kosinski, Hubert Buczynski
  *
@@ -133,32 +133,20 @@ void plo_cmdloop(void)
 void plo_init(void)
 {
 	u16 t = 0;
-	u32 st;
 
 	low_init();
-	timer_init();
-	serial_init(-1, &st);   /* TODO: provide generic calculation of baud rate */
 	phfs_init();
 	cmd_init();
 
-#ifdef CONSOLE_SERIAL
-	serial_write(0, "\033[?25h", 6);
-#endif
-
 	plostd_printf(ATTR_LOADER, "%s \n", PLO_WELCOME);
-	plostd_printf(ATTR_INIT, "Detected UART, setting to maximal speed %d Bps\n", st);
+	plostd_printf(ATTR_INIT, "Detected UART, setting to maximal speed %d Bps\n", serial_getBaudrate());
 
 	/* Wait and execute saved loader command */
 	for (t = low_getLaunchTimeout(); t; t--) {
 		plostd_printf(ATTR_INIT, "\r%d seconds to automatic boot      ", t);
 
-#ifdef CONSOLE_SERIAL
-		if (serial_read(0, &c, 1, 1000) > 0)
-			break;
-#else
 		if (timer_wait(1000, TIMER_KEYB, NULL, 0))
 			break;
-#endif
 	}
 
 	if (t == 0) {
@@ -169,9 +157,6 @@ void plo_init(void)
 
 	/* Enter to interactive mode */
 	plo_cmdloop();
-
-	serial_done();
-	timer_done();
 
 	low_done();
 

--- a/serial.h
+++ b/serial.h
@@ -17,8 +17,11 @@
 #ifndef _SERIAL_H_
 #define _SERIAL_H_
 
+#include "types.h"
 
-extern void serial_init(u32 baud, u32 *st);
+extern void serial_init(void);
+
+extern u32 serial_getBaudrate(void);
 
 extern int serial_read(unsigned int pn, u8 *buff, u16 len, u16 timeout);
 


### PR DESCRIPTION
The following PR contains:
- USB client driver,
- CDC driver,
- changes in phoenixd & msg allow to use different phfs,
- phfs-serial - interface to exchange data via serial with host app **phoenixd**,
- phfs-usb - interface to exchange data via usb with host app **phoenixd**,
- clean up device initialization,
- add lib module with doubly-linked list,

The code works as expected on **zynq7000** and **imxrt106x** ( https://github.com/phoenix-rtos/plo/pull/38 has to be added).
To merge this PR, the code should be tested on **imxrt117x**. @MaciejPurski, can you verify it on hardware?