### PR TITLE
tty-bios/console-vga: fix \b moving cursor to the previous row + rename 'curs' variable to 'pos'

### DIFF
--- a/devices/tty-bios/tty-bios.c
+++ b/devices/tty-bios/tty-bios.c
@@ -3,7 +3,7 @@
  *
  * Operating system loader
  *
- * Terminal emulator (based on BIOS 0x16 interrupt for data input)
+ * Terminal emulator (based on BIOS 0x16 interrupt call for data input)
  *
  * Copyright 2012, 2020, 2021 Phoenix Systems
  * Copyright 2001, 2005 Pawel Pisarczyk
@@ -214,7 +214,7 @@ static ssize_t ttybios_read(unsigned int minor, addr_t offs, void *buff, size_t 
 static ssize_t ttybios_write(unsigned int minor, addr_t offs, const void *buff, size_t len)
 {
 	ttybios_t *tty;
-	unsigned int i, row, col, curs;
+	unsigned int i, row, col, pos;
 	size_t n;
 	char c;
 
@@ -223,11 +223,11 @@ static ssize_t ttybios_write(unsigned int minor, addr_t offs, const void *buff, 
 
 	/* Print from current cursor position */
 	hal_outb(tty->crtc, 0x0f);
-	curs = hal_inb((void *)((addr_t)tty->crtc + 1));
+	pos = hal_inb((void *)((addr_t)tty->crtc + 1));
 	hal_outb(tty->crtc, 0x0e);
-	curs |= (u16)hal_inb((void *)((addr_t)tty->crtc + 1)) << 8;
-	row = curs / tty->cols;
-	col = curs % tty->cols;
+	pos |= (u16)hal_inb((void *)((addr_t)tty->crtc + 1)) << 8;
+	row = pos / tty->cols;
+	col = pos % tty->cols;
 
 	for (n = 0; n < len; n++) {
 		c = *((char *)buff + n);
@@ -242,7 +242,7 @@ static ssize_t ttybios_write(unsigned int minor, addr_t offs, const void *buff, 
 					}
 					else if (row) {
 						row--;
-						col = tty->cols;
+						col = tty->cols - 1;
 					}
 					break;
 

--- a/hal/ia32/console-vga.c
+++ b/hal/ia32/console-vga.c
@@ -78,16 +78,16 @@ static void console_memmove(volatile u16 *dst, volatile u16 *src, unsigned int n
 
 void hal_consolePrint(const char *s)
 {
-	unsigned int i, row, col, curs;
+	unsigned int i, row, col, pos;
 	char c;
 
 	/* Print from current cursor position */
 	hal_outb(halconsole_common.crtc, 0x0f);
-	curs = hal_inb((void *)((addr_t)halconsole_common.crtc + 1));
+	pos = hal_inb((void *)((addr_t)halconsole_common.crtc + 1));
 	hal_outb(halconsole_common.crtc, 0x0e);
-	curs |= (u16)hal_inb((void *)((addr_t)halconsole_common.crtc + 1)) << 8;
-	row = curs / halconsole_common.cols;
-	col = curs % halconsole_common.cols;
+	pos |= (u16)hal_inb((void *)((addr_t)halconsole_common.crtc + 1)) << 8;
+	row = pos / halconsole_common.cols;
+	col = pos % halconsole_common.cols;
 
 	while ((c = *s++)) {
 		/* Control character */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Bug fix to changes introduced in the previous commit + renamed variable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `\b` key doesn't move cursor to the previous row.
[JIRA: PD-169](https://jira.phoenix-rtos.com/browse/PD-169)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
