### PR TITLE
ia32: Add the `plo image` to temporary map

### DIFF
--- a/hal/ia32/memory.c
+++ b/hal/ia32/memory.c
@@ -23,6 +23,7 @@ struct {
 
 /* Linker symbols */
 extern char __ramtext_start[], __ramtext_end[];
+extern char _start[], _end[];
 extern char __data_start[], __data_end[];
 extern char __bss_start[], __bss_end[];
 extern char __heap_base[], __heap_limit[];
@@ -124,6 +125,7 @@ int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 	/* The following entries are used only by plo - type = hal_entryTemp, kernel defines them by its own */
 	static const mapent_t entries[] = {
 		{ .start = 0x0, .end = 0x1000, .type = hal_entryTemp },
+		{ .start = (addr_t)_start, .end = (addr_t)_end, .type = hal_entryTemp },
 		{ .start = (addr_t)__ramtext_start, .end = (addr_t)__ramtext_end, .type = hal_entryTemp },
 		{ .start = (addr_t)__data_start, .end = (addr_t)__data_end, .type = hal_entryTemp },
 		{ .start = (addr_t)__bss_start, .end = (addr_t)__bss_end, .type = hal_entryTemp },


### PR DESCRIPTION
JIRA: RTOS-241

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

On `ia32`, the `plo image` during the bootstrap process is fully loaded from the hard drive into the RAM, it literally takes an area from `_start` to `_end`  (all sections). It resides there temporarily for the time of the operating system is being loaded. During that time it is required to protect the `.init`, `.text` and `.ro/.data` sections from accidental overwriting by adding a temporary mapping (released after the plo is finished). For example, an accidental overwrite can happen when loading a syspage application into the lower RAM using the plo `app` command, this ends up very bad in the picture below:

Clue:
![2022-08-27-185140_517x217_scrot](https://user-images.githubusercontent.com/141153/187041191-fdb2c95d-4689-412b-b0fb-9b476762916a.png)

This happened during loading an application into the "free" (not marked as used by plo image) area which spans form `0x7000` up to `0x172f0` and crashed the plo image.

This PR fixes that behavior.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (`ia32-generic`).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
