### PR TITLE
plo: constructors, destructors and device module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ include hal/$(TARGET_SUFF)/$(TARGET_SUBFAMILY)/Makefile
 CFLAGS += $(BOARD_CONFIG)
 CFLAGS += -I../plo/hal/$(TARGET_SUFF)/$(TARGET_SUBFAMILY)
 
-OBJS += $(addprefix $(PREFIX_O), plo.o plostd.o phoenixd.o msg.o phfs.o cmd.o syspage.o)
+OBJS += $(addprefix $(PREFIX_O), _startc.o plo.o plostd.o phoenixd.o msg.o phfs.o cmd.o syspage.o)
 
 
 all: $(PREFIX_PROG_STRIPPED)plo-$(TARGET_FAMILY)-$(TARGET_SUBFAMILY).elf  $(PREFIX_PROG_STRIPPED)plo-$(TARGET_FAMILY)-$(TARGET_SUBFAMILY).img\

--- a/_startc.c
+++ b/_startc.c
@@ -1,0 +1,45 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Entrypoint
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include "hal.h"
+
+extern void _end(void);
+extern void _plo_bss(void);
+
+extern void (*__init_array_start [])(void);
+extern void (*__init_array_end [])(void);
+
+extern void (*__fini_array_start [])(void);
+extern void (*__fini_array_end [])(void);
+
+
+extern void plo_init(void);
+
+
+void _startc(int argc, char **argv, char **env)
+{
+	size_t i, size;
+
+	/* Clear the .bss section */
+	hal_memset(_plo_bss, 0, (addr_t)_end - (addr_t)_plo_bss);
+
+	size = __init_array_end - __init_array_start;
+	for (i = 0; i < size; i++)
+		(*__init_array_start[i])();
+
+	plo_init();
+
+	size = __fini_array_end - __fini_array_start;
+	for (i = 0; i < size; i++)
+		(*__fini_array_start[i])();
+}

--- a/devices/devs.c
+++ b/devices/devs.c
@@ -1,0 +1,149 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * Device Interface
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include "devs.h"
+#include "../errors.h"
+
+#define SIZE_DEV             4
+#define SIZE_DEV_INSTANCES   16
+
+
+struct {
+	dev_handler_t devs[SIZE_DEV][SIZE_DEV_INSTANCES];
+	int (*init[SIZE_DEV])(unsigned int dn, dev_handler_t *h);
+} devs_common;
+
+
+void devs_regDriver(unsigned int dev, int (*init)(unsigned int dn, dev_handler_t *h))
+{
+	if (dev >= SIZE_DEV)
+		return;
+
+	devs_common.init[dev] = init;
+}
+
+
+void devs_init(void)
+{
+	unsigned int i, j;
+	dev_handler_t *handler;
+
+	for (i = 0; i < SIZE_DEV; ++i) {
+		if (devs_common.init[i] != NULL) {
+			for (j = 0; j < SIZE_DEV_INSTANCES; ++j) {
+				/* TODO: check in dtb the availability of a device in the current platform */
+				handler = &devs_common.devs[i][j];
+				/* TODO: check initialization */
+				devs_common.init[i](j, handler);
+			}
+		}
+	}
+}
+
+
+int devs_getHandler(unsigned int dev, unsigned int dn, dev_handler_t **h)
+{
+	dev_handler_t *temph;
+
+	if (dev >= SIZE_DEV || dn >= SIZE_DEV_INSTANCES)
+		return ERR_ARG;
+
+	temph = &devs_common.devs[dev][dn];
+	if (temph->deinit == NULL ||
+		temph->sync == NULL ||
+		temph->read == NULL ||
+		temph->write == NULL)
+		return ERR_ARG;
+
+	*h = temph;
+
+	return ERR_NONE;
+}
+
+
+ssize_t devs_read(unsigned int dev, unsigned int dn, addr_t offs, u8 *buff, unsigned int len)
+{
+	dev_handler_t *handler;
+
+	if (dev >= SIZE_DEV || dn >= SIZE_DEV_INSTANCES)
+		return ERR_ARG;
+
+	handler = &devs_common.devs[dev][dn];
+	if (handler->read == NULL)
+		return ERR_ARG;
+
+	return handler->read(dn, offs, buff, len);
+}
+
+
+ssize_t devs_write(unsigned int dev, unsigned int dn, addr_t offs, const u8 *buff, unsigned int len)
+{
+	dev_handler_t *handler;
+
+	if (dev >= SIZE_DEV || dn >= SIZE_DEV_INSTANCES)
+		return ERR_ARG;
+
+	handler = &devs_common.devs[dev][dn];
+	if (handler->write == NULL)
+		return ERR_ARG;
+
+	return handler->write(dn, offs, buff, len);
+}
+
+
+int devs_deinit(unsigned int dev, unsigned int dn)
+{
+	dev_handler_t *handler;
+
+	if (dev >= SIZE_DEV || dn >= SIZE_DEV_INSTANCES)
+		return ERR_ARG;
+
+	handler = &devs_common.devs[dev][dn];
+	if (handler->deinit == NULL)
+		return ERR_ARG;
+
+	return handler->deinit(dn);
+}
+
+
+int devs_sync(unsigned int dev, unsigned int dn)
+{
+	dev_handler_t *handler;
+
+	if (dev >= SIZE_DEV || dn >= SIZE_DEV_INSTANCES)
+		return ERR_ARG;
+
+	handler = &devs_common.devs[dev][dn];
+	if (handler->sync == NULL)
+		return ERR_ARG;
+
+	return handler->sync(dn);
+}
+
+
+
+void devs_deinitAll(void)
+{
+	unsigned int i, j;
+	dev_handler_t *handler;
+
+	for (i = 0; i < SIZE_DEV; ++i) {
+		for (j = 0; j < SIZE_DEV_INSTANCES; ++j) {
+			handler = &devs_common.devs[i][j];
+			if (handler->deinit != NULL)
+				handler->deinit(i);
+		}
+	}
+}

