### PR TITLE
hal/armv7m: fix setting interrupts

### DIFF
--- a/hal/armv7m/imxrt/10xx/imxrt.c
+++ b/hal/armv7m/imxrt/10xx/imxrt.c
@@ -1499,7 +1499,10 @@ u32 _imxrt_scbGetPriority(s8 excpn)
 void _imxrt_nvicSetIRQ(s8 irqn, u8 state)
 {
 	volatile u32 *ptr = imxrt_common.nvic + ((u8)irqn >> 5) + (state ? nvic_iser : nvic_icer);
-	*ptr |= 1 << (irqn & 0x1F);
+	*ptr = 1 << (irqn & 0x1F);
+
+	imxrt_dataSyncBarrier();
+	imxrt_dataInstrBarrier();
 }
 
 
@@ -1513,7 +1516,7 @@ u32 _imxrt_nvicGetPendingIRQ(s8 irqn)
 void _imxrt_nvicSetPendingIRQ(s8 irqn, u8 state)
 {
 	volatile u32 *ptr = imxrt_common.nvic + ((u8)irqn >> 5) + (state ? nvic_ispr : nvic_icpr);
-	*ptr |= 1 << (irqn & 0x1F);
+	*ptr = 1 << (irqn & 0x1F);
 }
 
 

--- a/hal/armv7m/imxrt/117x/imxrt.c
+++ b/hal/armv7m/imxrt/117x/imxrt.c
@@ -281,7 +281,10 @@ u32 _imxrt_scbGetPriority(s8 excpn)
 void _imxrt_nvicSetIRQ(s8 irqn, u8 state)
 {
 	volatile u32 *ptr = imxrt_common.nvic + ((u8)irqn >> 5) + (state ? nvic_iser : nvic_icer);
-	*ptr |= 1 << (irqn & 0x1F);
+	*ptr = 1 << (irqn & 0x1F);
+
+	imxrt_dataSyncBarrier();
+	imxrt_dataInstrBarrier();
 }
 
 
@@ -295,7 +298,7 @@ u32 _imxrt_nvicGetPendingIRQ(s8 irqn)
 void _imxrt_nvicSetPendingIRQ(s8 irqn, u8 state)
 {
 	volatile u32 *ptr = imxrt_common.nvic + ((u8)irqn >> 5) + (state ? nvic_ispr : nvic_icpr);
-	*ptr |= 1 << (irqn & 0x1F);
+	*ptr = 1 << (irqn & 0x1F);
 }
 
 


### PR DESCRIPTION
JIRA: PD-131

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
While interrupt is cleared, it shouldn't be done using logical OR operation. It causes that several other interrupts might be cleared as well.

https://developer.arm.com/documentation/dui0646/c/cortex-m7-peripherals/nested-vectored-interrupt-controller/interrupt-clear-enable-registers?lang=en
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (imxrt106x).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
