### PR TITLE
flash-zynq7000: handle flash memory available on qemu

### DIFF
--- a/devices/flash-zynq7000/flashdrv.c
+++ b/devices/flash-zynq7000/flashdrv.c
@@ -247,7 +247,7 @@ static ssize_t flashdrv_pageProgram(addr_t offs, const void *buff, size_t len)
 static ssize_t flashdrv_read(unsigned int minor, addr_t offs, void *buff, size_t len, time_t timeout)
 {
 	ssize_t res;
-	size_t cmdSz, dataSz;
+	size_t cmdSz, dataSz, transferSz;
 	const flash_cmd_t *cmd = &fdrv_common.info.cmds[flash_cmd_qior];
 
 	if (len == 0)
@@ -266,7 +266,8 @@ static ssize_t flashdrv_read(unsigned int minor, addr_t offs, void *buff, size_t
 	cmdSz = (cmd->size + cmd->dummyCyc / 8 + 0x3) & ~0x3;
 
 	/* Size of the data which is received during cmd transfer */
-	dataSz = cmdSz - cmd->size - cmd->dummyCyc / 8;
+	transferSz = cmdSz - cmd->size - cmd->dummyCyc / 8;
+	dataSz = (transferSz > len) ? len : transferSz;
 
 	qspi_start();
 	if ((res = qspi_polledTransfer(fdrv_common.cmdTx, fdrv_common.cmdRx, cmdSz, TIMEOUT_CMD_MS)) < 0) {

--- a/devices/flash-zynq7000/qspi.c
+++ b/devices/flash-zynq7000/qspi.c
@@ -223,32 +223,32 @@ static int qspi_initCtrlClk(void)
 static int qspi_linearMode(void)
 {
 	/* Disable QSPI */
-	*(flashdrv_common.base + er) &= ~0x1;
+	*(qspi_common.base + er) &= ~0x1;
 	hal_cpuDataMemoryBarrier();
 
 	/* Disable IRQs */
-	*(flashdrv_common.base + idr) = 0x7d;
+	*(qspi_common.base + idr) = 0x7d;
 
 	/* Disable linear mode */
-	*(flashdrv_common.base + lqspi_cr) = 0;
+	*(qspi_common.base + lqspi_cr) = 0;
 
-	*(flashdrv_common.base + cr) = (1 << 14);
-	*(flashdrv_common.base + cr) = (1 << 10);
+	*(qspi_common.base + cr) = (1 << 14);
+	*(qspi_common.base + cr) = (1 << 10);
 
-	*(flashdrv_common.base + cr) &= ~(0x7 << 3);
-	*(flashdrv_common.base + cr) |= (0x3 << 3);
+	*(qspi_common.base + cr) &= ~(0x7 << 3);
+	*(qspi_common.base + cr) |= (0x3 << 3);
 
-	*(flashdrv_common.base + cr) |= 0x1;
-	*(flashdrv_common.base + cr) |= (1 << 31);
-	*(flashdrv_common.base + cr) &= ~(1 << 26);
+	*(qspi_common.base + cr) |= 0x1;
+	*(qspi_common.base + cr) |= (1 << 31);
+	*(qspi_common.base + cr) &= ~(1 << 26);
 
-	*(flashdrv_common.base + cr) |= (0x3 << 6);
-	*(flashdrv_common.base + cr) &= ~(0x3 << 1);
-	*(flashdrv_common.base + cr) |= (0x1 << 19);
+	*(qspi_common.base + cr) |= (0x3 << 6);
+	*(qspi_common.base + cr) &= ~(0x3 << 1);
+	*(qspi_common.base + cr) |= (0x1 << 19);
 
-	*(flashdrv_common.base + lqspi_cr) =  0x80000003;
+	*(qspi_common.base + lqspi_cr) =  0x80000003;
 
-	*(flashdrv_common.base + er) = 0x1;
+	*(qspi_common.base + er) = 0x1;
 	hal_cpuDataMemoryBarrier();
 
 	return EOK;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
- handle flash memory available on qemu,
- clean up qspi liner mode,
- fix read operation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (lzynq7000, qemu-system-aarch64).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
