### PR TITLE
cmd/kernel: add optional kernel alias/name argument

### DIFF
--- a/cmds/app.c
+++ b/cmds/app.c
@@ -27,7 +27,7 @@ static void cmd_appInfo(void)
 }
 
 
-static int cmd_cpphfs2map(handler_t handler, const char *imap)
+static int cmd_cpphfs2map(handler_t handler, const char *imap, void *top)
 {
 	int res;
 	addr_t offs = 0;
@@ -35,12 +35,15 @@ static int cmd_cpphfs2map(handler_t handler, const char *imap)
 
 	do {
 		if ((res = phfs_read(handler, offs, buff, SIZE_MSG_BUFF)) < 0) {
+			syspage_setMapTop(imap, top);
 			log_error("\nCan't read data");
 			return -EIO;
 		}
 
-		if (syspage_write2Map(imap, buff, res) < 0)
+		if (syspage_write2Map(imap, buff, res) < 0) {
+			syspage_setMapTop(imap, top);
 			return -EINVAL;
+		}
 
 		offs += res;
 	} while (res > 0);
@@ -85,7 +88,7 @@ static int cmd_loadApp(handler_t handler, size_t size, const char *imap, const c
 
 	/* Copy program's elf to imap */
 	if (res == dev_isNotMappable) {
-		if ((res = cmd_cpphfs2map(handler, imap)) < 0)
+		if ((res = cmd_cpphfs2map(handler, imap, start)) < 0)
 			return res;
 
 		/* Get map top address after copying */

--- a/cmds/app.c
+++ b/cmds/app.c
@@ -27,7 +27,7 @@ static void cmd_appInfo(void)
 }
 
 
-static int cmd_cpphfs2map(handler_t handler, const char *imap, void *top)
+static int cmd_cpphfs2map(handler_t handler, const char *imap, addr_t top)
 {
 	int res;
 	addr_t offs = 0;
@@ -56,7 +56,7 @@ static int cmd_loadApp(handler_t handler, size_t size, const char *imap, const c
 {
 	int res;
 	Elf32_Ehdr hdr;
-	void *start, *end;
+	addr_t start, end;
 	addr_t addr, offs = 0;
 	unsigned int attr;
 
@@ -81,7 +81,7 @@ static int cmd_loadApp(handler_t handler, size_t size, const char *imap, const c
 		return -EINVAL;
 	}
 
-	if ((res = phfs_map(handler, offs, size, mAttrRead | mAttrWrite, (addr_t)start, size, attr, &addr)) < 0) {
+	if ((res = phfs_map(handler, offs, size, mAttrRead | mAttrWrite, start, size, attr, &addr)) < 0) {
 		log_error("\nDevice is not mappable in %s", imap);
 		return -EINVAL;
 	}
@@ -98,7 +98,7 @@ static int cmd_loadApp(handler_t handler, size_t size, const char *imap, const c
 		if (phfs_getFileAddr(handler, &offs) < 0)
 			return -EINVAL;
 
-		start = (void *)(offs + addr);
+		start = offs + addr;
 		end = start + size;
 	}
 	else {

--- a/cmds/go.c
+++ b/cmds/go.c
@@ -15,6 +15,7 @@
 
 #include "cmd.h"
 
+#include <syspage.h>
 #include <hal/hal.h>
 #include <lib/log.h>
 #include <lib/console.h>
@@ -30,16 +31,23 @@ static int cmd_go(char *s)
 {
 	unsigned int argsc;
 	cmdarg_t *args;
+	addr_t kernel_entry;
+	int ret;
 
 	if ((argsc = cmd_getArgs(s, DEFAULT_BLANKS, &args)) != 0) {
 		log_error("\nWrong args: %s", s);
 		return -EINVAL;
 	}
 
+	if ((ret = syspage_validateKernel(&kernel_entry)) != EOK) {
+		log_error("\nValid kernel image has not been loaded.");
+		return ret;
+	}
+
 	log_info("\nRunning Phoenix-RTOS");
 	lib_printf(CONSOLE_NORMAL CONSOLE_CLEAR CONSOLE_CURSOR_SHOW);
-	hal_launch();
 
+	hal_cpuJump(kernel_entry);
 	return EOK;
 }
 

--- a/cmds/kernel.c
+++ b/cmds/kernel.c
@@ -122,14 +122,14 @@ static int cmd_kernel(char *s)
 
 		/* Find .bss section header */
 		if (shdr.sh_type == SHT_NOBITS && shdr.sh_flags == (SHF_WRITE | SHF_ALLOC))
-			syspage_setKernelBss((void *)shdr.sh_addr, (u32)shdr.sh_size);
+			syspage_setKernelBss((void *)hal_vm2phym(shdr.sh_addr), (u32)shdr.sh_size);
 	}
 
 	/* TODO: it is temporary solution. It should be defined. */
 	syspage_setKernelData(0, 0);
 
-	syspage_setKernelText((void *)minaddr, maxaddr - minaddr);
-	hal_setKernelEntry(hdr.e_entry);
+	syspage_setKernelText((void *)hal_vm2phym(minaddr), maxaddr - minaddr);
+	syspage_setKernelEntry(hal_vm2phym(hdr.e_entry));
 
 	if (phfs_close(handler) < 0) {
 		log_error("\nCan't close %s, on %s", KERNEL_PATH, args[0]);

--- a/cmds/kernel.c
+++ b/cmds/kernel.c
@@ -125,13 +125,13 @@ static int cmd_kernel(char *s)
 
 		/* Find .bss section header */
 		if (shdr.sh_type == SHT_NOBITS && shdr.sh_flags == (SHF_WRITE | SHF_ALLOC))
-			syspage_setKernelBss((void *)hal_vm2phym(shdr.sh_addr), (u32)shdr.sh_size);
+			syspage_setKernelBss(hal_vm2phym(shdr.sh_addr), (addr_t)shdr.sh_size);
 	}
 
 	/* TODO: it is temporary solution. It should be defined. */
 	syspage_setKernelData(0, 0);
 
-	syspage_setKernelText((void *)hal_vm2phym(minaddr), maxaddr - minaddr);
+	syspage_setKernelText(hal_vm2phym(minaddr), maxaddr - minaddr);
 	syspage_setKernelEntry(hal_vm2phym(hdr.e_entry));
 
 	if (phfs_close(handler) < 0) {

--- a/cmds/map.c
+++ b/cmds/map.c
@@ -64,7 +64,7 @@ static int cmd_map(char *s)
 		return -EINVAL;
 	}
 
-	if (syspage_addmap(mapname, (void *)start, (void *)end, args[3]) < 0) {
+	if (syspage_addmap(mapname, start, end, args[3]) < 0) {
 		log_error("\nCan't create map %s", mapname);
 		return -EINVAL;
 	}

--- a/cmds/syspage.c
+++ b/cmds/syspage.c
@@ -48,7 +48,7 @@ static int cmd_syspage(char *s)
 		return -EINVAL;
 	}
 
-	syspage_setAddress((void *)addr);
+	syspage_setAddress(addr);
 	log_info("\nSetting address: 0x%x", addr);
 
 	return EOK;

--- a/hal/armv7a/zynq7000/hal.c
+++ b/hal/armv7a/zynq7000/hal.c
@@ -44,7 +44,7 @@ void hal_init(void)
 	console_init();
 
 	syspage_init();
-	syspage_setAddress((void *)SYSPAGE_ADDRESS);
+	syspage_setAddress(SYSPAGE_ADDRESS);
 }
 
 

--- a/hal/armv7a/zynq7000/hal.c
+++ b/hal/armv7a/zynq7000/hal.c
@@ -19,11 +19,6 @@
 #include <devices/gpio-zynq7000/gpio.h>
 
 
-struct{
-	addr_t kernel_entry;
-} hal_common;
-
-
 /* Linker symbols */
 extern void _end(void);
 extern void _plo_bss(void);
@@ -91,7 +86,7 @@ void hal_cpuInvCacheAll(unsigned int type)
 }
 
 
-void hal_setKernelEntry(addr_t addr)
+addr_t hal_vm2phym(addr_t addr)
 {
 	addr_t offs;
 
@@ -100,23 +95,11 @@ void hal_setKernelEntry(addr_t addr)
 		addr = ADDR_DDR + offs;
 	}
 
-	hal_common.kernel_entry = addr;
-}
-
-
-addr_t hal_vm2phym(addr_t addr)
-{
-	u32 offs;
-	if ((u32)VADDR_KERNEL_INIT != (u32)ADDR_DDR) {
-		offs = addr - VADDR_KERNEL_INIT;
-		addr = ADDR_DDR + offs;
-	}
-
 	return addr;
 }
 
 
-int hal_launch(void)
+int hal_cpuJump(addr_t addr)
 {
 	time_t start;
 	syspage_save();
@@ -132,7 +115,7 @@ int hal_launch(void)
 	__asm__ volatile("mov r9, %1; \
 		 blx %0"
 		 :
-		 : "r"(hal_common.kernel_entry), "r"(syspage_getAddress()));
+		 : "r"(addr), "r"(syspage_getAddress()));
 
 	hal_interruptsEnable();
 

--- a/hal/armv7m/imxrt106x/hal.c
+++ b/hal/armv7m/imxrt106x/hal.c
@@ -49,10 +49,10 @@ void hal_init(void)
 	console_init();
 
 	syspage_init();
-	syspage_setAddress((void *)SYSPAGE_ADDRESS);
+	syspage_setAddress(SYSPAGE_ADDRESS);
 
 	/* Add entries related to plo image */
-	syspage_addEntries((u32)_plo_bss, (u32)_end - (u32)_plo_bss + STACK_SIZE);
+	syspage_addEntries((addr_t)_plo_bss, (addr_t)_end - (addr_t)_plo_bss + STACK_SIZE);
 }
 
 

--- a/hal/armv7m/imxrt106x/hal.c
+++ b/hal/armv7m/imxrt106x/hal.c
@@ -5,8 +5,8 @@
  *
  * Hardware Abstraction Layer
  *
- * Copyright 2020 Phoenix Systems
- * Author: Hubert Buczynski, Marcin Baran
+ * Copyright 2020-2021 Phoenix Systems
+ * Author: Hubert Buczynski, Marcin Baran, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -25,7 +25,6 @@ typedef struct {
 
 
 struct{
-	addr_t kernel_entry;
 	intr_handler_t irqs[SIZE_INTERRUPTS];
 } hal_common;
 
@@ -101,11 +100,6 @@ void hal_cpuInvCacheAll(unsigned int type)
 }
 
 
-void hal_setKernelEntry(addr_t addr)
-{
-	hal_common.kernel_entry = addr;
-}
-
 
 addr_t hal_vm2phym(addr_t addr)
 {
@@ -113,7 +107,7 @@ addr_t hal_vm2phym(addr_t addr)
 }
 
 
-int hal_launch(void)
+int hal_cpuJump(addr_t addr)
 {
 	time_t start;
 
@@ -130,7 +124,7 @@ int hal_launch(void)
 	__asm__ volatile("mov r9, %1; \
 		 blx %0"
 		 :
-		 : "r"(hal_common.kernel_entry), "r"(syspage_getAddress()));
+		 : "r"(addr), "r"(syspage_getAddress()));
 	hal_interruptsEnable();
 
 	return -1;

--- a/hal/armv7m/imxrt117x/hal.c
+++ b/hal/armv7m/imxrt117x/hal.c
@@ -5,7 +5,7 @@
  *
  * Hardware Abstraction Layer
  *
- * Copyright 2020 Phoenix Systems
+ * Copyright 2020-2021 Phoenix Systems
  * Author: Hubert Buczynski, Marcin Baran
  *
  * This file is part of Phoenix-RTOS.
@@ -24,7 +24,6 @@ typedef struct {
 
 
 struct{
-	addr_t kernel_entry;
 	intr_handler_t irqs[SIZE_INTERRUPTS];
 } hal_common;
 
@@ -96,19 +95,13 @@ void hal_cpuInvCacheAll(unsigned int type)
 }
 
 
-void hal_setKernelEntry(addr_t addr)
-{
-	hal_common.kernel_entry = addr;
-}
-
-
 addr_t hal_vm2phym(addr_t addr)
 {
 	return addr;
 }
 
 
-int hal_launch(void)
+int hal_cpuJump(addr_t addr)
 {
 	time_t start;
 
@@ -125,7 +118,7 @@ int hal_launch(void)
 	__asm__ volatile("mov r9, %1; \
 		 blx %0"
 		 :
-		 : "r"(hal_common.kernel_entry), "r"(syspage_getAddress()));
+		 : "r"(addr), "r"(syspage_getAddress()));
 	hal_interruptsEnable();
 
 	return -1;

--- a/hal/armv7m/imxrt117x/hal.c
+++ b/hal/armv7m/imxrt117x/hal.c
@@ -48,10 +48,10 @@ void hal_init(void)
 	console_init();
 
 	syspage_init();
-	syspage_setAddress((void *)SYSPAGE_ADDRESS);
+	syspage_setAddress(SYSPAGE_ADDRESS);
 
 	/* Add entries related to plo image */
-	syspage_addEntries((u32)_plo_bss, (u32)_end - (u32)_plo_bss + STACK_SIZE);
+	syspage_addEntries((addr_t)_plo_bss, (addr_t)_end - (addr_t)_plo_bss + STACK_SIZE);
 }
 
 

--- a/hal/hal.h
+++ b/hal/hal.h
@@ -5,7 +5,7 @@
  *
  * Hardware Abstraction Layer
  *
- * Copyright 2012, 2017, 2020 Phoenix Systems
+ * Copyright 2012, 2017, 2020-2021 Phoenix Systems
  * Copyright 2006 Radoslaw F. Wawrzusiak
  * Copyright 2001, 2005 Pawel Pisarczyk
  * Authors: Pawel Pisarczyk, Radoslaw F. Wawrzusiak, Hubert Buczynski
@@ -41,14 +41,11 @@ extern void hal_cpuInvCache(unsigned int type, addr_t addr, size_t sz);
 extern void hal_cpuInvCacheAll(unsigned int type);
 
 
-/* Function sets kernel's entry address */
-extern void hal_setKernelEntry(addr_t addr);
-
 /* Function translates virtual address into physical */
 extern addr_t hal_vm2phym(addr_t addr);
 
 /* Function starts kernel loaded into memory */
-extern int hal_launch(void);
+extern int hal_cpuJump(addr_t addr);
 
 
 /* Function enables interrupts */

--- a/syspage.c
+++ b/syspage.c
@@ -298,7 +298,7 @@ void syspage_init(void)
 
 /* Syspage's location functions */
 
-void syspage_setAddress(void *addr)
+void syspage_setAddress(addr_t addr)
 {
 	size_t sz;
 
@@ -306,7 +306,7 @@ void syspage_setAddress(void *addr)
 	syspage_common.syspage = (void *)addr;
 	sz = (size_t)(MAX_SYSPAGE_SIZE / PAGE_SIZE) * PAGE_SIZE + (MAX_SYSPAGE_SIZE % PAGE_SIZE ? PAGE_SIZE : 0); /* allign to PAGE_SIZE */
 
-	syspage_addEntries((addr_t)addr, sz);
+	syspage_addEntries(addr, sz);
 
 	syspage_common.syspage->arg = NULL;
 	syspage_common.syspage->maps = NULL;
@@ -327,9 +327,9 @@ void syspage_setAddress(void *addr)
 }
 
 
-void *syspage_getAddress(void)
+addr_t syspage_getAddress(void)
 {
-	return (void *)syspage_common.syspage;
+	return (addr_t)syspage_common.syspage;
 }
 
 
@@ -492,7 +492,7 @@ int syspage_validateKernel(addr_t *addr)
 
 /* Map's functions */
 
-int syspage_addmap(const char *name, void *start, void *end, const char *attr)
+int syspage_addmap(const char *name, addr_t start, addr_t end, const char *attr)
 {
 	int i;
 	size_t size;
@@ -504,7 +504,7 @@ int syspage_addmap(const char *name, void *start, void *end, const char *attr)
 	/* Check whether map exists and overlaps with other maps */
 	for (i = 0; i < syspage_common.mapsCnt; ++i) {
 		map = &syspage_common.maps[i].map;
-		if (((map->start < (addr_t)end) && (map->end > (addr_t)start)) ||
+		if (((map->start < end) && (map->end > start)) ||
 			(hal_strncmp(name, map->name, hal_strlen(map->name)) == 0))
 			return -EINVAL;
 	}
@@ -512,8 +512,8 @@ int syspage_addmap(const char *name, void *start, void *end, const char *attr)
 	ploMap = &syspage_common.maps[mapID];
 	map = &ploMap->map;
 
-	map->start = (addr_t)start;
-	map->end = (addr_t)end;
+	map->start = start;
+	map->end = end;
 	map->id = mapID;
 	if (syspage_strAttr2ui(attr, &map->attr) < 0)
 		return -EINVAL;
@@ -524,7 +524,7 @@ int syspage_addmap(const char *name, void *start, void *end, const char *attr)
 	hal_memcpy(map->name, name, size);
 	map->name[size] = '\0';
 
-	ploMap->top = (addr_t)start;
+	ploMap->top = start;
 
 	for (i = 0; i < MAX_ENTRIES_NB; ++i) {
 		entry = &syspage_common.entries[i];
@@ -538,7 +538,7 @@ int syspage_addmap(const char *name, void *start, void *end, const char *attr)
 }
 
 
-int syspage_getMapTop(const char *map, void **addr)
+int syspage_getMapTop(const char *map, addr_t *addr)
 {
 	u8 id;
 
@@ -547,13 +547,13 @@ int syspage_getMapTop(const char *map, void **addr)
 		return -EINVAL;
 	}
 
-	*addr = (void *)syspage_common.maps[id].top;
+	*addr = syspage_common.maps[id].top;
 
 	return EOK;
 }
 
 
-int syspage_setMapTop(const char *map, void *addr)
+int syspage_setMapTop(const char *map, addr_t addr)
 {
 	u8 id;
 
@@ -562,7 +562,7 @@ int syspage_setMapTop(const char *map, void *addr)
 		return -EINVAL;
 	}
 
-	syspage_common.maps[id].top = (addr_t)addr;
+	syspage_common.maps[id].top = addr;
 
 	return EOK;
 }
@@ -677,7 +677,7 @@ int syspage_getMapAttr(const char *map, unsigned int *attr)
 
 /* Program's functions */
 
-int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, const char *cmdline, u32 flags)
+int syspage_addProg(addr_t start, addr_t end, const char *imap, const char *dmap, const char *cmdline, u32 flags)
 {
 	u8 imapID, dmapID;
 	unsigned int pos, len;
@@ -708,8 +708,8 @@ int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, 
 	}
 
 	prog = &syspage_common.progs[progID];
