### PR TITLE
cmds/cmd: command line parsing changed

### DIFF
--- a/cmds/call.c
+++ b/cmds/call.c
@@ -78,7 +78,10 @@ static int cmd_call(char *s)
 		offs += res;
 		if (res == 0 || c == '\n' || i == (sizeof(buff) - 1)) {
 			buff[i] = '\0';
-			cmd_parse(buff);
+
+			if (cmd_parse(buff) < 0)
+				return -EINVAL;
+
 			i = 0;
 			continue;
 		}

--- a/cmds/cmd.h
+++ b/cmds/cmd.h
@@ -57,7 +57,7 @@ extern const cmd_t *cmd_getCmd(unsigned int id);
 
 
 /* Function parses loader commands */
-extern void cmd_parse(char *line);
+extern int cmd_parse(char *line);
 
 
 /* Function prase arguments from command */


### PR DESCRIPTION
The function `cmd_parse()` is called in functions:
```
cmd_call()
cmd_prompt()
cmd_run()
```
The `'\n'` character occurs in the argument passed to `cmd_parse()` only in `cmd_run()`.
In this PR parsing `'\n'` character has been moved to `cmd_run()`.
The `cmd_parse()` function type has also been changed.