### PR TITLE
script: simplification of script processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,43 +20,51 @@ include hal/$(TARGET_SUFF)/$(TARGET_SUBFAMILY)/Makefile
 
 CFLAGS += $(BOARD_CONFIG)
 CFLAGS += -I../plo/hal/$(TARGET_SUFF)/$(TARGET_SUBFAMILY)
+CFLAGS += -I$(BUILD_DIR)
 
-OBJS += $(addprefix $(PREFIX_O), plo.o plostd.o phoenixd.o msg.o phfs.o cmd.o syspage.o)
+OBJS += $(addprefix $(PREFIX_O), plo.o plostd.o phoenixd.o msg.o phfs.o cmd.o syspage.o script.o)
 
 
 all: $(PREFIX_PROG_STRIPPED)plo-$(TARGET_FAMILY)-$(TARGET_SUBFAMILY).elf  $(PREFIX_PROG_STRIPPED)plo-$(TARGET_FAMILY)-$(TARGET_SUBFAMILY).img\
      $(PREFIX_PROG_STRIPPED)plo-ram-$(TARGET_FAMILY)-$(TARGET_SUBFAMILY).elf $(PREFIX_PROG_STRIPPED)plo-ram-$(TARGET_FAMILY)-$(TARGET_SUBFAMILY).img
 
 
+$(PREFIX_O)script.o: $(BUILD_DIR)/script.plo.h
 
 $(BUILD_DIR)/script.plo:
-	@printf "TOUCH script.plo\n"
-	$(SIL)touch $(BUILD_DIR)/script.plo
+	@printf "TOUCH $(@F)\n"
+	$(SIL)touch "$@"
 
-$(PREFIX_O)/script.o.plo: $(PREFIX_O)script.o $(BUILD_DIR)/script.plo
+$(BUILD_DIR)/script.plo.h: $(BUILD_DIR)/script.plo
 	@mkdir -p $(@D)
-	@printf "EMBED script.plo\n"
-	$(SIL)$(OBJCOPY) --update-section .data=$(BUILD_DIR)/script.plo $(PREFIX_O)script.o --add-symbol script=.data:0 $(PREFIX_O)script.o.plo
+	@printf "CREATE $(@F)\n"
+	@printf "" > "$@";\
+	if [ -s "$<" ]; then\
+		while read -r line; do\
+			if [ $${#line} -gt 0 ]; then\
+				printf '"%s",\n' "$$line" >> "$@";\
+			fi;\
+		done < "$<";\
+	fi
 
-
-$(PREFIX_PROG)plo-$(TARGET_FAMILY)-$(TARGET_SUBFAMILY).elf: $(OBJS) $(PREFIX_O)/script.o.plo $(STARTUP)
+$(PREFIX_PROG)plo-$(TARGET_FAMILY)-$(TARGET_SUBFAMILY).elf: $(OBJS) $(STARTUP)
 	@mkdir -p $(@D)
-	@(printf "LD  %-24s\n" "$(@F)");
-	$(SIL)$(LD) $(LDFLAGS) -e _start --section-start .init=$(INIT_FLASH) $(BSS) -o $(PREFIX_PROG)plo-$(TARGET_FAMILY)-$(TARGET_SUBFAMILY).elf $(OBJS) $(PREFIX_O)/script.o.plo $(GCCLIB)
+	@printf "LD  %-24s\n" "$(@F)"
+	$(SIL)$(LD) $(LDFLAGS) -e _start --section-start .init=$(INIT_FLASH) $(BSS) -o $@ $(OBJS) $(GCCLIB)
 
 $(PREFIX_PROG)plo-ram-$(TARGET_FAMILY)-$(TARGET_SUBFAMILY).elf: $(OBJS) $(STARTUP_RAM)
 	@mkdir -p $(@D)
-	@(printf "LD  %-24s\n" "$(@F)");
-	$(SIL)$(LD) $(LDFLAGS) -e _start --section-start .init=$(INIT_RAM) $(BSS) -o $(PREFIX_PROG)plo-ram-$(TARGET_FAMILY)-$(TARGET_SUBFAMILY).elf $(OBJS) $(PREFIX_O)/script.o.plo $(GCCLIB)
+	@printf "LD  %-24s\n" "$(@F)"
+	$(SIL)$(LD) $(LDFLAGS) -e _start --section-start .init=$(INIT_RAM) $(BSS) -o $@ $(OBJS) $(GCCLIB)
 
 
 $(PREFIX_PROG_STRIPPED)%.hex: $(PREFIX_PROG_STRIPPED)%.elf
-	@(printf "HEX %s\n" "$(@F)");
+	@printf "HEX %s\n" "$(@F)"
 	$(SIL)$(OBJCOPY) -O ihex $< $@
 
 
 $(PREFIX_PROG_STRIPPED)%.img: $(PREFIX_PROG_STRIPPED)%.elf
-	@(printf "BIN %s\n" "$(@F)");
+	@printf "BIN %s\n" "$(@F)";
 	$(SIL)$(OBJCOPY) -O binary $< $@
 
 


### PR DESCRIPTION
Instead of creating an array of copies of individual script lines, an array of pointers to those lines is created.
The file `script.plo.h` is created in the `Makefile` and then included in `script.c`.

Other changes:

- `script_expandAlias()`:  moved the calculation of name length and parameter position outside the for loop.
- ` Makefile`:  removed unnecessary semicolons.
