### PR TITLE
Quick fixes of max allowed files in phfs and the length of an app

### DIFF
--- a/cmds/app.c
+++ b/cmds/app.c
@@ -121,7 +121,7 @@ static int cmd_app(char *s)
 
 	char *cmdline;
 	unsigned int flags = 0;
-	char imap[8], dmap[8], appName[SIZE_APP_NAME];
+	char imap[8], dmap[8], appName[SIZE_APP_NAME + 1];
 
 	handler_t handler;
 	phfs_stat_t stat;
@@ -165,7 +165,7 @@ static int cmd_app(char *s)
 			break;
 	}
 
-	if (pos >= SIZE_APP_NAME) {
+	if (pos > SIZE_APP_NAME) {
 		log_error("\nApp %s name is too long", cmdline);
 		return -EINVAL;
 	}

--- a/phfs/phfs.c
+++ b/phfs/phfs.c
@@ -23,7 +23,7 @@
 
 
 #define SIZE_PHFS_HANDLERS 8
-#define SIZE_PHFS_FILES    10
+#define SIZE_PHFS_FILES    20
 
 #define PHFS_TIMEOUT_MS 500
 


### PR DESCRIPTION
Quick fixes about issues reported in Jira: RTOS-41, RTOS-42

Previously max. allowed app name length was up to 15 characters + 1 null byte (16 bytes), after change #71 it is 14 characters + 1 null byte (15 bytes). Syspage actually do accept 15 characters + 1 null byte (16 bytes), take a look [plo/syspage.c#L53](https://github.com/phoenix-rtos/plo/blob/9afdfa3892030629ee89630a4299e7fbea30e38e/syspage.c#L53) and [plo/syspage.c#L629](https://github.com/phoenix-rtos/plo/blob/9afdfa3892030629ee89630a4299e7fbea30e38e/syspage.c#L629)

![tolong](https://user-images.githubusercontent.com/141153/121071189-edfef980-c7cf-11eb-9e75-12cb18cdce3c.png)

One of the projects require more programs to be later executed with `sysexec`, limit of 10 is too low.

![tomanyprograms](https://user-images.githubusercontent.com/141153/121071213-f48d7100-c7cf-11eb-9774-e98661cd38f6.png)