--- a/devices/devs.h
+++ b/devices/devs.h
@@ -1,0 +1,62 @@
+/*
+ * Phoenix-RTOS
+ *
+ * phoenix-rtos-loader
+ *
+ * Devices Interface
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Hubert Buczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#ifndef _DEVS_H_
+#define _DEVS_H_
+
+#include "../types.h"
+#include "config.h"
+
+#define DEV_UART    0
+#define DEV_USB     1
+#define DEV_FLASH   2
+
+
+typedef struct {
+	int (*deinit)(unsigned int dn);
+	int (*sync)(unsigned int dn);
+
+	ssize_t (*read)(unsigned int dn, addr_t offs, u8 *buff, unsigned int len);
+	ssize_t (*write)(unsigned int dn, addr_t offs, const u8 *buff, unsigned int len);
+} dev_handler_t;
+
+
+/* This function should be called only before devs_init(),
+ * preferably from device drivers constructors. */
+extern void devs_regDriver(unsigned int dev, int (*init)(unsigned int dn, dev_handler_t *h));
+
+
+extern void devs_init(void);
+
+
+extern int devs_sync(unsigned int dev, unsigned int dn);
+
+
+extern int devs_getHandler(unsigned int dev, unsigned int dn, dev_handler_t **h);
+
+
+extern ssize_t devs_read(unsigned int dev, unsigned int dn, addr_t offs, u8 *buff, unsigned int len);
+
+
+extern ssize_t devs_write(unsigned int dev, unsigned int dn, addr_t offs, const u8 *buff, unsigned int len);
+
+
+extern int devs_deinit(unsigned int dev, unsigned int dn);
+
+
+extern void devs_deinitAll(void);
+
+#endif

--- a/hal.h
+++ b/hal.h
@@ -67,6 +67,8 @@ extern addr_t hal_vm2phym(addr_t addr);
 
 extern void hal_memcpy(void *dst, const void *src, unsigned int l);
 
+extern void hal_memset(void *dst, int v, unsigned int l);
+
 
 /* Function starts kernel loaded into memory */
 

--- a/hal/armv7a/zynq7000/Makefile
+++ b/hal/armv7a/zynq7000/Makefile
@@ -11,6 +11,7 @@ INIT_FLASH = 0x0
 
 LDFLAGS:=$(filter-out -Tbss% , $(LDFLAGS))
 LDFLAGS:=$(filter-out -Tdata% , $(LDFLAGS))
+LDFLAGS+=--defsym _plo_bss=__bss_start
 
 CFLAGS:=$(filter-out -mfloat-abi% , $(CFLAGS))
 CFLAGS:=$(filter-out -mfpu% , $(CFLAGS))

--- a/hal/armv7a/zynq7000/_startup.S
+++ b/hal/armv7a/zynq7000/_startup.S
@@ -153,7 +153,7 @@ set_loop:
 
 
 	/* Jump to plo */
-	ldr r8, =plo_init
+	ldr r8, =_startc
 	bx r8
 
 

