### PR TITLE
cmds/script: array index out of range has been fixed

### DIFF
--- a/cmds/script.c
+++ b/cmds/script.c
@@ -66,7 +66,7 @@ static int cmd_script(int argc, char *argv[])
 	lib_printf(CONSOLE_BOLD "\nScript - %s:", argv[2]);
 	lib_printf(CONSOLE_NORMAL);
 	do {
-		if ((res = phfs_read(h, offs, buff, SIZE_CMD_ARG_LINE)) < 0) {
+		if ((res = phfs_read(h, offs, buff, SIZE_CMD_ARG_LINE - 1)) < 0) {
 			log_error("\nCan't read %s from %s", argv[2], argv[1]);
 			return res;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This PR fixes an index outside the range of the array.
Array `buff` is defined as:
```
	char buff[SIZE_CMD_ARG_LINE];
```
in loop
```
do {
		if ((res = phfs_read(h, offs, (u8 *)buff, SIZE_CMD_ARG_LINE)) < 0) {
			log_error("\nCan't read %s from %s", argv[2], argv[1]);
			return res;
		}
		buff[res] = '\0';
		lib_printf(buff);
		offs += res;
	} while (res > 0);
```
if `res == SIZE_CMD_ARG`
`buff[res] = '\0'` is out of range.

Alternatively, define the array as:
```
	char buff[SIZE_CMD_ARG_LINE + 1];
```


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
