### PR TITLE
generic syspage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ include hal/$(TARGET_SUFF)/$(TARGET_SUBFAMILY)/Makefile
 CFLAGS += $(BOARD_CONFIG)
 CFLAGS += -I../plo/hal/$(TARGET_SUFF)/$(TARGET_SUBFAMILY)
 
-OBJS += $(PREFIX_O)plo.o $(PREFIX_O)plostd.o $(PREFIX_O)phoenixd.o $(PREFIX_O)msg.o $(PREFIX_O)phfs.o $(PREFIX_O)cmd.o
+OBJS += $(addprefix $(PREFIX_O), plo.o plostd.o phoenixd.o msg.o phfs.o cmd.o syspage.o)
 
 
 all: $(PREFIX_PROG_STRIPPED)plo-$(TARGET_FAMILY)-$(TARGET_SUBFAMILY).elf  $(PREFIX_PROG_STRIPPED)plo-$(TARGET_FAMILY)-$(TARGET_SUBFAMILY).img\

--- a/hal/armv7a/zynq7000/Makefile
+++ b/hal/armv7a/zynq7000/Makefile
@@ -19,4 +19,5 @@ CFLAGS += -DVADDR_KERNEL_INIT=$(VADDR_KERNEL_INIT)
 
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
-OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/$(TARGET_SUBFAMILY)/, _startup.o hal.o zynq.o serial.o timer.o syspage.o cmd.o interrupts.o usbphy.o gpio.o)
+OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/$(TARGET_SUBFAMILY)/, _startup.o hal.o zynq.o serial.o timer.o\
+		cmd.o interrupts.o usbphy.o gpio.o)

--- a/hal/armv7a/zynq7000/config.h
+++ b/hal/armv7a/zynq7000/config.h
@@ -57,5 +57,9 @@ typedef u32 addr_t;
 
 typedef unsigned int size_t;
 
+typedef struct {
+	/* Empty architecture data */
+} syspage_arch_t;
+
 
 #endif

--- a/hal/armv7a/zynq7000/config.h
+++ b/hal/armv7a/zynq7000/config.h
@@ -58,8 +58,8 @@ typedef u32 addr_t;
 typedef unsigned int size_t;
 
 typedef struct {
-	/* Empty architecture data */
-} syspage_arch_t;
+	/* Empty hal data */
+} syspage_hal_t;
 
 
 #endif

--- a/hal/armv7m/imxrt106x/Makefile
+++ b/hal/armv7m/imxrt106x/Makefile
@@ -20,4 +20,5 @@ CFLAGS+= -mfloat-abi=soft
 
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
-OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/$(TARGET_SUBFAMILY)/, _startup.o hal.o imxrt.o serial.o cmd.o timer.o flashdrv.o rom_api.o flashcfg.o phfs-flash.o syspage.o usbphy.o)
+OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/$(TARGET_SUBFAMILY)/, _startup.o hal.o imxrt.o serial.o cmd.o\
+		timer.o flashdrv.o rom_api.o flashcfg.o phfs-flash.o usbphy.o)

--- a/hal/armv7m/imxrt106x/config.h
+++ b/hal/armv7m/imxrt106x/config.h
@@ -64,8 +64,8 @@ typedef u32 addr_t;
 typedef unsigned int size_t;
 
 typedef struct {
-	/* Empty architecture data */
-} syspage_arch_t;
+	/* Empty hal data */
+} syspage_hal_t;
 
 
 #endif

--- a/hal/armv7m/imxrt106x/config.h
+++ b/hal/armv7m/imxrt106x/config.h
@@ -63,5 +63,9 @@ extern void plo_bss(void);
 typedef u32 addr_t;
 typedef unsigned int size_t;
 
+typedef struct {
+	/* Empty architecture data */
+} syspage_arch_t;
+
 
 #endif

