### PR TITLE
cmds/cmd.c: changed reading command prompt character timeout to infinite

### DIFF
--- a/cmds/cmd.c
+++ b/cmds/cmd.c
@@ -21,9 +21,8 @@
 #include <lib/ctype.h>
 
 
-#define SIZE_HIST          8
-#define SIZE_CMDS          24
-#define TIMEOUT_CONSOLE_MS 200
+#define SIZE_HIST 8
+#define SIZE_CMDS 24
 
 #define PROMPT "(plo)% "
 
@@ -168,8 +167,7 @@ void cmd_prompt(void)
 
 	lib_printf("\n%s", PROMPT);
 	while (c != '#') {
-		while (console_getc(&c, TIMEOUT_CONSOLE_MS) <= 0)
-			;
+		console_getc(&c, -1);
 
 		sc = 0;
 		/* Translate backspace */
@@ -178,13 +176,11 @@ void cmd_prompt(void)
 		}
 		/* Simple parser for VT100 commands */
 		else if (c == 27) {
-			while (console_getc(&c, TIMEOUT_CONSOLE_MS) <= 0)
-				;
+			console_getc(&c, -1);
 
 			switch (c) {
 				case 91:
-					while (console_getc(&c, TIMEOUT_CONSOLE_MS) <= 0)
-						;
+					console_getc(&c, -1);
 
 					switch (c) {
 						case 'A': /* UP */

--- a/lib/console.c
+++ b/lib/console.c
@@ -35,7 +35,7 @@ void console_puts(const char *s)
 		return;
 	}
 
-	devs_write(console_common.major, console_common.minor, 0, (const u8 *)s, hal_strlen(s));
+	devs_write(console_common.major, console_common.minor, 0, s, hal_strlen(s));
 }
 
 
@@ -48,11 +48,11 @@ void console_putc(char c)
 		return;
 	}
 
-	devs_write(console_common.major, console_common.minor, 0, (const u8 *)&data, 1);
+	devs_write(console_common.major, console_common.minor, 0, &data, 1);
 }
 
 
-int console_getc(char *c, unsigned int timeout)
+int console_getc(char *c, time_t timeout)
 {
 	if (!console_common.init) {
 		console_puts(CONSOLE_RED);
@@ -61,7 +61,7 @@ int console_getc(char *c, unsigned int timeout)
 		for (;;);
 	}
 
-	return devs_read(console_common.major, console_common.minor, 0, (u8 *)c, 1, timeout);
+	return devs_read(console_common.major, console_common.minor, 0, c, 1, timeout);
 }
 
 

--- a/lib/console.h
+++ b/lib/console.h
@@ -44,7 +44,7 @@ extern void console_putc(char c);
 
 
 /* Function gets char */
-extern int console_getc(char *c, unsigned int timeout);
+extern int console_getc(char *c, time_t timeout);
 
 
 #endif

--- a/phfs/msg.c
+++ b/phfs/msg.c
@@ -66,7 +66,7 @@ static int msg_write(unsigned int major, unsigned int minor, msg_t *msg)
 }
 
 
-static int msg_read(unsigned int major, unsigned int minor, msg_t *msg, u16 timeout, int *state)
+static int msg_read(unsigned int major, unsigned int minor, msg_t *msg, time_t timeout, int *state)
 {
 	u8 c;
 	u8 buff[MSG_HDRSZ + MSG_MAXLEN];
@@ -74,7 +74,7 @@ static int msg_read(unsigned int major, unsigned int minor, msg_t *msg, u16 time
 	unsigned int l = 0;
 
 	for (;;) {
-		if ((res = devs_read(major, minor, 0, buff, sizeof(buff), MSGRECV_TIMEOUT)) < 0)
+		if ((res = devs_read(major, minor, 0, buff, sizeof(buff), timeout)) < 0)
 			break;
 
 		for (i = 0; i < res; ++i) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Changed command prompt character read timeout to infinite value.
Fixed missing interface changes from [ Clean up standard functions interface #106 ](https://github.com/phoenix-rtos/plo/pull/106)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cleaner code + there is additional benefit of blocking character read when using tty-bios on ia32-generic target (no busy waiting for character).
[JIRA: PD-152](https://jira.phoenix-rtos.com/browse/PD-152)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
