### PR TITLE
imxrt/117x: add usb physical layer

### DIFF
--- a/devices/usbc-cdc/usbphy-imxrt106x.c
+++ b/devices/usbc-cdc/usbphy-imxrt106x.c
@@ -3,7 +3,7 @@
  *
  * Operating system loader
  *
- * USB physical layer controller
+ * i.MX RT106x USB physical layer controller
  *
  * Copyright 2021 Phoenix Systems
  * Author: Hubert Buczynski
@@ -17,8 +17,8 @@
 #include "usbphy.h"
 
 
-/* Memory size for endpoints and setup data */
-#define BUFF_SIZE (ENDPOINTS_DIR_NB * ENDPOINTS_NUMBER + 1) * USB_BUFFER_SIZE
+/* Size of memory pool aligned to USB_BUFFER_SIZE, used by USB descriptors */
+#define USB_POOL_SIZE (ENDPOINTS_DIR_NB * ENDPOINTS_NUMBER + 1) * USB_BUFFER_SIZE
 
 
 enum {
@@ -41,33 +41,32 @@ enum {
 
 
 struct {
-	__attribute__((aligned(USB_BUFFER_SIZE))) u8 data[BUFF_SIZE];
-	u32 buffCounter;
+	u8 pool[USB_POOL_SIZE] __attribute__((aligned(USB_BUFFER_SIZE)));
+	size_t usedPools;
 } phyusb_common;
 
 
 void *usbclient_allocBuff(u32 size)
 {
-	void *mem;
+	size_t org = USB_BUFFER_SIZE * phyusb_common.usedPools;
 
-	if ((size % USB_BUFFER_SIZE) || (USB_BUFFER_SIZE * phyusb_common.buffCounter + size) > BUFF_SIZE)
+	if ((size % USB_BUFFER_SIZE) != 0 || org + size > USB_POOL_SIZE)
 		return NULL;
 
-	mem = (void *)(&phyusb_common.data[USB_BUFFER_SIZE * phyusb_common.buffCounter]);
-	phyusb_common.buffCounter += size / USB_BUFFER_SIZE;
+	phyusb_common.usedPools += size / USB_BUFFER_SIZE;
 
-	return mem;
+	return &phyusb_common.pool[org];
 }
 
 
 void usbclient_buffReset(void)
 {
-	phyusb_common.buffCounter = 0;
+	phyusb_common.usedPools = 0;
 }
 
 void *phy_getBase(void)
 {
-	return (void *)USB0_BASE_ADDR;
+	return USB0_BASE_ADDR;
 }
 
 
@@ -114,7 +113,7 @@ void phy_reset(void)
 
 void phy_init(void)
 {
-	phyusb_common.buffCounter = 0;
+	phyusb_common.usedPools = 0;
 
 	phy_setClock();
 	phy_initPad();

--- a/devices/usbc-cdc/usbphy-imxrt117x.c
+++ b/devices/usbc-cdc/usbphy-imxrt117x.c
@@ -1,0 +1,162 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system loader
+ *
+ * i.MX RT117x USB physical layer controller
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Gerard Swiderski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include "client.h"
+#include "usbphy.h"
+
+
+/* Size of memory pool aligned to USB_BUFFER_SIZE, used by USB descriptors */
+#define USB_POOL_SIZE ((ENDPOINTS_DIR_NB * ENDPOINTS_NUMBER + 1) * USB_BUFFER_SIZE)
+
+
+static struct {
+	u8 pool[USB_POOL_SIZE] __attribute__((aligned(USB_BUFFER_SIZE)));
+	size_t usedPools;
+} phyusb_common;
+
+
+enum {
+	/* Power-Down Register */
+	usbphy_pwd = 0, usbphy_pwd_set, usbphy_pwd_clr, usbphy_pwd_tog,
+	/* Transmitter & Receiver Control Registers */
+	usbphy_tx, usbphy_tx_set, usbphy_tx_clr, usbphy_tx_tog,
+	usbphy_rx, usbphy_rx_set, usbphy_rx_clr, usbphy_rx_tog,
+	/* General Control Register */
+	usbphy_ctrl, usbphy_ctrl_set, usbphy_ctrl_clr, usbphy_ctrl_tog,
+	/* USB Status & Debug Registers */
+	usbphy_status,
+	usbphy_debug = 20, usbphy_debug_set, usbphy_debug_clr, usbphy_debug_tog,
+	/* UTMI Status & Debug Registers */
+	usbphy_debug0_status, usbphy_debug1 = 28,
+	usbphy_debug1_set, usbphy_debug1_clr, usbphy_debug1_tog,
+	/* UTMI RTL */
+	usbphy_version,
+	/* PLL Control & Status */
+	usbphy_pll_sic = 40, usbphy_pll_sic_set, usbphy_pll_sic_clr, usbphy_pll_sic_tog,
+	/* VBUS Detector Control */
+	usbphy_vbus_detect = 48,
+	usbphy_vbus_detect_set, usbphy_vbus_detect_clr, usbphy_vbus_detect_tog, usbphy_vbus_detect_stat,
+	/* Charger Detect Control */
+	usbphy_chrg_detect = 56,
+	usbphy_chrg_detect_set, usbphy_chrg_detect_clr, usbphy_chrg_detect_tog, usbphy_chrg_detect_stat,
+	/* Analog Control Register */
+	usbphy_anactrl = 64,
+	usbphy_anactrl_set, usbphy_anactrl_clr, usbphy_anactrl_tog,
+	/* Loopback Control */
+	usbphy_loopback, usbphy_loopback_set, usbphy_loopback_clr, usbphy_loopback_tog,
+	/* Loopback Packet Number Select Register */
+	usbphy_loopback_hsfscnt, usbphy_loopback_hsfscnt_set, usbphy_loopback_hsfscnt_clr, usbphy_loopback_hsfscnt_tog,
+	/* Trim Override Enable */
+	usbphy_trim_override_en, usbphy_trim_override_en_set, usbphy_trim_override_en_clr, usbphy_trim_override_en_tog,
+};
+
+
+enum { usbotg_usbcmd = 0x50 };
+
+
+void *usbclient_allocBuff(u32 size)
+{
+	size_t org = USB_BUFFER_SIZE * phyusb_common.usedPools;
+
+	if ((size % USB_BUFFER_SIZE) != 0 || org + size > USB_POOL_SIZE)
+		return NULL;
+
+	phyusb_common.usedPools += size / USB_BUFFER_SIZE;
+
+	return &phyusb_common.pool[org];
+}
+
+
+void usbclient_buffReset(void)
+{
+	phyusb_common.usedPools = 0;
+}
+
+
+void *phy_getBase(void)
+{
+	return USB0_BASE_ADDR;
+}
+
+
+u32 phy_getIrq(void)
+{
+	return USB0_IRQ;
+}
+
+
+void phy_reset(void)
+{
+	volatile u32 *usbphy = (u32 *)USB0_PHY_BASE_ADDR;
+
+	/* Reset PHY */
+	*(usbphy + usbphy_ctrl_set) = (1 << 31);
+
+	/* Enable clock and release the PHY from reset */
+	*(usbphy + usbphy_ctrl_clr) = (1 << 31) | (1 << 30);
+
+	/* Power up the PHY */
+	*(usbphy + usbphy_pwd) = 0;
+}
+
+
+void phy_init(void)
+{
+	u32 tmp;
+	volatile u32 *usbphy = (u32 *)USB0_PHY_BASE_ADDR;
+	volatile u32 *usbcmd = (u32 *)USB0_BASE_ADDR + usbotg_usbcmd;
+
+	phyusb_common.usedPools = 0;
+
+	/* Enable USB clock gate */
+	_imxrt_setDirectLPCG(pctl_lpcg_usb, 1);
+
+	/* Controller reset */
+	*usbcmd |= (1 << 1);
+
+	/* PHY soft reset */
+	*(usbphy + usbphy_ctrl_set) = (1 << 31);
+
+	/* Clear UTMI CLKGATE */
+	*(usbphy + usbphy_ctrl) &= ~(1 << 30);
+	*(usbphy + usbphy_ctrl) |= (1 << 15) | (1 << 14);
+	*(usbphy + usbphy_ctrl) |= (1 << 30) | (1 << 20);
+
+	/* Enable regulator */
+	*(usbphy + usbphy_pll_sic) |= (1 << 21);
+
+	/* 24 MHz input clock (480MHz / 20) */
+	tmp = *(usbphy + usbphy_pll_sic) & ~(7 << 22);
+	*(usbphy + usbphy_pll_sic) = tmp | (3 << 22);
+
+	/* Enable the power */
+	*(usbphy + usbphy_pll_sic) |= (1 << 13) | (1 << 12);
+
+	/* Wait until the PLL locks */
+	while ((*(usbphy + usbphy_pll_sic) & (1 << 31)) == 0)
+		;
+
+	/* Enable usb clocks */
+	*(usbphy + usbphy_pll_sic) |= (1 << 6);
+
+	/* Clear bypass bit */
+	*(usbphy + usbphy_pll_sic_clr) = (1 << 16);
+
+	/* Enable clock and release the PHY from reset */
+	*(usbphy + usbphy_ctrl_clr) = (1 << 31) | (1 << 30);
+
+	/* Power up the PHY */
+	*(usbphy + usbphy_pwd) = 0;
+}

--- a/devices/usbc-cdc/usbphy-zynq7000.c
+++ b/devices/usbc-cdc/usbphy-zynq7000.c
@@ -3,7 +3,7 @@
  *
  * Operating system loader
  *
- * USB physical layer controller
+ * Zynq 7000 USB physical layer controller
  *
  * Copyright 2021 Phoenix Systems
  * Author: Hubert Buczynski
@@ -18,39 +18,38 @@
 #include <devices/gpio-zynq7000/gpio.h>
 
 
-/* Memory size for endpoints and setup data */
-#define BUFF_SIZE (ENDPOINTS_DIR_NB * ENDPOINTS_NUMBER + 1) * USB_BUFFER_SIZE
+/* Size of memory pool aligned to USB_BUFFER_SIZE, used by USB descriptors */
+#define USB_POOL_SIZE (ENDPOINTS_DIR_NB * ENDPOINTS_NUMBER + 1) * USB_BUFFER_SIZE
 
 
 struct {
-	__attribute__((aligned(USB_BUFFER_SIZE))) u8 data[BUFF_SIZE];
-	u32 buffCounter;
+	u8 pool[USB_POOL_SIZE] __attribute__((aligned(USB_BUFFER_SIZE)));
+	size_t usedPools;
 } phyusb_common;
 
 
 void *usbclient_allocBuff(u32 size)
 {
-	void *mem;
+	size_t org = USB_BUFFER_SIZE * phyusb_common.usedPools;
 
-	if ((size % USB_BUFFER_SIZE) || (USB_BUFFER_SIZE * phyusb_common.buffCounter + size) >= BUFF_SIZE)
+	if ((size % USB_BUFFER_SIZE) != 0 || org + size > USB_POOL_SIZE)
 		return NULL;
 
-	mem = (void *)(&phyusb_common.data[USB_BUFFER_SIZE * phyusb_common.buffCounter]);
-	phyusb_common.buffCounter += size / USB_BUFFER_SIZE;
+	phyusb_common.usedPools += size / USB_BUFFER_SIZE;
 
-	return mem;
+	return &phyusb_common.pool[org];
 }
 
 
 void usbclient_buffReset(void)
 {
-	phyusb_common.buffCounter = 0;
+	phyusb_common.usedPools = 0;
 }
 
 
 void *phy_getBase(void)
 {
-	return (void *)USB0_BASE_ADDR;
+	return USB0_BASE_ADDR;
 }
 
 
@@ -124,7 +123,7 @@ static void phy_setPins(void)
 
 void phy_init(void)
 {
-	phyusb_common.buffCounter = 0;
+	phyusb_common.usedPools = 0;
 
 	phy_setPins();
 	phy_reset();
@@ -139,6 +138,6 @@ void phy_reset(void)
 	gpio_writePin(mio_pin_07, 0);
 	gpio_writePin(mio_pin_07, 1);
 
-	phyusb_common.buffCounter = 0;
+	phyusb_common.usedPools = 0;
 	_zynq_setAmbaClk(amba_usb0_clk, clk_disable);
 }

--- a/hal/armv7m/imxrt/117x/Makefile
+++ b/hal/armv7m/imxrt/117x/Makefile
@@ -22,6 +22,7 @@ GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
 PLO_COMMANDS = alias app call console copy devs dump echo go help kernel map mpu phfs script syspage wait
 
+include devices/usbc-cdc/Makefile
 include devices/uart-imxrt117x/Makefile
 include devices/flash-imxrt/Makefile
 

--- a/hal/armv7m/imxrt/117x/imxrt.c
+++ b/hal/armv7m/imxrt/117x/imxrt.c
@@ -498,6 +498,28 @@ int _imxrt_setDevClock(int clock, int div, int mux, int mfd, int mfn, int state)
 }
 
 
+int _imxrt_setDirectLPCG(int clock, int state)
+{
+	u32 t;
+	volatile u32 *reg;
+
+	if (clock < pctl_lpcg_m7 || clock > pctl_lpcg_uniq_edt_i)
+		return -1;
+
+	reg = imxrt_common.ccm + 0x1800 + clock * 0x8;
+
+	if (((*reg ^ state) & 1) != 0) {
+		t = *reg & ~1u;
+		*reg = t | (state & 1);
+
+		imxrt_dataSyncBarrier();
+		imxrt_dataInstrBarrier();
+	}
+
+	return 0;
+}
+
+
 void _imxrt_init(void)
 {
 	int i;

--- a/hal/armv7m/imxrt/117x/imxrt.h
+++ b/hal/armv7m/imxrt/117x/imxrt.h
@@ -22,8 +22,7 @@
 #include "../types.h"
 
 
-/* CCM - Clock gating */
-
+/* CCM - Root Clocks */
 enum { pctl_clk_cm7 = 0, pctl_clk_cm4, pctl_clk_bus, pctl_clk_bus_lpsr, pctl_clk_semc, pctl_clk_cssys,
 	pctl_clk_cstrace, pctl_clk_m4_systick, pctl_clk_m7_systick, pctl_clk_adc1, pctl_clk_adc2, pctl_clk_acmp,
 	pctl_clk_flexio1, pctl_clk_flexio2, pctl_clk_gpt1, pctl_clk_gpt2, pctl_clk_gpt3, pctl_clk_gpt4, pctl_clk_gpt5,
@@ -37,6 +36,32 @@ enum { pctl_clk_cm7 = 0, pctl_clk_cm4, pctl_clk_bus, pctl_clk_bus_lpsr, pctl_clk
 	pctl_clk_sai2, pctl_clk_sai3, pctl_clk_sai4, pctl_clk_gpu2d, pctl_clk_elcdif, pctl_clk_lcdifv2, pctl_clk_mipi_ref,
 	pctl_clk_mipi_esc, pctl_clk_csi2, pctl_clk_csi2_esc, pctl_clk_csi2_ui, pctl_clk_csi, pctl_clk_ccm_clko1,
 	pctl_clk_ccm_clko2 };
+
+
+/* CCM - Low Power Clock Gates */
+enum { pctl_lpcg_m7 = 0, pctl_lpcg_m4, pctl_lpcg_sim_m7, pctl_lpcg_sim_m, pctl_lpcg_sim_disp, pctl_lpcg_sim_per,
+	pctl_lpcg_sim_lpsr, pctl_lpcg_anadig, pctl_lpcg_dcdc, pctl_lpcg_src, pctl_lpcg_ccm, pctl_lpcg_gpc, pctl_lpcg_ssarc,
+	pctl_lpcg_sim_r, pctl_lpcg_wdog1, pctl_lpcg_wdog2, pctl_lpcg_wdog3, pctl_lpcg_wdog4, pctl_lpcg_ewm0, pctl_lpcg_sema,
+	pctl_lpcg_mu_a, pctl_lpcg_mu_b, pctl_lpcg_edma, pctl_lpcg_edma_lpsr, pctl_lpcg_romcp, pctl_lpcg_ocram,
+	pctl_lpcg_flexram, pctl_lpcg_lmem, pctl_lpcg_flexspi1, pctl_lpcg_flexspi2, pctl_lpcg_rdc, pctl_lpcg_m7_xrdc,
+	pctl_lpcg_m4_xrdc, pctl_lpcg_semc, pctl_lpcg_xecc, pctl_lpcg_iee, pctl_lpcg_puf, pctl_lpcg_ocotp, pctl_lpcg_snvs_hp,
+	pctl_lpcg_snvs, pctl_lpcg_caam, pctl_lpcg_jtag_mux, pctl_lpcg_cstrace, pctl_lpcg_xbar1, pctl_lpcg_xbar2,
+	pctl_lpcg_xbar3, pctl_lpcg_aoi1, pctl_lpcg_aoi2, pctl_lpcg_adc_etc, pctl_lpcg_iomuxc, pctl_lpcg_iomuxc_lpsr,
+	pctl_lpcg_gpio, pctl_lpcg_kpp, pctl_lpcg_flexio1, pctl_lpcg_flexio2, pctl_lpcg_lpadc1, pctl_lpcg_lpadc2,
+	pctl_lpcg_dac, pctl_lpcg_acmp1, pctl_lpcg_acmp2, pctl_lpcg_acmp3, pctl_lpcg_acmp4, pctl_lpcg_pit1, pctl_lpcg_pit2,
+	pctl_lpcg_gpt1, pctl_lpcg_gpt2, pctl_lpcg_gpt3, pctl_lpcg_gpt4, pctl_lpcg_gpt5, pctl_lpcg_gpt6, pctl_lpcg_qtimer1,
+	pctl_lpcg_qtimer2, pctl_lpcg_qtimer3, pctl_lpcg_qtimer4, pctl_lpcg_enc1, pctl_lpcg_enc2, pctl_lpcg_enc3,
+	pctl_lpcg_enc4, pctl_lpcg_hrtimer, pctl_lpcg_pwm1, pctl_lpcg_pwm2, pctl_lpcg_pwm3, pctl_lpcg_pwm4, pctl_lpcg_can1,
+	pctl_lpcg_can2, pctl_lpcg_can3, pctl_lpcg_lpuart1, pctl_lpcg_lpuart2, pctl_lpcg_lpuart3, pctl_lpcg_lpuart4,
+	pctl_lpcg_lpuart5, pctl_lpcg_lpuart6, pctl_lpcg_lpuart7, pctl_lpcg_lpuart8, pctl_lpcg_lpuart9, pctl_lpcg_lpuart10,
+	pctl_lpcg_lpuart11, pctl_lpcg_lpuart12, pctl_lpcg_lpi2c1, pctl_lpcg_lpi2c2, pctl_lpcg_lpi2c3, pctl_lpcg_lpi2c4,
+	pctl_lpcg_lpi2c5, pctl_lpcg_lpi2c6, pctl_lpcg_lpspi1, pctl_lpcg_lpspi2, pctl_lpcg_lpspi3, pctl_lpcg_lpspi4,
+	pctl_lpcg_lpspi5, pctl_lpcg_lpspi6, pctl_lpcg_sim1, pctl_lpcg_sim2, pctl_lpcg_enet, pctl_lpcg_enet_1g,
+	pctl_lpcg_enet_qos, pctl_lpcg_usb, pctl_lpcg_cdog, pctl_lpcg_usdhc1, pctl_lpcg_usdhc2, pctl_lpcg_asrc,
+	pctl_lpcg_mqs, pctl_lpcg_pdm, pctl_lpcg_spdif, pctl_lpcg_sai1, pctl_lpcg_sai2, pctl_lpcg_sai3, pctl_lpcg_sai4,
+	pctl_lpcg_pxp, pctl_lpcg_gpu2d, pctl_lpcg_lcdif, pctl_lpcg_lcdifv2, pctl_lpcg_mipi_dsi, pctl_lpcg_mipi_csi,
+	pctl_lpcg_csi, pctl_lpcg_dcic_mipi, pctl_lpcg_dcic_lcd, pctl_lpcg_video_mux, pctl_lpcg_uniq_edt_i };
+
 
 /* IOMUX - MUX */
 enum {
@@ -350,6 +375,9 @@ extern void _imxrt_nvicSystemReset(void);
 
 
 extern int _imxrt_setDevClock(int clock, int div, int mux, int mfd, int mfn, int state);
+
+
+extern int _imxrt_setDirectLPCG(int clock, int state);
 
 
 #endif

--- a/hal/armv7m/imxrt/117x/peripherals.h
+++ b/hal/armv7m/imxrt/117x/peripherals.h
@@ -251,6 +251,10 @@
 
 /* USB */
 
+#define USB0_BASE_ADDR     ((void *)0x40430000)
+#define USB0_PHY_BASE_ADDR ((void *)0x40434000)
+#define USB0_IRQ           usb_otg1_irq
+
 #define PHFS_ACM_PORTS_NB 1 /* Number of ports define by CDC driver; min = 1, max = 2 */
 
 


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->
I'm adding an OTG1 USB device phy layer to the `imxrt1176` platform. Additionally PHY initialization requires LPCG115 gate to be enabled, that's why I'm adding `_imxrt_setDirectLPCG()` function with set of appropriate `enum's` .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
JIRA: NIL-141

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1176-nil).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
