### PR TITLE
stm32l4: Fix bad size of the SRAM area map

### DIFF
--- a/ld/armv7m4-stm32l4x6.ldt
+++ b/ld/armv7m4-stm32l4x6.ldt
@@ -32,7 +32,7 @@
 /* Memory map setup */
 MEMORY
 {
-	m_sram    (rwx) : ORIGIN = 0x20000000 + AREA_KERNEL, LENGTH = 384k - AREA_KERNEL
+	m_sram    (rwx) : ORIGIN = 0x20000000 + AREA_KERNEL, LENGTH = (256k + 64k) - AREA_KERNEL
 	m_flash2  (rx)  : ORIGIN = 0x08080000, LENGTH = 512k
 	m_flash1  (rx)  : ORIGIN = 0x08000000, LENGTH = 512k
 }


### PR DESCRIPTION
JIRA: RTOS-233

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
On STM32L49x/L4Ax devices, the SRAM size should be 320 K (256K + 64K), instead of the  mistakenly set 384 K (256K + 128K).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
