### PR TITLE
plo: fix uart

### DIFF
--- a/devices/uart-imxrt117x/uart.c
+++ b/devices/uart-imxrt117x/uart.c
@@ -34,13 +34,13 @@ typedef struct {
 	u16 txFifoSz;
 
 	u8 rxBuff[BUFFER_SIZE];
-	u16 rxHead;
-	u16 rxTail;
+	volatile u16 rxHead;
+	volatile u16 rxTail;
 
 	u8 txBuff[BUFFER_SIZE];
-	u16 txHead;
-	u16 txTail;
-	u8 tFull;
+	volatile u16 txHead;
+	volatile u16 txTail;
+	volatile u8 tFull;
 } uart_t;
 
 

--- a/devices/uart-zynq7000/uart.c
+++ b/devices/uart-zynq7000/uart.c
@@ -32,14 +32,14 @@ typedef struct {
 	u16 txFifoSz;
 
 	u8 rxBuff[BUFFER_SIZE];
-	u16 rxHead;
-	u16 rxTail;
+	volatile u16 rxHead;
+	volatile u16 rxTail;
 
 	u8 txBuff[BUFFER_SIZE];
-	u16 txHead;
-	u16 txTail;
+	volatile u16 txHead;
+	volatile u16 txTail;
 
-	u8 tFull;
+	volatile u8 tFull;
 } uart_t;
 
 

--- a/hal/armv7a/zynq7000/timer.c
+++ b/hal/armv7a/zynq7000/timer.c
@@ -92,7 +92,7 @@ static void timer_setPrescaler(u32 freq)
 }
 
 
-int timer_wait(u32 ms, int flags, u16 *p, u16 v)
+int timer_wait(u32 ms, int flags, volatile u16 *p, u16 v)
 {
 	/* Set value that determines when an irq t will be generated */
 	timer_common.leftTime = ms;

--- a/hal/armv7m/imxrt106x/_startup.S
+++ b/hal/armv7m/imxrt106x/_startup.S
@@ -217,7 +217,7 @@ _intd0:
     ldr sp, [sp]
 _intd1:
     ldmia sp!, {r0-r1, r4-r11, lr}
-
+	dmb
     bx lr
 .size _interrupts_dispatch, .-_interrupts_dispatch
 .ltorg

--- a/hal/armv7m/imxrt106x/timer.c
+++ b/hal/armv7m/imxrt106x/timer.c
@@ -47,7 +47,7 @@ static int timer_isr(u16 irq, void *data)
 }
 
 
-int timer_wait(u32 ms, int flags, u16 *p, u16 v)
+int timer_wait(u32 ms, int flags, volatile u16 *p, u16 v)
 {
 	timer_common.done = 0;
 

--- a/hal/armv7m/imxrt117x/timer.c
+++ b/hal/armv7m/imxrt117x/timer.c
@@ -47,7 +47,7 @@ static int timer_isr(u16 irq, void *data)
 }
 
 
-int timer_wait(u32 ms, int flags, u16 *p, u16 v)
+int timer_wait(u32 ms, int flags, volatile u16 *p, u16 v)
 {
 	timer_common.done = 0;
 

--- a/hal/timer.h
+++ b/hal/timer.h
@@ -28,7 +28,7 @@ extern void timer_init(void);
 
 
 /* Function waits for specific period of time or event */
-extern int timer_wait(u32 ms, int flags, u16 *p, u16 v);
+extern int timer_wait(u32 ms, int flags, volatile u16 *p, u16 v);
 
 
 /* Function resets timer controller */


### PR DESCRIPTION
This PR should solve the problem with UART driver which causes that plo occasionally freezes on imxrt106x.
Within this changes the volatile types are added to variables which values are changed in interrupts.

@jsarzy, please test this solution with runner.