### PR TITLE
imxrt: use UART_CONSOLE to setup early console

### DIFF
--- a/hal/armv7m/imxrt/117x/console.c
+++ b/hal/armv7m/imxrt/117x/console.c
@@ -6,7 +6,7 @@
  * Console
  *
  * Copyright 2021 Phoenix Systems
- * Authors: Hubert Buczynski
+ * Authors: Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -14,6 +14,22 @@
  */
 
 #include <hal/hal.h>
+
+#define CONCAT(a, b)         a##b
+#define CONCAT2(a, b)        CONCAT(a, b)
+#define UART_PIN(n, pin)     CONCAT(UART, n##_##pin)
+#define CONSOLE_BASE(n)      (UART_PIN(n, BASE))
+#define CONSOLE_CLK(n)       (UART_PIN(n, CLK))
+#define CONSOLE_MUX(n, pin)  (CONCAT2(pctl_mux_gpio_, UART_PIN(n, pin)))
+#define CONSOLE_PAD(n, pin)  (CONCAT2(pctl_pad_gpio_, UART_PIN(n, pin)))
+#define CONSOLE_ISEL(n, pin) (CONCAT2(pctl_isel_lpuart, CONCAT(n, _##pin)))
+#define CONSOLE_BAUD(n)      (UART_PIN(n, BAUDRATE))
+
+#if CONSOLE_BAUD(UART_CONSOLE)
+#define CONSOLE_BAUDRATE CONSOLE_BAUD(UART_CONSOLE)
+#else
+#define CONSOLE_BAUDRATE (UART_BAUDRATE)
+#endif
 
 
 struct {
@@ -23,7 +39,6 @@ struct {
 
 enum { uart_verid = 0, uart_param, uart_global, uart_pincfg, uart_baud, uart_stat, uart_ctrl,
 	   uart_data, uart_match, uart_modir, uart_fifo, uart_water };
-
 
 
 void hal_consolePrint(const char *s)
@@ -40,20 +55,22 @@ void console_init(void)
 {
 	u32 t;
 
-	halconsole_common.uart = UART11_BASE;
+	halconsole_common.uart = CONSOLE_BASE(UART_CONSOLE);
 
-	_imxrt_setDevClock(UART11_CLK, 0, 0, 0, 0, 1);
+	_imxrt_setDevClock(CONSOLE_CLK(UART_CONSOLE), 0, 0, 0, 0, 1);
 
 	/* tx */
-	_imxrt_setIOmux(pctl_mux_gpio_ad_24, 0, 0);
-	_imxrt_setIOpad(pctl_pad_gpio_ad_24, 0, 0, 0, 0, 0, 0);
+	_imxrt_setIOmux(CONSOLE_MUX(UART_CONSOLE, TX_PIN), 0, 0);
+	_imxrt_setIOpad(CONSOLE_PAD(UART_CONSOLE, TX_PIN), 0, 0, 0, 0, 0, 0);
 
 	/* rx */
-	_imxrt_setIOmux(pctl_mux_gpio_ad_25, 0, 0);
-	_imxrt_setIOpad(pctl_pad_gpio_ad_25, 0, 0, 1, 1, 0, 0);
+	_imxrt_setIOmux(CONSOLE_MUX(UART_CONSOLE, RX_PIN), 0, 0);
+	_imxrt_setIOpad(CONSOLE_PAD(UART_CONSOLE, RX_PIN), 0, 0, 1, 1, 0, 0);
 
-	_imxrt_setIOisel(pctl_isel_lpuart1_rxd, 0);
-	_imxrt_setIOisel(pctl_isel_lpuart1_txd, 0);
+#if (UART_CONSOLE == 1) || (UART_CONSOLE == 12)
+	_imxrt_setIOisel(CONSOLE_ISEL(UART_CONSOLE, txd), 0);
+	_imxrt_setIOisel(CONSOLE_ISEL(UART_CONSOLE, rxd), 0);
+#endif
 
 	/* Reset all internal logic and registers, except the Global Register */
 	*(halconsole_common.uart + uart_global) |= 1 << 1;
@@ -61,9 +78,22 @@ void console_init(void)
 	*(halconsole_common.uart + uart_global) &= ~(1 << 1);
 	imxrt_dataBarrier();
 
-	/* Set 115200 baudrate */
-	t = *(halconsole_common.uart + uart_baud) & ~((0x1f << 24) | (1 << 17) | 0xfff);
-	*(halconsole_common.uart + uart_baud) = t | 50462772;
+	/* Set baud rate */
+	t = *(halconsole_common.uart + uart_baud) & ~((0x1f << 24) | (1 << 17) | 0x1fff);
+
+	/* For baud rate calculation, default UART_CLK=24MHz assumed */
+	switch (CONSOLE_BAUDRATE) {
+		case 9600: t |= 0x03020271; break;
+		case 19200: t |= 0x03020138; break;
+		case 38400: t |= 0x0302009c; break;
+		case 57600: t |= 0x03020068; break;
+		case 115200: t |= 0x03020034; break;
+		case 230400: t |= 0x0302001a; break;
+		case 460800: t |= 0x0302000d; break;
+		/* As fallback use default 115200 */
+		default: t |= 0x03020034; break;
+	}
+	*(halconsole_common.uart + uart_baud) = t;
 
 	/* Set 8 bit and no parity mode */
 	*(halconsole_common.uart + uart_ctrl) &= ~0x117;


### PR DESCRIPTION
JIRA: RTOS-118

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

On `imxrt117x` the `UART_CONSOLE_PLO`, and `UART_CONSOLE` environment variables do not configure the (so-called) early plo console (default port is hardcoded) side effect of this may observed when plo starts:
![before](https://user-images.githubusercontent.com/141153/139943125-1c5b35c8-6a50-490d-ad8f-8b6894020231.png)

Hardcoded values are assigned to `UART1` which is not the default console port for the current project being developed on `imxrt117x`, for ease of use with `BOARD_CONFIG`,  `UART_CONSOLE` or `UART_CONSOLE_PLO` may be used to assign a default port per project. I assume the macros provided are per each `console.c`, but may be moved to `peripherals.h`.

This commit fixes that, so with default `UART_CONSOLE` from `peripherals.h` which is `UART11` it looks like:
![after](https://user-images.githubusercontent.com/141153/139943219-d2bae1bd-fd7d-4b3f-b7b4-c712d3d65742.png)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1176-custom, imxrt1064-evalkit).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
