### PR TITLE
syspage.c: disable top validation in syspage_validateAddrMap()

### DIFF
--- a/syspage.c
+++ b/syspage.c
@@ -446,9 +446,11 @@ int syspage_validateAddrMap(unsigned int opt, addr_t addr, u8 id, unsigned int a
 		pmap = &syspage_common.maps[i];
 
 		if (addr >= pmap->map.start && addr < pmap->map.end) {
+#if 0
 			/* optional check if addr is below map top */
 			if ((opt & flagValidateTop) != 0 && addr >= pmap->top)
 				break;
+#endif
 
 			/* optional check of map id */
 			if ((opt & flagValidateMap) != 0 && id != i)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Disabled top relative map address validation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In syspage_validateKernel() we check if `kernel.text` and `kernel_entry` are below their map top address (I believe they don't have to be). I'm not sure why we have this check so I disabled it for now. The change is required for kernel jump to work on new plo for ia32-generic.
[JIRA: PD-97](https://jira.phoenix-rtos.com/browse/PD-97)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
