### PR TITLE
imxrt/10xx: Change FlexRam setting by increasing dtcm and decreasing …

### DIFF
--- a/hal/armv7m/imxrt/10xx/_init.S
+++ b/hal/armv7m/imxrt/10xx/_init.S
@@ -188,7 +188,7 @@ _start:
 	ldr r9, =0x00200007
 	str r9, [r8, #0x40]
 
-	ldr r9, =0xaabfffff
+	ldr r9, =0xaaaaabff
 	str r9, [r8, #0x44]
 
 _plo:


### PR DESCRIPTION
…itcm

Increase dtcm size from 160 kB to 352 kB and decrease itcm from 352 kB
to 160 kB. This change is needed in order to run usb stack, which
requires non-cachable memory for its buffers.

JIRA: RTOS-21

<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes shortly -->
This change amends flexRam setting in order to increase dtcm size.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In my project I need more dtcm memory, which is not cachable for the usb stack. The whole set of programs including kernel uses 216 kB of dtcm and only 122 kB of itcm. This change would also be beneficial in the future, as we are planning to run more programs, which would also increase the kernel's dtcm usage.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->
In dependent projects we need to change memory map settings for itcm and dtcm.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
Additional PRs:
https://github.com/phoenix-rtos/phoenix-rtos-hostutils/pull/26
https://github.com/phoenix-rtos/phoenix-rtos-project/pull/148