### PR TITLE
cmd/script: usage without arguments shows preinit script

### DIFF
--- a/cmds/script.c
+++ b/cmds/script.c
@@ -24,7 +24,7 @@ extern char script[];
 
 static void cmd_scriptInfo(void)
 {
-	lib_printf("shows script, usage: script <preinit/name> [dev] [magic]");
+	lib_printf("shows script, usage: script [<dev> <name> <magic>]");
 }
 
 
@@ -36,23 +36,13 @@ static int cmd_script(int argc, char *argv[])
 	char buff[SIZE_CMD_ARG_LINE];
 
 	if (argc == 1) {
-		log_error("\n%s: Arguments have to be defined", argv[0]);
-		return -EINVAL;
+		lib_printf(CONSOLE_BOLD "\nPreinit script:");
+		lib_printf(CONSOLE_NORMAL "\n%s", (char *)script);
+		return EOK;
 	}
-	else if (argc != 2 && argc != 4) {
+	else if (argc != 4) {
 		log_error("\n%s: Wrong argument count", argv[0]);
 		return -EINVAL;
-	}
-
-	if (hal_strcmp(argv[1], "preinit") == 0) {
-		lib_printf("\n%s", (char *)script);
-		return EOK;
-	}
-
-	/* Show user script */
-	if (argc != 4) {
-		log_error("\nProvide device and magic number for %s", argv[1]);
-		return EOK;
 	}
 
 	if ((res = phfs_open(argv[1], argv[2], 0, &h)) < 0) {
@@ -73,7 +63,8 @@ static int cmd_script(int argc, char *argv[])
 		return -EINVAL;
 	}
 
-	lib_printf("\n");
+	lib_printf(CONSOLE_BOLD "\nScript - %s:", argv[2]);
+	lib_printf(CONSOLE_NORMAL);
 	do {
 		if ((res = phfs_read(h, offs, (u8 *)buff, SIZE_CMD_ARG_LINE)) < 0) {
 			log_error("\nCan't read %s from %s", argv[2], argv[1]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Command `script` without any arguments shows preinit script. Otherwise, the device, script's name and magic number is needed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Unification of commands.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (imxrt1064).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