--- a/hal/armv7a/zynq7000/config.h
+++ b/hal/armv7a/zynq7000/config.h
@@ -40,7 +40,7 @@
 
 /* Linker symbols */
 extern void _end(void);
-extern void plo_bss(void);
+extern void _plo_bss(void);
 
 
 /* PHFS sources  */
@@ -56,6 +56,7 @@ extern void plo_bss(void);
 typedef u32 addr_t;
 
 typedef unsigned int size_t;
+typedef int ssize_t;
 
 typedef struct {
 	/* Empty hal data */

--- a/hal/armv7a/zynq7000/hal.c
+++ b/hal/armv7a/zynq7000/hal.c
@@ -48,7 +48,6 @@ const cmd_device_t devices[] = {
 	{ NULL, NULL }
 };
 
-
 /* Initialization functions */
 
 void hal_init(void)
@@ -187,6 +186,35 @@ void hal_memcpy(void *dst, const void *src, unsigned int l)
 	: "+l" (dst), "+l" (src), "+l" (l)
 	:
 	: "r3", "memory", "cc");
+}
+
+
+void hal_memset(void *dst, int v, unsigned int l)
+{
+	__asm__ volatile
+	(" \
+		mov r1, %2; \
+		mov r3, %1; \
+		orr r3, r3, r3, lsl #8; \
+		orr r3, r3, r3, lsl #16; \
+		mov r4, %0; \
+		ands r2, r4, #3; \
+		bne 2f; \
+	1: \
+		cmp r1, #4; \
+		itt hs; \
+		strhs r3, [r4], #4; \
+		subshs r1, #4; \
+		bhs 1b; \
+	2: \
+		cmp r1, #0; \
+		itt ne; \
+		strbne r3, [r4], #1; \
+		subsne r1, #1; \
+		bne 2b"
+	:
+	: "r" (dst), "r" (v & 0xff), "r" (l)
+	: "r1", "r2", "r3", "r4", "memory", "cc");
 }
 
 

--- a/hal/armv7m/imxrt106x/Makefile
+++ b/hal/armv7m/imxrt106x/Makefile
@@ -10,7 +10,7 @@ INIT_RAM = 0x0
 INIT_FLASH = 0x70000000
 
 BSS=-Tbss=20010000
-LDFLAGS+=--defsym=plo_bss=0x20010000
+LDFLAGS+=--defsym _plo_bss=0x20010000
 
 LDFLAGS:=$(filter-out -Tbss% , $(LDFLAGS))
 LDFLAGS:=$(filter-out -Tdata% , $(LDFLAGS))

--- a/hal/armv7m/imxrt106x/_startup.S
+++ b/hal/armv7m/imxrt106x/_startup.S
@@ -198,7 +198,7 @@ _plo:
     str r1, [r0]
     ldr r0, [r1]
     msr msp, r0
-    ldr r8, =plo_init
+    ldr r8, =_startc
     bx r8
 
 .size _start, .-_start

--- a/hal/armv7m/imxrt106x/config.h
+++ b/hal/armv7m/imxrt106x/config.h
@@ -42,7 +42,7 @@
 
 /* Linker symbols */
 extern void _end(void);
-extern void plo_bss(void);
+extern void _plo_bss(void);
 
 
 /* PHFS sources  */
@@ -62,6 +62,8 @@ extern void plo_bss(void);
 
 typedef u32 addr_t;
 typedef unsigned int size_t;
+typedef int ssize_t;
+
 
 typedef struct {
 	/* Empty hal data */

--- a/hal/armv7m/imxrt106x/hal.c
+++ b/hal/armv7m/imxrt106x/hal.c
@@ -82,7 +82,7 @@ void hal_init(void)
 	syspage_setAddress((void *)SYSPAGE_ADDRESS);
 
 	/* Add entries related to plo image */
-	syspage_addEntries((u32)plo_bss, (u32)_end - (u32)plo_bss + STACK_SIZE);
+	syspage_addEntries((u32)_plo_bss, (u32)_end - (u32)_plo_bss + STACK_SIZE);
 }
 
 
@@ -208,6 +208,34 @@ void hal_memcpy(void *dst, const void *src, unsigned int l)
 	: "+l" (dst), "+l" (src), "+l" (l)
 	:
 	: "r3", "memory", "cc");