-	prog->start = (addr_t)start;
-	prog->end = (addr_t)end;
+	prog->start = start;
+	prog->end = end;
 	prog->dmap = dmapID;
 	prog->imap = imapID;
 
@@ -742,30 +742,30 @@ void syspage_setKernelEntry(addr_t addr)
 }
 
 
-void syspage_setKernelText(void *addr, size_t size)
+void syspage_setKernelText(addr_t addr, size_t size)
 {
-	syspage_common.syspage->kernel.text = (addr_t)addr;
+	syspage_common.syspage->kernel.text = addr;
 	syspage_common.syspage->kernel.textsz = size;
 
-	syspage_addEntries((addr_t)addr, size);
+	syspage_addEntries(addr, size);
 }
 
 
-void syspage_setKernelBss(void *addr, size_t size)
+void syspage_setKernelBss(addr_t addr, size_t size)
 {
-	syspage_common.syspage->kernel.bss = (addr_t)addr;
+	syspage_common.syspage->kernel.bss = addr;
 	syspage_common.syspage->kernel.bsssz = size;
 
-	syspage_addEntries((addr_t)addr, size);
+	syspage_addEntries(addr, size);
 }
 
 
-void syspage_setKernelData(void *addr, size_t size)
+void syspage_setKernelData(addr_t addr, size_t size)
 {
-	syspage_common.syspage->kernel.data = (addr_t)addr;
+	syspage_common.syspage->kernel.data = addr;
 	syspage_common.syspage->kernel.datasz = size;
 
-	syspage_addEntries((addr_t)addr, size);
+	syspage_addEntries(addr, size);
 }
 
 

