### PR TITLE
add support for quad spi flash memory on MIMXRT1170-EVK evaluation board

### DIFF
--- a/devices/flash-imxrt/flashcfg.c
+++ b/devices/flash-imxrt/flashcfg.c
@@ -40,9 +40,9 @@ static int flashcfg_getWindbondConfig(flash_context_t *ctx)
 static void flashcfg_setWindbondLUT(flash_context_t *ctx)
 {
 	/* QUAD Fast Read */
-	ctx->config.mem.lut[4 * QUAD_FAST_READ_SEQ_ID] = LUT_INSTR(LUT_CMD_CMD, LUT_PAD1, FLASH_SPANSION_CMD_QIOR, LUT_CMD_ADDR, LUT_PAD4, 0x18); /* 0xa1804eb */
-	ctx->config.mem.lut[4 * QUAD_FAST_READ_SEQ_ID + 1] = LUT_INSTR(LUT_CMD_MODE8, LUT_PAD4, 0x04, LUT_CMD_DUMMY, LUT_PAD4, 0x04);             /* 0x32061ef4 */
-	ctx->config.mem.lut[4 * QUAD_FAST_READ_SEQ_ID + 2] = LUT_INSTR(LUT_CMD_READ, LUT_PAD4, 0x04, 0, 0, 0);                                    /* 0x2604 */
+	ctx->config.mem.lut[4 * QUAD_FAST_READ_SEQ_ID] = LUT_INSTR(LUT_CMD_CMD, LUT_PAD1, FLASH_SPANSION_CMD_QIOR, LUT_CMD_ADDR, LUT_PAD4, LUT_3B_ADDR); /* 0xa1804eb */
+	ctx->config.mem.lut[4 * QUAD_FAST_READ_SEQ_ID + 1] = LUT_INSTR(LUT_CMD_MODE8, LUT_PAD4, 0x04, LUT_CMD_DUMMY, LUT_PAD4, 0x04);                    /* 0x32041e04 */
+	ctx->config.mem.lut[4 * QUAD_FAST_READ_SEQ_ID + 2] = LUT_INSTR(LUT_CMD_READ, LUT_PAD4, 0x04, 0, 0, 0);                                           /* 0x2604 */
 	ctx->config.mem.lut[4 * QUAD_FAST_READ_SEQ_ID + 3] = 0;
 	flexspi_norFlashUpdateLUT(ctx->instance, QUAD_FAST_READ_SEQ_ID, (const u32 *)&ctx->config.mem.lut[4 * QUAD_FAST_READ_SEQ_ID], 1);
 
@@ -83,7 +83,7 @@ static void flashcfg_setWindbondLUT(flash_context_t *ctx)
 
 	/* Chip Erase */
 	ctx->config.mem.lut[4 * CHIP_ERASE_SEQ_ID] = LUT_INSTR(LUT_CMD_CMD, LUT_PAD1, FLASH_SPANSION_CMD_BE, 0, 0, 0); /* 0x0460 */
-	ctx->config.mem.lut[4 * CHIP_ERASE_SEQ_ID + 1] = LUT_INSTR(LUT_CMD_WRITE, LUT_PAD1, 0x04, 0, 0, 0);            /* 0x2004 */
+	ctx->config.mem.lut[4 * CHIP_ERASE_SEQ_ID + 1] = 0;
 	ctx->config.mem.lut[4 * CHIP_ERASE_SEQ_ID + 2] = 0;
 	ctx->config.mem.lut[4 * CHIP_ERASE_SEQ_ID + 3] = 0;
 
@@ -254,7 +254,7 @@ static void flashcfg_setMicronLUT(flash_context_t *ctx)
 
 	/* Chip Erase */
 	ctx->config.mem.lut[4 * CHIP_ERASE_SEQ_ID] = LUT_INSTR(LUT_CMD_CMD, LUT_PAD1, FLASH_SPANSION_CMD_BE, 0, 0, 0); /* 0x0460 */
-	ctx->config.mem.lut[4 * CHIP_ERASE_SEQ_ID + 1] = LUT_INSTR(LUT_CMD_WRITE, LUT_PAD1, 0x04, 0, 0, 0);            /* 0x2004 */
+	ctx->config.mem.lut[4 * CHIP_ERASE_SEQ_ID + 1] = 0;
 	ctx->config.mem.lut[4 * CHIP_ERASE_SEQ_ID + 2] = 0;
 	ctx->config.mem.lut[4 * CHIP_ERASE_SEQ_ID + 3] = 0;
 	flexspi_norFlashUpdateLUT(ctx->instance, CHIP_ERASE_SEQ_ID, (const u32 *)&ctx->config.mem.lut[4 * CHIP_ERASE_SEQ_ID], 1);

--- a/devices/flash-imxrt/flashcfg.h
+++ b/devices/flash-imxrt/flashcfg.h
@@ -5,7 +5,7 @@
  *
  * i.MX RT Flash Configurator
  *
- * Copyright 2019, 2020 Phoenix Systems
+ * Copyright 2019-2021 Phoenix Systems
  * Author: Hubert Buczynski
  *
  * This file is part of Phoenix-RTOS.
@@ -24,7 +24,9 @@
 
 /* List of supported flash memories */
 #define WINDBOND_W25Q32JV_IQ 0x4016
+#define ISSI_DEV_IS25WP032A  0x7016
 #define ISSI_DEV_IS25WP064A  0x7017
+#define ISSI_DEV_IS25WP128A  0x7018
 #define MICRON_MT25QL512ABB  0xba20
 #define MICRON_MT25QL01GBBB  0xba21
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

This PR adds support for quad spi flash IS25xx128 used in MIMXRT1170-EVK evaluation board. Additionally fixes the redundant use of the write command in the flexspi lookup table for the chip erase entry.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (MIMXRT1170-EVK).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
