### PR TITLE
devices: clean up devices before jump to kernel

### DIFF
--- a/cmds/go.c
+++ b/cmds/go.c
@@ -15,6 +15,7 @@
 
 #include "cmd.h"
 
+#include <devices/devs.h>
 #include <syspage.h>
 #include <hal/hal.h>
 #include <lib/log.h>
@@ -44,7 +45,7 @@ static int cmd_go(int argc, char *argv[])
 
 	log_info("\nRunning Phoenix-RTOS");
 	lib_printf(CONSOLE_NORMAL CONSOLE_CLEAR CONSOLE_CURSOR_SHOW);
-
+	devs_done();
 	hal_cpuJump(kernel_entry);
 	return EOK;
 }

--- a/devices/uart-imxrt106x/uart.c
+++ b/devices/uart-imxrt106x/uart.c
@@ -546,6 +546,10 @@ static int uart_done(unsigned int minor)
 	if ((uart = uart_getInstance(minor)) == NULL)
 		return -EINVAL;
 
+	/* Wait for transmission activity complete */
+	while ((*(uart->base + statr) & (1 << 22)) == 0)
+		;
+
 	/* Disable TX and RX */
 	*(uart->base + ctrlr) &= ~((1 << 19) | (1 << 18));
 	imxrt_dataBarrier();

--- a/devices/uart-imxrt117x/uart.c
+++ b/devices/uart-imxrt117x/uart.c
@@ -561,6 +561,10 @@ static int uart_done(unsigned int minor)
 	if ((uart = uart_getInstance(minor)) == NULL)
 		return -EINVAL;
 
+	/* Wait for transmission activity complete */
+	while ((*(uart->base + statr) & (1 << 22)) == 0)
+		;
+
 	/* disable TX and RX */
 	*(uart->base + ctrlr) &= ~((1 << 19) | (1 << 18));
 	*(uart->base + ctrlr) &= ~((1 << 23) | (1 << 21));

--- a/devices/uart-zynq7000/uart.c
+++ b/devices/uart-zynq7000/uart.c
@@ -331,6 +331,8 @@ static int uart_done(unsigned int minor)
 
 	uart = &uart_common.uarts[minor];
 
+	/* TODO: wait for end of transmission */
+
 	/* Disable interrupts */
 	*(uart->base + idr) = 0xfff;
 

--- a/hal/armv7a/zynq7000/hal.c
+++ b/hal/armv7a/zynq7000/hal.c
@@ -88,12 +88,7 @@ addr_t hal_kernelGetAddress(addr_t addr)
 
 int hal_cpuJump(addr_t addr)
 {
-	time_t start;
 	syspage_save();
-
-	/* Give the LPUART transmitters some time */
-	start = hal_timerGet();
-	while ((hal_timerGet() - start) < 100);
 
 	/* Tidy up */
 	hal_done();

--- a/hal/armv7m/imxrt/10xx/hal.c
+++ b/hal/armv7m/imxrt/10xx/hal.c
@@ -98,13 +98,7 @@ addr_t hal_kernelGetAddress(addr_t addr)
 
 int hal_cpuJump(addr_t addr)
 {
-	time_t start;
-
 	syspage_save();
-
-	/* Give the LPUART transmitters some time */
-	start = hal_timerGet();
-	while ((hal_timerGet() - start) < 100);
 
 	/* Tidy up */
 	hal_done();

--- a/hal/armv7m/imxrt/117x/hal.c
+++ b/hal/armv7m/imxrt/117x/hal.c
@@ -90,13 +90,7 @@ addr_t hal_kernelGetAddress(addr_t addr)
 
 int hal_cpuJump(addr_t addr)
 {
-	time_t start;
-
 	syspage_save();
-
-	/* Give the LPUART transmitters some time */
-	start = hal_timerGet();
-	while ((hal_timerGet() - start) < 100);
 
 	/* Tidy up */
 	hal_done();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Invoke `dev_done()` before jump to phoenix-rtos-kernel.

JIRA: PD-137

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Interrupts from devices should be disabled before jumping to kernel.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (imxrt106x).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