--- a/syspage.c
+++ b/syspage.c
@@ -381,7 +381,7 @@ void syspage_showMaps(void)
 		return;
 	}
 
-	lib_printf(CONSOLE_BOLD "\n%-4s %-8s %-14s %-14s %-14s %-14s %s\n", "ID", "NAME", "START", "END", "STOP", "FREESZ", "ATTR");
+	lib_printf(CONSOLE_BOLD "\n%-4s %-8s %-14s %-14s %-14s %-14s %s\n", "ID", "NAME", "START", "END", "TOP", "FREESZ", "ATTR");
 	lib_printf(CONSOLE_NORMAL);
 	for (i = 0; i < syspage_common.mapsCnt; ++i) {
 		pmap = &syspage_common.maps[i];
@@ -487,6 +487,21 @@ int syspage_getMapTop(const char *map, void **addr)
 	}
 
 	*addr = (void *)syspage_common.maps[id].top;
+
+	return EOK;
+}
+
+
+int syspage_setMapTop(const char *map, void *addr)
+{
+	u8 id;
+
+	if (syspage_getMapID(map, &id) < 0) {
+		log_error("\nsyspage: %s does not exist", map);
+		return -EINVAL;
+	}
+
+	syspage_common.maps[id].top = (addr_t)addr;
 
 	return EOK;
 }

