### PR TITLE
plo: fix interrupts and disable interrupts when ROM API is used

### DIFF
--- a/devices/flash-imxrt/romapi-imxrt106x.c
+++ b/devices/flash-imxrt/romapi-imxrt106x.c
@@ -38,47 +38,95 @@ static const flexspi_norDriverInterface_t *volatile const flexspi_norApi = (void
 
 int flexspi_norFlashInit(u32 instance, flexspi_norConfig_t *config)
 {
-	return flexspi_norApi->init(instance, config);
+	int res;
+
+	hal_interruptsDisable();
+	res = flexspi_norApi->init(instance, config);
+	hal_interruptsEnable();
+
+	return res;
 }
 
 
 int flexspi_norFlashPageProgram(u32 instance, flexspi_norConfig_t *config, u32 dstAddr, const u32 *src)
 {
-	return flexspi_norApi->program(instance, config, dstAddr, src);
+	int res;
+
+	hal_interruptsDisable();
+	res = flexspi_norApi->program(instance, config, dstAddr, src);
+	hal_interruptsEnable();
+
+	return res;
 }
 
 
 int flexspi_norFlashEraseAll(u32 instance, flexspi_norConfig_t *config)
 {
-	return flexspi_norApi->erase_all(instance, config);
+	int res;
+
+	hal_interruptsDisable();
+	res = flexspi_norApi->erase_all(instance, config);
+	hal_interruptsEnable();
+
+	return res;
 }
 
 
 int flexspi_norGetConfig(u32 instance, flexspi_norConfig_t *config, serial_norConfigOption_t *option)
 {
-	return flexspi_norApi->get_config(instance, config, option);
+	int res;
+
+	hal_interruptsDisable();
+	res = flexspi_norApi->get_config(instance, config, option);
+	hal_interruptsEnable();
+
+	return res;
 }
 
 
 int flexspi_norFlashErase(u32 instance, flexspi_norConfig_t *config, u32 start, u32 length)
 {
-	return flexspi_norApi->erase(instance, config, start, length);
+	int res;
+
+	hal_interruptsDisable();
+	res = flexspi_norApi->erase(instance, config, start, length);
+	hal_interruptsEnable();
+
+	return res;
 }
 
 
 int flexspi_norFlashRead(u32 instance, flexspi_norConfig_t *config, char *dst, u32 start, u32 bytes)
 {
-	return flexspi_norApi->read(instance, config, (u32 *)dst, start, bytes);
+	int res;
+
+	hal_interruptsDisable();
+	res = flexspi_norApi->read(instance, config, (u32 *)dst, start, bytes);
+	hal_interruptsEnable();
+
+	return res;
 }
 
 
 int flexspi_norFlashUpdateLUT(u32 instance, u32 seqIndex, const u32 *lutBase, u32 seqNumber)
 {
-	return flexspi_norApi->update_lut(instance, seqIndex, lutBase, seqNumber);
+	int res;
+
+	hal_interruptsDisable();
+	res = flexspi_norApi->update_lut(instance, seqIndex, lutBase, seqNumber);
+	hal_interruptsEnable();
+
+	return res;
 }
 
 
 int flexspi_norFlashExecuteSeq(u32 instance, flexspi_xfer_t *xfer)
 {
-	return flexspi_norApi->xfer(instance, xfer);
+	int res;
+
+	hal_interruptsDisable();
+	res = flexspi_norApi->xfer(instance, xfer);
+	hal_interruptsEnable();
+
+	return res;
 }

--- a/devices/flash-imxrt/romapi-imxrt117x.c
+++ b/devices/flash-imxrt/romapi-imxrt117x.c
@@ -52,47 +52,95 @@ static const bootloader_tree_t **volatile const bootloader_tree = (void *)FLEXSP
 
 int flexspi_norFlashInit(u32 instance, flexspi_norConfig_t *config)
 {
-	return (*bootloader_tree)->flexspiNorDriver->init(instance, config);
+	int res;
+
+	hal_interruptsDisable();
+	res = (*bootloader_tree)->flexspiNorDriver->init(instance, config);
+	hal_interruptsEnable();
+
+	return res;
 }
 
 
 int flexspi_norFlashPageProgram(u32 instance, flexspi_norConfig_t *config, u32 dstAddr, const u32 *src)
 {
-	return (*bootloader_tree)->flexspiNorDriver->page_program(instance, config, dstAddr, src);
+	int res;
+
+	hal_interruptsDisable();
+	res = (*bootloader_tree)->flexspiNorDriver->page_program(instance, config, dstAddr, src);
+	hal_interruptsEnable();
+
+	return res;
 }
 
 
 int flexspi_norFlashEraseAll(u32 instance, flexspi_norConfig_t *config)
 {
-	return (*bootloader_tree)->flexspiNorDriver->erase_all(instance, config);
+	int res;
+
+	hal_interruptsDisable();
+	res = (*bootloader_tree)->flexspiNorDriver->erase_all(instance, config);
+	hal_interruptsEnable();
+
+	return res;
 }
 
 
 int flexspi_norGetConfig(u32 instance, flexspi_norConfig_t *config, serial_norConfigOption_t *option)
 {
-	return (*bootloader_tree)->flexspiNorDriver->get_config(instance, config, option);
+	int res;
+
+	hal_interruptsDisable();
+	res = (*bootloader_tree)->flexspiNorDriver->get_config(instance, config, option);
+	hal_interruptsEnable();
+
+	return res;
 }
 
 
 int flexspi_norFlashErase(u32 instance, flexspi_norConfig_t *config, u32 start, u32 length)
 {
-	return (*bootloader_tree)->flexspiNorDriver->erase(instance, config, start, length);
+	int res;
+
+	hal_interruptsDisable();
+	res = (*bootloader_tree)->flexspiNorDriver->erase(instance, config, start, length);
+	hal_interruptsEnable();
+
+	return res;
 }
 
 
 int flexspi_norFlashRead(u32 instance, flexspi_norConfig_t *config, char *dst, u32 start, u32 bytes)
 {
-	return (*bootloader_tree)->flexspiNorDriver->read(instance, config, (u32 *)dst, start, bytes);
+	int res;
+
+	hal_interruptsDisable();
+	res = (*bootloader_tree)->flexspiNorDriver->read(instance, config, (u32 *)dst, start, bytes);
+	hal_interruptsEnable();
+
+	return res;
 }
 
 
 int flexspi_norFlashUpdateLUT(u32 instance, u32 seqIndex, const u32 *lutBase, u32 seqNumber)
 {
-	return (*bootloader_tree)->flexspiNorDriver->update_lut(instance, seqIndex, lutBase, seqNumber);
+	int res;
+
+	hal_interruptsDisable();
+	res = (*bootloader_tree)->flexspiNorDriver->update_lut(instance, seqIndex, lutBase, seqNumber);
+	hal_interruptsEnable();
+
+	return res;
 }
 
 
 int flexspi_norFlashExecuteSeq(u32 instance, flexspi_xfer_t *xfer)
 {
-	return (*bootloader_tree)->flexspiNorDriver->xfer(instance, xfer);
+	int res;
+
+	hal_interruptsDisable();
+	res = (*bootloader_tree)->flexspiNorDriver->xfer(instance, xfer);
+	hal_interruptsEnable();
+
+	return res;
 }

--- a/hal/armv7m/imxrt/10xx/_startup.S
+++ b/hal/armv7m/imxrt/10xx/_startup.S
@@ -49,7 +49,7 @@ _fcfb:
 .byte 0, 0, 0
 .word 0, 0, 0, 0 /* configCmdSeqs */
 .word 0, 0, 0, 0 /* cfgCmdArgs */
-.word 0x00000000 /* controllerMiscOption */
+.word 0x00000010 /* controllerMiscOption */
 .byte 0x1        /* deviceType */
 .byte 0x4        /* sflashPadType */
 .byte 0x8        /* serialClkFreq */
@@ -97,11 +97,11 @@ _fcfb:
 
 .word 0x00000100 /* pageSize */
 .word 0x00001000 /* sectorSize */
-.word 0x00000000 /* ipCmdSerialClkFreq */
+.word 0x00000001 /* ipCmdSerialClkFreq */
 .word 0x00000000
 
 /* reserved */
-.word 0x00000000, 0x00000000, 0x00000000, 0x00000000
+.word 0x00010000, 0x00000000, 0x00000000, 0x00000000
 .word 0x00000000, 0x00000000, 0x00000000, 0x00000000
 .word 0x00000000, 0x00000000, 0x00000000, 0x00000000
 
@@ -195,9 +195,9 @@ _plo:
     /* Init vector table and stack pointer */
     ldr r0, =0xe000ed08
     ldr r1, =_init_vectors
-
     str r1, [r0]
     ldr r0, [r1]
+    bic r0, 7
     msr msp, r0
     ldr r8, =_startc
     bx r8
@@ -210,15 +210,11 @@ _plo:
 .type _interrupts_dispatch, %function
 _interrupts_dispatch:
     mrs r0, ipsr
-    sub r1, sp, #44
-    stmdb sp!, {r1-r2, r4-r11, lr}
-
-_intd0:
+    stmdb sp!, {r0, r4-r11, lr}
     bl hal_irqdispatch
-    ldr sp, [sp]
-_intd1:
-    ldmia sp!, {r0-r1, r4-r11, lr}
-	dmb
+    ldmia sp!, {r0, r4-r11, lr}
+    dmb
+
     bx lr
 .size _interrupts_dispatch, .-_interrupts_dispatch
 .ltorg

--- a/hal/armv7m/imxrt/10xx/_startup.S
+++ b/hal/armv7m/imxrt/10xx/_startup.S
@@ -109,40 +109,40 @@ _fcfb:
 .org _fcfb + 0x1000, 0xff
 
 ivt_flash:
-    .word 0x412000d1                         /* hdr */
-    .word _start                             /* entry */
-    .word 0                                  /* reserved 1 */
-    .word 0                                  /* dcd */
-    .word flash_boot_data                    /* boot_data */
-    .word ivt_flash                          /* self */
-    .word 0                                  /* csf */
-    .word 0                                  /* reserved 2 */
+	.word 0x412000d1                         /* hdr */
+	.word _start                             /* entry */
+	.word 0                                  /* reserved 1 */
+	.word 0                                  /* dcd */
+	.word flash_boot_data                    /* boot_data */
+	.word ivt_flash                          /* self */
+	.word 0                                  /* csf */
+	.word 0                                  /* reserved 2 */
 
 flash_boot_data:
-    .word FLEXSPI2_BASE                      /* load address */
-    .word _etext - _fcfb                     /* size */
-    .word 0                                  /* plugin */
-    .word 0xffffffff                         /* empty - extra data word */
+	.word FLEXSPI2_BASE                      /* load address */
+	.word _etext - _fcfb                     /* size */
+	.word 0                                  /* plugin */
+	.word 0xffffffff                         /* empty - extra data word */
 
 ivt_flash_end:
 
 .org _fcfb + 0x1050, 0xff
 
 ivt:
-    .word 0x412000d1                         /* hdr */
-    .word _start                             /* entry */
-    .word 0                                  /* reserved 1 */
-    .word 0                                  /* dcd */
-    .word boot_data                          /* boot_data */
-    .word ivt                                /* self */
-    .word 0                                  /* csf */
-    .word 0                                  /* reserved 2 */
+	.word 0x412000d1                         /* hdr */
+	.word _start                             /* entry */
+	.word 0                                  /* reserved 1 */
+	.word 0                                  /* dcd */
+	.word boot_data                          /* boot_data */
+	.word ivt                                /* self */
+	.word 0                                  /* csf */
+	.word 0                                  /* reserved 2 */
 
 boot_data:
-    .word ADDR_ITCM                          /* load address */
-    .word _etext - _fcfb                     /* size */
-    .word 0                                  /* plugin */
-    .word 0xffffffff
+	.word ADDR_ITCM                          /* load address */
+	.word _etext - _fcfb                     /* size */
+	.word 0                                  /* plugin */
+	.word 0xffffffff
 
 ivt_end:
 
@@ -181,26 +181,26 @@ _init_vectors:
 .globl _start
 .type _start, %function
 _start:
-    cpsid if
+	cpsid if
 
-    /* Configure FLEX RAM */
-    ldr r8, =IOMUXC_GPR
-    ldr r9, =0x00200007
-    str r9, [r8, #0x40]
+	/* Configure FLEX RAM */
+	ldr r8, =IOMUXC_GPR
+	ldr r9, =0x00200007
+	str r9, [r8, #0x40]
 
-    ldr r9, =0xaabfffff
-    str r9, [r8, #0x44]
+	ldr r9, =0xaabfffff
+	str r9, [r8, #0x44]
 
 _plo:
-    /* Init vector table and stack pointer */
-    ldr r0, =0xe000ed08
-    ldr r1, =_init_vectors
-    str r1, [r0]
-    ldr r0, [r1]
-    bic r0, 7
-    msr msp, r0
-    ldr r8, =_startc
-    bx r8
+	/* Init vector table and stack pointer */
+	ldr r0, =0xe000ed08
+	ldr r1, =_init_vectors
+	str r1, [r0]
+	ldr r0, [r1]
+	bic r0, 7
+	msr msp, r0
+	ldr r8, =_startc
+	bx r8
 
 .size _start, .-_start
 .ltorg
@@ -209,13 +209,13 @@ _plo:
 .globl _interrupts_dispatch
 .type _interrupts_dispatch, %function
 _interrupts_dispatch:
-    mrs r0, ipsr
-    stmdb sp!, {r0, r4-r11, lr}
-    bl hal_irqdispatch
-    ldmia sp!, {r0, r4-r11, lr}
-    dmb
+	mrs r0, ipsr
+	stmdb sp!, {r0, r4-r11, lr}
+	bl hal_irqdispatch
+	ldmia sp!, {r0, r4-r11, lr}
+	dmb
 
-    bx lr
+	bx lr
 .size _interrupts_dispatch, .-_interrupts_dispatch
 .ltorg
 
@@ -224,8 +224,8 @@ _interrupts_dispatch:
 .type _exceptions_dispatch, %function
 
 _exceptions_dispatch:
-    cpsid if
-    /* TODO: implement exception dispatcher */
-    1: b 1b
+	cpsid if
+	/* TODO: implement exception dispatcher */
+	1: b 1b
 .size _exceptions_dispatch, .-_exceptions_dispatch
 .ltorg

--- a/hal/armv7m/imxrt/10xx/hal.c
+++ b/hal/armv7m/imxrt/10xx/hal.c
@@ -51,6 +51,8 @@ void hal_init(void)
 	syspage_init();
 	syspage_setAddress(SYSPAGE_ADDRESS);
 
+	_imxrt_scbSetPriorityGrouping(3);
+
 	/* Add entries related to plo image */
 	syspage_addEntries((addr_t)_plo_bss, (addr_t)_end - (addr_t)_plo_bss + STACK_SIZE);
 }
@@ -143,7 +145,7 @@ int hal_interruptsSet(unsigned int irq, int (*isr)(unsigned int, void *), void *
 		_imxrt_nvicSetIRQ(irq - 0x10, 0);
 	}
 	else {
-		_imxrt_nvicSetPriority(irq - 0x10, 1);
+		_imxrt_nvicSetPriority(irq - 0x10, 0);
 		_imxrt_nvicSetIRQ(irq - 0x10, 1);
 	}
 	hal_interruptsEnable();

--- a/hal/armv7m/imxrt/117x/_startup.S
+++ b/hal/armv7m/imxrt/117x/_startup.S
@@ -204,6 +204,7 @@ _start:
 
 	str r1, [r0]
 	ldr r0, [r1]
+	bic r0, 7
 	msr msp, r0
 	ldr r8, =_startc
 	bx r8
@@ -215,19 +216,12 @@ _start:
 .globl _interrupts_dispatch
 .type _interrupts_dispatch, %function
 _interrupts_dispatch:
-	cpsid if
-
 	mrs r0, ipsr
-	sub r1, sp, #44
-	stmdb sp!, {r1-r2, r4-r11, lr}
-
-_intd0:
+	stmdb sp!, {r0, r4-r11, lr}
 	bl hal_irqdispatch
-	ldr sp, [sp]
-_intd1:
-	ldmia sp!, {r0-r1, r4-r11, lr}
+	ldmia sp!, {r0, r4-r11, lr}
+	dmb
 
-	cpsie if
 	bx lr
 .size _interrupts_dispatch, .-_interrupts_dispatch
 .ltorg


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- change interrupts priority for imxrt106x,
- fix interrupt dispatch for imxrt,
- disable interrupts while ROM API is used.

JIRA: PD-123

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When `copy` command form usb0 to flash1 is proceeded by many `app usb0` command, the exception is called. This behavior only occurs during access to internal flash.
At the same time there are interrupts from usb, timer and uart.
The same problem was described on NXP forum:
https://community.nxp.com/t5/i-MX-RT/Programming-the-internal-Flash-of-RT1064/m-p/883989

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt106x).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