+}
+
+void hal_memset(void *dst, int v, unsigned int l)
+{
+	__asm__ volatile
+	(" \
+		mov r1, %2; \
+		mov r3, %1; \
+		orr r3, r3, r3, lsl #8; \
+		orr r3, r3, r3, lsl #16; \
+		mov r4, %0; \
+		ands r2, r4, #3; \
+		bne 2f; \
+	1: \
+		cmp r1, #4; \
+		itt hs; \
+		strhs r3, [r4], #4; \
+		subshs r1, #4; \
+		bhs 1b; \
+	2: \
+		cmp r1, #0; \
+		itt ne; \
+		strbne r3, [r4], #1; \
+		subsne r1, #1; \
+		bne 2b"
+	:
+	: "r" (dst), "r" (v & 0xff), "r" (l)
+	: "r1", "r2", "r3", "r4", "memory", "cc");
 }
 
 

--- a/hal/armv7m/imxrt117x/Makefile
+++ b/hal/armv7m/imxrt117x/Makefile
@@ -10,7 +10,7 @@ INIT_RAM = 0x20250000
 INIT_FLASH = 0x30000000
 
 BSS=-Tbss=20011000
-LDFLAGS+=--defsym=plo_bss=0x20011000
+LDFLAGS+=--defsym _plo_bss=0x20011000
 
 LDFLAGS:=$(filter-out -Tbss% , $(LDFLAGS))
 LDFLAGS:=$(filter-out -Tdata% , $(LDFLAGS))

--- a/hal/armv7m/imxrt117x/_startup.S
+++ b/hal/armv7m/imxrt117x/_startup.S
@@ -205,7 +205,7 @@ _start:
 	str r1, [r0]
 	ldr r0, [r1]
 	msr msp, r0
-	ldr r8, =plo_init
+	ldr r8, =_startc
 	bx r8
 
 .size _start, .-_start

--- a/hal/armv7m/imxrt117x/config.h
+++ b/hal/armv7m/imxrt117x/config.h
@@ -42,7 +42,7 @@
 
 /* Linker symbols */
 extern void _end(void);
-extern void plo_bss(void);
+extern void _plo_bss(void);
 
 
 /* PHFS sources  */
@@ -59,6 +59,7 @@ extern void plo_bss(void);
 
 typedef u32 addr_t;
 typedef unsigned int size_t;
+typedef int ssize_t;
 
 typedef struct {
 	/* Empty hal data */

--- a/hal/armv7m/imxrt117x/hal.c
+++ b/hal/armv7m/imxrt117x/hal.c
@@ -84,7 +84,7 @@ void hal_init(void)
 	syspage_setAddress((void *)SYSPAGE_ADDRESS);
 
 	/* Add entries related to plo image */
-	syspage_addEntries((u32)plo_bss, (u32)_end - (u32)plo_bss + STACK_SIZE);
+	syspage_addEntries((u32)_plo_bss, (u32)_end - (u32)_plo_bss + STACK_SIZE);
 }
 
 
@@ -195,6 +195,35 @@ void hal_memcpy(void *dst, const void *src, unsigned int l)
 	: "+l" (dst), "+l" (src), "+l" (l)
 	:
 	: "r3", "memory", "cc");
+}
+
+
+void hal_memset(void *dst, int v, unsigned int l)
+{
+	__asm__ volatile
+	(" \
+		mov r1, %2; \
+		mov r3, %1; \
+		orr r3, r3, r3, lsl #8; \
+		orr r3, r3, r3, lsl #16; \
+		mov r4, %0; \
+		ands r2, r4, #3; \
+		bne 2f; \
+	1: \
+		cmp r1, #4; \
+		itt hs; \
+		strhs r3, [r4], #4; \
+		subshs r1, #4; \
+		bhs 1b; \
+	2: \
+		cmp r1, #0; \
+		itt ne; \
+		strbne r3, [r4], #1; \
+		subsne r1, #1; \
+		bne 2b"
+	:
+	: "r" (dst), "r" (v & 0xff), "r" (l)
+	: "r1", "r2", "r3", "r4", "memory", "cc");
 }
 
 


### PR DESCRIPTION
Due to the fact that [PR](https://github.com/phoenix-rtos/plo/pull/51) has been growing, it is separated into different PRs which will be merged into a `feature/devs` branch in plo. When the whole functionality will done, the `feature/devs` will be merged into master.

This PR provides the following changes:
- add `_startc.c` to handle constructors and destructors
- add device interface to allow initialize specific driver based on platform settings

For example, registration of uart driver:

```
int uart_init(int dn, dev_handler_t *h)
{
...
}

__attribute__((constructor)) static void uart_regDev(void)
{
	devs_regDriver(DEV_UART_ID, uart_init);
}
```

If this mechanism is accepted I will implement it in the current drivers and will add changes it into this PR.