--- a/syspage.h
+++ b/syspage.h
@@ -33,6 +33,10 @@ enum { mAttrRead = 0x01, mAttrWrite = 0x02, mAttrExec = 0x04, mAttrShareable = 0
 enum { flagSyspageExec = 0x01 };
 
 
+/* syspage_validateAddrMap type of validation bitflags */
+enum { flagValidateTop = 0x01, flagValidateMap = 0x02, flagValidateAttr = 0x04 };
+
+
 /* Initialization function */
 extern void syspage_init(void);
 
@@ -60,6 +64,14 @@ extern void syspage_showApps(void);
 
 
 extern void syspage_showKernel(void);
+
+
+/* Validation */
+
+extern int syspage_validateAddrMap(unsigned int ftype, addr_t addr, u8 id, unsigned int attr);
+
+
+extern int syspage_validateKernel(addr_t *addr);
 
 
 /* Map's functions */
@@ -94,6 +106,9 @@ extern int syspage_addProg(void *start, void *end, const char *imap, const char 
 
 
 /* Setting kernel's data */
+
+extern void syspage_setKernelEntry(addr_t addr);
+
 
 extern void syspage_setKernelText(void *addr, size_t size);
 

--- a/syspage.h
+++ b/syspage.h
@@ -43,10 +43,10 @@ extern void syspage_init(void);
 
 /* Syspage's location functions */
 
-extern void syspage_setAddress(void *addr);
+extern void syspage_setAddress(addr_t addr);
 
 
-extern void *syspage_getAddress(void);
+extern addr_t syspage_getAddress(void);
 
 
 /* General functions */
@@ -76,13 +76,13 @@ extern int syspage_validateKernel(addr_t *addr);
 
 /* Map's functions */
 
-extern int syspage_addmap(const char *name, void *start, void *end, const char *attr);
+extern int syspage_addmap(const char *name, addr_t start, addr_t end, const char *attr);
 
 
-extern int syspage_getMapTop(const char *map, void **addr);
+extern int syspage_getMapTop(const char *map, addr_t *addr);
 
 
-extern int syspage_setMapTop(const char *map, void *addr);
+extern int syspage_setMapTop(const char *map, addr_t addr);
 
 
 extern int syspage_alignMapTop(const char *map);
@@ -102,7 +102,7 @@ extern int syspage_getMapAttr(const char *map, unsigned int *attr);
 
 /* Program's functions */
 
-extern int syspage_addProg(void *start, void *end, const char *imap, const char *dmap, const char *name, u32 flags);
+extern int syspage_addProg(addr_t start, addr_t end, const char *imap, const char *dmap, const char *name, u32 flags);
 
 
 /* Setting kernel's data */
@@ -110,13 +110,13 @@ extern int syspage_addProg(void *start, void *end, const char *imap, const char 
 extern void syspage_setKernelEntry(addr_t addr);
 
 
-extern void syspage_setKernelText(void *addr, size_t size);
+extern void syspage_setKernelText(addr_t addr, size_t size);
 
 
-extern void syspage_setKernelBss(void *addr, size_t size);
+extern void syspage_setKernelBss(addr_t addr, size_t size);
 
 
-extern void syspage_setKernelData(void *addr, size_t size);
+extern void syspage_setKernelData(addr_t addr, size_t size);
 
 
 /* Add specific hal data */

--- a/syspage.h
+++ b/syspage.h
@@ -70,6 +70,9 @@ extern int syspage_addmap(const char *name, void *start, void *end, const char *
 extern int syspage_getMapTop(const char *map, void **addr);
 
 
+extern int syspage_setMapTop(const char *map, void *addr);
+
+
 extern int syspage_alignMapTop(const char *map);
 
 


### PR DESCRIPTION
Two improvements within this pull request:
- add the ability to indicate an alias name to the `kernel` command like e.g. `kernel flash1 my-kernel` instead of hard-coded name `phoenix-armv7m7-imxrt106x.elf`.
- add kernel address validation in the `go` command if the kernel was properly loaded
- and a few minor fixes

JIRA: RTOS-43, RTOS-44, PD-89, PD-117