--- a/hal/armv7m/imxrt117x/Makefile
+++ b/hal/armv7m/imxrt117x/Makefile
@@ -20,4 +20,5 @@ CFLAGS+= -mfloat-abi=soft
 
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
-OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/$(TARGET_SUBFAMILY)/, _startup.o hal.o imxrt.o serial.o cmd.o timer.o flashdrv.o rom_api.o flashcfg.o phfs-flash.o syspage.o)
+OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/$(TARGET_SUBFAMILY)/, _startup.o hal.o imxrt.o serial.o cmd.o timer.o\
+		flashdrv.o rom_api.o flashcfg.o phfs-flash.o)

--- a/hal/armv7m/imxrt117x/config.h
+++ b/hal/armv7m/imxrt117x/config.h
@@ -61,8 +61,8 @@ typedef u32 addr_t;
 typedef unsigned int size_t;
 
 typedef struct {
-	/* Empty architecture data */
-} syspage_arch_t;
+	/* Empty hal data */
+} syspage_hal_t;
 
 
 

--- a/hal/armv7m/imxrt117x/config.h
+++ b/hal/armv7m/imxrt117x/config.h
@@ -60,6 +60,10 @@ extern void plo_bss(void);
 typedef u32 addr_t;
 typedef unsigned int size_t;
 
+typedef struct {
+	/* Empty architecture data */
+} syspage_arch_t;
+
 
 
 #endif

--- a/plostd.c
+++ b/plostd.c
@@ -297,6 +297,7 @@ void plostd_printf(char attr, const char *fmt, ...)
 			break;
 		case 'p':
 			i = va_arg(ap, int);
+			plostd_puts("0x");
 			plostd_puts(plostd_itoah((u8 *)&i, 4, buff, 1));
 			break;
 		case 'P':

--- a/syspage.c
+++ b/syspage.c
@@ -13,10 +13,9 @@
  * %LICENSE%
  */
 
-
-#include "../hal.h"
-#include "../plostd.h"
-#include "../syspage.h"
+#include "hal.h"
+#include "plostd.h"
+#include "syspage.h"
 
 #define MAX_PROGRAMS_NB         32
 #define MAX_MAPS_NB             16

--- a/syspage.c
+++ b/syspage.c
@@ -75,7 +75,7 @@ typedef struct {
 	size_t mapssz;
 	syspage_map_t *maps;
 
-	syspage_arch_t arch;
+	syspage_hal_t hal;
 } syspage_t;
 
 #pragma pack(pop)
@@ -114,7 +114,7 @@ struct {
 	/* General entries: syspage, kernel's elf sections and plo's elf sections */
 	map_entry_t entries[MAX_ENTRIES_NB];
 
-	syspage_arch_t arch;
+	syspage_hal_t hal;
 } syspage_common;
 
 
@@ -286,9 +286,9 @@ int syspage_save(void)
 	syspage_common.syspage->mapssz = syspage_common.mapsCnt;
 
 	/* Save architecture dependent structure */
-	if (sizeof(syspage_arch_t) != 0) {
-		hal_memcpy((void *)&syspage_common.syspage->arch, (void *)&syspage_common.arch, sizeof(syspage_arch_t));
-		syspage_common.syspage->syspagesz += sizeof(syspage_arch_t);
+	if (sizeof(syspage_hal_t) != 0) {
+		hal_memcpy((void *)&syspage_common.syspage->hal, (void *)&syspage_common.hal, sizeof(syspage_hal_t));
+		syspage_common.syspage->syspagesz += sizeof(syspage_hal_t);
 	}
 
 	return ERR_NONE;
@@ -577,11 +577,11 @@ void syspage_setKernelData(void *addr, size_t size)
 }
 
 
-/* Add specific architecture data */
+/* Add specific hal data */
 
-void syspage_setArchData(const syspage_arch_t *arch)
+void syspage_setHalData(const syspage_hal_t *hal)
 {
-	if (sizeof(syspage_arch_t) != 0)
-		hal_memcpy((void *)&syspage_common.arch, (void *)arch, sizeof(syspage_arch_t));
+	if (sizeof(syspage_hal_t) != 0)
+		hal_memcpy((void *)&syspage_common.hal, (void *)hal, sizeof(syspage_hal_t));
 }
 

