### PR TITLE
cmds: simpler number validation

### DIFF
--- a/cmds/alias.c
+++ b/cmds/alias.c
@@ -53,7 +53,7 @@ static int cmd_alias(char *s)
 		else if (i == 2)
 			sz = lib_strtoul(args[i], &end, 0);
 
-		if (hal_strlen(end) != 0) {
+		if (*end) {
 			log_error("\nWrong args: %s", s);
 			return -EINVAL;
 		}

--- a/cmds/console.c
+++ b/cmds/console.c
@@ -44,13 +44,13 @@ static int cmd_console(char *s)
 
 	/* Get major/minor */
 	major = lib_strtoul(args[0], &endptr, 0);
-	if (hal_strlen(endptr) != 0) {
+	if (*endptr) {
 		log_error("\nWrong major value: %s", args[0]);
 		return -EINVAL;
 	}
 
 	minor = lib_strtoul(args[1], &endptr, 0);
-	if (hal_strlen(endptr) != 0) {
+	if (*endptr) {
 		log_error("\nWrong minor value: %s", args[1]);
 		return -EINVAL;
 	}

--- a/cmds/copy.c
+++ b/cmds/copy.c
@@ -85,7 +85,7 @@ static int cmd_parseDev(handler_t *h, addr_t *offs, size_t *sz, cmdarg_t *args, 
 	*offs = lib_strtoul(args[*argsID], &endptr, 0);
 
 	/* Open device using alias to file */
-	if (hal_strlen(endptr) != 0) {
+	if (*endptr) {
 		*offs = 0;
 		*sz = 0;
 		if (phfs_open(alias, args[(*argsID)], 0, h) < 0) {
@@ -97,7 +97,7 @@ static int cmd_parseDev(handler_t *h, addr_t *offs, size_t *sz, cmdarg_t *args, 
 	/* Open device using direct access to memory */
 	else {
 		*sz = lib_strtoul(args[++(*argsID)], &endptr, 0);
-		if (hal_strlen(endptr) != 0) {
+		if (*endptr) {
 			log_error("\nWrong size value: %s, for %s with offs 0x%x", args[(*argsID)], alias, *offs);
 			return -EINVAL;
 		}

--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -44,7 +44,7 @@ static int cmd_dump(char *s)
 	}
 
 	offs = lib_strtoul(args[0], &endptr, 16);
-	if (hal_strlen(endptr) != 0) {
+	if (*endptr) {
 		log_error("\nWrong address value: %s", args[0]);
 		return -EINVAL;
 	}

--- a/cmds/map.c
+++ b/cmds/map.c
@@ -52,14 +52,14 @@ static int cmd_map(char *s)
 
 	++argID;
 	start = lib_strtoul(args[argID], &endptr, 0);
-	if (hal_strlen(endptr) != 0) {
+	if (*endptr) {
 		log_error("\nWrong args: %s", s);
 		return -EINVAL;
 	}
 
 	++argID;
 	end = lib_strtoul(args[argID], &endptr, 0);
-	if (hal_strlen(endptr) != 0) {
+	if (*endptr) {
 		log_error("\nWrong args: %s", s);
 		return -EINVAL;
 	}

--- a/cmds/phfs.c
+++ b/cmds/phfs.c
@@ -43,13 +43,13 @@ static int cmd_phfs(char *s)
 
 	/* Get major/minor */
 	major = lib_strtoul(args[1], &endptr, 0);
-	if (hal_strlen(endptr) != 0) {
+	if (*endptr) {
 		log_error("\nWrong major value %s for %s", args[1], args[0]);
 		return -EINVAL;
 	}
 
 	minor = lib_strtoul(args[2], &endptr, 0);
-	if (hal_strlen(endptr) != 0) {
+	if (*endptr) {
 		log_error("\nWrong minor value %s for %s", args[2], args[0]);
 		return -EINVAL;
 	}

--- a/cmds/syspage.c
+++ b/cmds/syspage.c
@@ -43,7 +43,7 @@ static int cmd_syspage(char *s)
 	}
 
 	addr = lib_strtoul(args[0], &end, 0);
-	if (hal_strlen(end) != 0) {
+	if (*end) {
 		log_error("\nWrong args %s", s);
 		return -EINVAL;
 	}

--- a/cmds/wait.c
+++ b/cmds/wait.c
@@ -50,7 +50,7 @@ static int cmd_wait(char *s)
 
 	/* Wait for the time specified by the user */
 	time = lib_strtoul(args[0], &endptr, 0);
-	if (hal_strlen(endptr) != 0) {
+	if (*endptr) {
 		log_error("\nWrong args: %s", s);
 		return -EINVAL;
 	}


### PR DESCRIPTION
Instead of `strlen()` just check the value of `*end`.

