### PR TITLE
script: script parsing improved

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -737,7 +737,7 @@ void cmd_app(char *s)
 
 	pos = plostd_strlen(name);
 	if (name[0] == '@') {
-		if (script_expandAlias(&name) < 0) {
+		if (script_expandAlias(name) < 0) {
 			plostd_printf(ATTR_ERROR, "\nWrong arguments!!\n");
 			return;
 		}

--- a/script.c
+++ b/script.c
@@ -26,27 +26,41 @@ extern char script[];
 
 struct {
 	u32 cmdCnt;
-	char basicCmds[MAX_SCRIPT_LINES_NB][LINESZ];
+	char *basicCmds[MAX_SCRIPT_LINES_NB];
 } script_common;
 
 
 void script_init(void)
 {
-	int i;
-	unsigned int pos = 0;
-	char *argsScript = (char *)script;
+	unsigned int i, len;
+	char *s = script;
 
 	script_common.cmdCnt = 0;
 
-	for (i = 0;; ++i) {
+	for (i = 0; *s; ++i) {
 		if (i >= MAX_SCRIPT_LINES_NB) {
 			plostd_printf(ATTR_ERROR, "\nWarning: too many script lines, only %d loaded.\n", MAX_SCRIPT_LINES_NB);
 			break;
 		}
 
-		cmd_skipblanks(argsScript, &pos, "\n");
-		if (cmd_getnext(argsScript, &pos, "\n", NULL, script_common.basicCmds[i], sizeof(script_common.basicCmds[i])) == NULL || (script_common.basicCmds[i][0] == '\0'))
+		while (*s == '\n')
+			s++;
+		if (*s == '\0')
 			break;
+
+		len = 0;
+		script_common.basicCmds[i] = s;
+		while (*s && (*s != '\n')) {
+			len++;
+			s++;
+		}
+		*s++ = '\0';
+
+		if (len >= LINESZ) {
+			plostd_printf(ATTR_ERROR, "\nWarning: script line to long:\n%s\n", script_common.basicCmds[i]);
+			break;
+		}
+
 		script_common.cmdCnt++;
 	}
 }
@@ -65,24 +79,28 @@ void script_run(void)
 }
 
 
-int script_expandAlias(char **name)
+int script_expandAlias(char *name)
 {
-	int i;
-	unsigned int len;
+	unsigned int i, len, pos;
+
+	/* Computing the length of the name and positions of the arguments */
+	len = plostd_strlen(name);
+	if (len == 1)
+		return -1;
+
+	pos = 1;
+	while (pos < len) {
+		if (name[pos] == ';')
+			break;
+		++pos;
+	}
+	--pos;
 
 	for (i = 0; i < script_common.cmdCnt; ++i) {
 		if (script_common.basicCmds[i][0] == '@') {
-			len = 1;
-			/* Omit program arguments */
-			while (len < plostd_strlen(*name)) {
-				if ((*name)[len] == ';')
-					break;
-				++len;
-			}
-			--len;
-			if (plostd_strncmp(*name + 1, script_common.basicCmds[i] + 1, len) == 0) {
+			if (plostd_strncmp(name + 1, script_common.basicCmds[i] + 1, pos) == 0) {
 				/* Copy size and offset to app name */
-				hal_memcpy(*name + plostd_strlen(*name), script_common.basicCmds[i] + len + 1, plostd_strlen(script_common.basicCmds[i]) - len);
+				hal_memcpy(name + len, script_common.basicCmds[i] + pos + 1, plostd_strlen(script_common.basicCmds[i]) - pos);
 				return 0;
 			}
 		}
@@ -90,4 +108,3 @@ int script_expandAlias(char **name)
 
 	return -1;
 }
-

--- a/script.h
+++ b/script.h
@@ -27,7 +27,7 @@ extern void script_init(void);
 extern void script_run(void);
 
 
-extern int script_expandAlias(char **name);
+extern int script_expandAlias(char *name);
 
 
 #endif


### PR DESCRIPTION
Instead of creating an array of copies of individual script lines, I create an array of pointers to those lines.

Other changes:
- I moved the calculation of name length and parameter position outside the for loop.
- I changed the argument of the `script_expandAlias()` function from `char **name` to `char *name` (in the `script_expandAlias()` function, the pointer address to the name does not change).

The size of the `script_common` variable:
```
sizeof(script_common)
now           new
4+64*80=5124  4+64*4=260
```

What do you think about such a solution:
`script` variable as:
```
static char *script[] = {
    #include <script.plo.h>
    NULL
};
```
and the file `script.plo.h` is created in the `Makefile`.
I can show such a solution as PR.
 