### PR TITLE
cmd: fix checking elf's header identification

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -590,7 +590,7 @@ void cmd_kernel(char *s)
 		return;
 	}
 
-	if ((hdr.e_ident[0] != 0x7f) && (hdr.e_ident[1] != 'E') && (hdr.e_ident[2] != 'L') && (hdr.e_ident[3] != 'F')) {
+	if ((hdr.e_ident[0] != 0x7f) || (hdr.e_ident[1] != 'E') || (hdr.e_ident[2] != 'L') || (hdr.e_ident[3] != 'F')) {
 		plostd_printf(ATTR_ERROR, "File isn't ELF object!\n");
 		return;
 	}
@@ -683,7 +683,7 @@ static int cmd_loadApp(phfs_conf_t *phfs, const char *name, const char *imap, co
 		return ERR_PHFS_FILE;
 	}
 
-	if ((hdr.e_ident[0] != 0x7f) && (hdr.e_ident[1] != 'E') && (hdr.e_ident[2] != 'L') && (hdr.e_ident[3] != 'F')) {
+	if ((hdr.e_ident[0] != 0x7f) || (hdr.e_ident[1] != 'E') || (hdr.e_ident[2] != 'L') || (hdr.e_ident[3] != 'F')) {
 		plostd_printf(ATTR_ERROR, "\nFile isn't ELF object!\n");
 		return ERR_PHFS_FILE;
 	}

--- a/ia32/cmd.c
+++ b/ia32/cmd.c
@@ -324,7 +324,7 @@ void cmd_loadkernel(unsigned int pdn, char *arg, u16 *po)
 		plostd_printf(ATTR_ERROR, "Can't read ELF header!\n");
 		return;
 	}
-	if ((hdr.e_ident[0] != 0x7f) && (hdr.e_ident[1] != 'E') && (hdr.e_ident[2] != 'L') && (hdr.e_ident[3] != 'F')) {
+	if ((hdr.e_ident[0] != 0x7f) || (hdr.e_ident[1] != 'E') || (hdr.e_ident[2] != 'L') || (hdr.e_ident[3] != 'F')) {
 		plostd_printf(ATTR_ERROR, "File isn't ELF object!\n");
 		return;
 	}
@@ -561,7 +561,7 @@ void cmd_copy(char *s)
 
 	if ((ddn = cmd_getdevice(s, &p, DEFAULT_BLANKS, NULL, word, sizeof(word))) == -1) {
 		plostd_printf(ATTR_ERROR, "\n'%s' - unknown dst device!\n", word);
-		
+
 		if (phfs_close(devices[sdn].pdn, sh) < 0)
 			plostd_printf(ATTR_ERROR, "Failed to sync %s!\n", devices[sdn].name);
 


### PR DESCRIPTION
Majority of cmd.c based on ia32/cmd.c

So that this issue has to be fixed in ia32 as well.