### PR TITLE
arm/hal.c: reduce code size hal_memoryGetNextEntry()

### DIFF
--- a/hal/armv7a/imx6ull/hal.c
+++ b/hal/armv7a/imx6ull/hal.c
@@ -151,9 +151,9 @@ int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 	if (start == end)
 		return -1;
 
-	hal_memset(&tempEntry, 0, sizeof(tempEntry));
-	hal_memset(&minEntry, 0, sizeof(minEntry));
 	minEntry.start = (addr_t)-1;
+	minEntry.end = 0;
+	minEntry.type = 0;
 
 	/* Syspage entry */
 	tempEntry.start = (addr_t)hal_common.hs;
@@ -164,7 +164,9 @@ int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 	for (i = 0; i < sizeof(entries) / sizeof(entries[0]); ++i) {
 		if (entries[i].start >= entries[i].end)
 			continue;
-		hal_memcpy(&tempEntry, &entries[i], sizeof(mapent_t));
+		tempEntry.start = entries[i].start;
+		tempEntry.end = entries[i].end;
+		tempEntry.type = entries[i].type;
 		hal_getMinOverlappedRange(start, end, &tempEntry, &minEntry);
 	}
 

--- a/hal/armv7a/zynq7000/hal.c
+++ b/hal/armv7a/zynq7000/hal.c
@@ -138,9 +138,9 @@ int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 	if (start == end)
 		return -1;
 
-	hal_memset(&tempEntry, 0, sizeof(tempEntry));
-	hal_memset(&minEntry, 0, sizeof(minEntry));
 	minEntry.start = (addr_t)-1;
+	minEntry.end = 0;
+	minEntry.type = 0;
 
 	/* Syspage entry */
 	tempEntry.start = (addr_t)hal_common.hs;
@@ -151,7 +151,9 @@ int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 	for (i = 0; i < sizeof(entries) / sizeof(entries[0]); ++i) {
 		if (entries[i].start >= entries[i].end)
 			continue;
-		hal_memcpy(&tempEntry, &entries[i], sizeof(mapent_t));
+		tempEntry.start = entries[i].start;
+		tempEntry.end = entries[i].end;
+		tempEntry.type = entries[i].type;
 		hal_getMinOverlappedRange(start, end, &tempEntry, &minEntry);
 	}
 

--- a/hal/armv7m/imxrt/hal.c
+++ b/hal/armv7m/imxrt/hal.c
@@ -133,9 +133,9 @@ int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 	if (start == end)
 		return -1;
 
-	hal_memset(&tempEntry, 0, sizeof(tempEntry));
-	hal_memset(&minEntry, 0, sizeof(minEntry));
 	minEntry.start = (addr_t)-1;
+	minEntry.end = 0;
+	minEntry.type = 0;
 
 	/* Syspage entry */
 	tempEntry.start = (addr_t)hal_common.hs;
@@ -146,7 +146,9 @@ int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 	for (i = 0; i < sizeof(entries) / sizeof(entries[0]); ++i) {
 		if (entries[i].start >= entries[i].end)
 			continue;
-		hal_memcpy(&tempEntry, &entries[i], sizeof(mapent_t));
+		tempEntry.start = entries[i].start;
+		tempEntry.end = entries[i].end;
+		tempEntry.type = entries[i].type;
 		hal_getMinOverlappedRange(start, end, &tempEntry, &minEntry);
 	}
 

--- a/hal/armv7m/stm32/hal.c
+++ b/hal/armv7m/stm32/hal.c
@@ -130,9 +130,9 @@ int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 	if (start == end)
 		return -1;
 
-	hal_memset(&tempEntry, 0, sizeof(tempEntry));
-	hal_memset(&minEntry, 0, sizeof(minEntry));
 	minEntry.start = (addr_t)-1;
+	minEntry.end = 0;
+	minEntry.type = 0;
 
 	/* Syspage entry */
 	tempEntry.start = (addr_t)hal_common.hs;
@@ -143,7 +143,9 @@ int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 	for (i = 0; i < sizeof(entries) / sizeof(entries[0]); ++i) {
 		if (entries[i].start >= entries[i].end)
 			continue;
-		hal_memcpy(&tempEntry, &entries[i], sizeof(mapent_t));
+		tempEntry.start = entries[i].start;
+		tempEntry.end = entries[i].end;
+		tempEntry.type = entries[i].type;
 		hal_getMinOverlappedRange(start, end, &tempEntry, &minEntry);
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
The porosed fix reduces the size of generated code about 400 bytes.
Results for targets:
```
                          now   new   diff
plo-armv7a7-imx6ull.img   41204 40812 392
plo-armv7a9-zynq7000.img  46860 46452 408
plo-armv7m4-stm32l4x6.img 34772 34356 416
plo-armv7m7-imxrt106x.img 53456 53036 420
plo-armv7m7-imxrt117x.img 50668 50248 420
```
The `hal_memoryGetNextEntry()` and `hal_getMinOverlappedRange()` functions use only three members of the `mapent_t` structure: `start, end, type`.
I have abandoned the use of the `hal_memset()` and `hal_memcpy()` functions.
As a result, the compiler uses only registers to store local variables (without using the stack).
The result is shown above.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
