### PR TITLE
ia32: code for memmove function has been corrected

### DIFF
--- a/devices/tty-bios/tty-bios.c
+++ b/devices/tty-bios/tty-bios.c
@@ -98,8 +98,10 @@ static void ttybios_memmove(volatile u16 *dst, volatile u16 *src, unsigned int n
 			dst[i] = src[i];
 	}
 	else {
-		for (i = n; i--;)
-			dst[i] = src[i];
+		while (n) {
+			n--;
+			dst[n] = src[n];
+		}
 	}
 }
 

--- a/hal/ia32/console-vga.c
+++ b/hal/ia32/console-vga.c
@@ -70,8 +70,10 @@ static void console_memmove(volatile u16 *dst, volatile u16 *src, unsigned int n
 			dst[i] = src[i];
 	}
 	else {
-		for (i = n; i--;)
-			dst[i] = src[i];
+		while (n) {
+			n--;
+			dst[n] = src[n];
+		}
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This PR corrects the copying from the end to the beginning.
Now elements from `src[n]` to `src[1]` are copied, and it should be copying from `src[n-1]` to `src[0]`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