--- a/syspage.h
+++ b/syspage.h
@@ -16,7 +16,7 @@
 #ifndef SYSPAGE_H_
 #define SYSPAGE_H_
 
-#include "../types.h"
+#include "types.h"
 
 
 /* TODO: Make it compatible with Phoenix-RTOS kernel;

--- a/syspage.h
+++ b/syspage.h
@@ -89,9 +89,9 @@ extern void syspage_setKernelBss(void *addr, size_t size);
 extern void syspage_setKernelData(void *addr, size_t size);
 
 
-/* Add specific architecture data */
+/* Add specific hal data */
 
-extern void syspage_setArchData(const syspage_arch_t *arch);
+extern void syspage_setHalData(const syspage_hal_t *hal);
 
 
 #endif

--- a/syspage.h
+++ b/syspage.h
@@ -16,6 +16,7 @@
 #ifndef SYSPAGE_H_
 #define SYSPAGE_H_
 
+#include "config.h"
 #include "types.h"
 
 
@@ -44,7 +45,7 @@ extern void *syspage_getAddress(void);
 
 /* General functions */
 
-extern void syspage_save(void);
+extern int syspage_save(void);
 
 
 extern void syspage_show(void);
@@ -86,6 +87,11 @@ extern void syspage_setKernelBss(void *addr, u32 size);
 
 
 extern void syspage_setKernelData(void *addr, u32 size);
+
+
+/* Add specific architecture data */
+
+extern void syspage_setArchData(const syspage_arch_t *arch);
 
 
 #endif

--- a/syspage.h
+++ b/syspage.h
@@ -36,7 +36,7 @@ extern void syspage_init(void);
 
 /* Syspage's location functions */
 
-extern int syspage_setAddress(void *addr);
+extern void syspage_setAddress(void *addr);
 
 
 extern void *syspage_getAddress(void);
@@ -63,13 +63,13 @@ extern int syspage_getMapTop(const char *map, void **addr);
 extern int syspage_alignMapTop(const char *map);
 
 
-extern int syspage_getFreeSize(const char *map, u32 *sz);
+extern int syspage_getFreeSize(const char *map, size_t *sz);
 
 
-extern int syspage_write2Map(const char *map, const u8 *buff, u32 len);
+extern int syspage_write2Map(const char *map, const u8 *buff, size_t len);
 
 
-extern void syspage_addEntries(u32 start, u32 sz);
+extern void syspage_addEntries(addr_t start, size_t sz);
 
 
 
@@ -80,13 +80,13 @@ extern int syspage_addProg(void *start, void *end, const char *imap, const char 
 
 /* Setting kernel's data */
 
-extern void syspage_setKernelText(void *addr, u32 size);
+extern void syspage_setKernelText(void *addr, size_t size);
 
 
-extern void syspage_setKernelBss(void *addr, u32 size);
+extern void syspage_setKernelBss(void *addr, size_t size);
 
 
-extern void syspage_setKernelData(void *addr, u32 size);
+extern void syspage_setKernelData(void *addr, size_t size);
 
 
 /* Add specific architecture data */


### PR DESCRIPTION
The following PR contains:
1. Making one instance of generic syspage in phoenix-rtos-loader.
2. Adding architecture dependent field (**syspage_arch_t**).
3. Changing types of fields: size description **u32 -> size_t** and address description **void * -> addr_t**
4. Removing long references to nested structure elements which cause less code readability. 

@pawelpisarczyk, I would like to ask you to check whether current syspage structure is consistent with our assumptions, I think that the most important for You are mentioned points 2 and 3.

If changes in **syspage_t** structure are approved, I will change the **syspage_t** structure in phoenix-rtos-kernel to make it consistent with a loader.