### PR TITLE
tty-bios/console-vga: replace BIOS int 0x10 console with direct VGA memory access

### DIFF
--- a/hal/ia32/hal.c
+++ b/hal/ia32/hal.c
@@ -40,24 +40,9 @@ addr_t hal_kernelGetAddress(addr_t addr)
 }
 
 
-/* Sets video mode */
-static void hal_setMode(unsigned char mode)
-{
-	__asm__ volatile(
-		"pushl $0x10; "
-		"pushl $0x0; "
-		"pushl $0x0; "
-		"call _interrupts_bios; "
-		"addl $0xc, %%esp; "
-	:: "a" (mode)
-	: "memory", "cc");
-}
-
-
 void hal_done(void)
 {
-	/* Restore default text mode */
-	hal_setMode(0x3);
+	return;
 }
 
 
@@ -68,7 +53,4 @@ void hal_init(void)
 	hal_interruptsInit();
 	hal_memoryInit();
 	hal_timerInit();
-
-	/* Set graphics video mode (required for writing characters with color attribute via BIOS 0x10 interrupt) */
-	hal_setMode(0x12);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Replaced BIOS int 0x10 usage with direct VGA memory access.
 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The console felt sluggish.
[JIRA: PD-169](https://jira.phoenix-rtos.com/browse/PD-169)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
