### PR TITLE
stm32l4: Fixed not waiting for transmission complete on console TX

### DIFF
--- a/hal/armv7m/stm32/l4/console.c
+++ b/hal/armv7m/stm32/l4/console.c
@@ -35,7 +35,7 @@ void hal_consolePrint(const char *s)
 		*(halconsole_common.base + tdr) = *(s++);
 	}
 
-	while (~(*(halconsole_common.base + isr)) & 0x80)
+	while (~(*(halconsole_common.base + isr)) & 0x40)
 		;
 
 	return;
@@ -61,11 +61,11 @@ void console_init(void)
 
 	halconsole_common.base = uarts[uart].base;
 
-	/* Init tx pin - output, push-pull, high speed, no pull-up */
-	_stm32_gpioConfig(port, txpin, 2, af, 0, 2, 0);
+	/* Init tx pin - output, push-pull, low speed, no pull-up */
+	_stm32_gpioConfig(port, txpin, 2, af, 0, 0, 0);
 
-	/* Init rxd pin - input, push-pull, high speed, no pull-up */
-	_stm32_gpioConfig(port, rxpin, 2, af, 0, 2, 0);
+	/* Init rxd pin - input, push-pull, low speed, no pull-up */
+	_stm32_gpioConfig(port, rxpin, 2, af, 0, 0, 0);
 
 	/* Enable uart clock */
 	_stm32_rccSetDevClock(uarts[uart].uart, 1);


### PR DESCRIPTION
JIRA: SKAL-455

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There was a problem during uart reconfiguration (basic console -> plo uart driver) of interrupting ongoing transmission

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32l4).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
