### PR TITLE
Add plo image to map entries and provide section start/end symbols.

### DIFF
--- a/hal/armv7m/stm32/hal.c
+++ b/hal/armv7m/stm32/hal.c
@@ -22,6 +22,11 @@ struct {
 
 
 /* Linker symbols */
+extern char __init_start[], __init_end[];
+extern char __text_start[], __etext[];
+extern char __rodata_start[], __rodata_end[];
+extern char __init_array_start[], __init_array_end[];
+extern char __fini_array_start[], __fini_array_end[];
 extern char __ramtext_start[], __ramtext_end[];
 extern char __data_start[], __data_end[];
 extern char __bss_start[], __bss_end[];
@@ -120,6 +125,11 @@ int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 	mapent_t tempEntry, minEntry;
 
 	static const mapent_t entries[] = {
+		{ .start = (addr_t)__init_start, .end = (addr_t)__init_end, .type = hal_entryTemp },
+		{ .start = (addr_t)__text_start, .end = (addr_t)__etext, .type = hal_entryTemp },
+		{ .start = (addr_t)__rodata_start, .end = (addr_t)__rodata_end, .type = hal_entryTemp },
+		{ .start = (addr_t)__init_array_start, .end = (addr_t)__init_array_end, .type = hal_entryTemp },
+		{ .start = (addr_t)__fini_array_start, .end = (addr_t)__fini_array_end, .type = hal_entryTemp },
 		{ .start = (addr_t)__ramtext_start, .end = (addr_t)__ramtext_end, .type = hal_entryTemp },
 		{ .start = (addr_t)__data_start, .end = (addr_t)__data_end, .type = hal_entryTemp },
 		{ .start = (addr_t)__bss_start, .end = (addr_t)__bss_end, .type = hal_entryTemp },

--- a/ld/common/plo-arm.lds
+++ b/ld/common/plo-arm.lds
@@ -25,10 +25,15 @@ SECTIONS
 {
 	. = ORIGIN(PLO_IMAGE);
 
-	.init : { KEEP (*(SORT_NONE(.init))) } > PLO_IMAGE
+	.init : {
+		__init_start = .;
+		KEEP (*(SORT_NONE(.init)))
+		__init_end = .;
+	} > PLO_IMAGE
 
 	.text :
 	{
+		__text_start = .;
 		. = ALIGN(4);
 		*(SORT(.text.sorted.*))
 		*(.text .stub .text.* .gnu.linkonce.t.*)
@@ -36,6 +41,7 @@ SECTIONS
 		*(.glue_7t)     /* glue thumb to arm code */
 		*(.eh_frame)
 		. = ALIGN(4);
+		PROVIDE_HIDDEN(__text_end = .); /* use __etext to include .fini */
 	} > PLO_IMAGE
 
 	.fini : { KEEP (*(SORT_NONE(.fini))) } > PLO_IMAGE
@@ -45,15 +51,23 @@ SECTIONS
 	PROVIDE (_etext = .);
 	PROVIDE (etext = .);
 
-	.rodata : { *(.rodata .rodata.* .gnu.linkonce.r.*) } > PLO_IMAGE
+	.rodata : {
+		__rodata_start = .;
+		*(.rodata .rodata.* .gnu.linkonce.r.*)
+		__rodata_end = .;
+	} > PLO_IMAGE
 
-	/* put ARM the section containing information for unwinding the stack */
-	.ARM.extab : { *(.ARM.extab* .gnu.linkonce.armextab.*) } > PLO_IMAGE
+	/* put .ARM.ex* the sections containing information for unwinding the stack */
+	.ARM.extab : {
+		PROVIDE_HIDDEN(__extab_start = .);
+		*(.ARM.extab* .gnu.linkonce.armextab.*)
+		PROVIDE_HIDDEN(__extab_end = .);
+	} > PLO_IMAGE
 	.ARM.exidx :
 	{
-		__exidx_start = .;
+		PROVIDE_HIDDEN(__exidx_start = .);
 		*(.ARM.exidx*)     /* needed when -funwind-tables -fexceptions */
-		__exidx_end = .;
+		PROVIDE_HIDDEN(__exidx_end = .);
 	} > PLO_IMAGE
 
 	.init_array :

--- a/ld/common/plo-ia32.lds
+++ b/ld/common/plo-ia32.lds
@@ -25,10 +25,15 @@ SECTIONS
 {
 	. = ORIGIN(PLO_IMAGE);
 
-	.init : { KEEP (*(SORT_NONE(.init))) } > PLO_IMAGE
+	.init : {
+		__init_start = .;
+		KEEP (*(SORT_NONE(.init)))
+		__init_end = .;
+	} > PLO_IMAGE
 
 	.text :
 	{
+		__text_start = .;
 		. = ALIGN(4);
 		*(SORT(.text.sorted.*))
 		*(.text .stub .text.* .gnu.linkonce.t.*)
@@ -36,6 +41,7 @@ SECTIONS
 		*(.glue_7t)     /* glue thumb to arm code */
 		*(.eh_frame)
 		. = ALIGN(4);
+		PROVIDE_HIDDEN(__text_end = .); /* use __etext to include .fini */
 	} > PLO_IMAGE
 
 	.fini : { KEEP (*(SORT_NONE(.fini))) } > PLO_IMAGE
@@ -45,7 +51,11 @@ SECTIONS
 	PROVIDE (_etext = .);
 	PROVIDE (etext = .);
 
-	.rodata : { *(.rodata .rodata.* .gnu.linkonce.r.*) } > PLO_IMAGE
+	.rodata : {
+		__rodata_start = .;
+		*(.rodata .rodata.* .gnu.linkonce.r.*)
+		__rodata_end = .;
+	} > PLO_IMAGE
 	.eh_frame_hdr : { *(.eh_frame_hdr) *(.eh_frame_entry .eh_frame_entry.*) } > PLO_IMAGE
 	.eh_frame : ONLY_IF_RO { KEEP (*(.eh_frame)) *(.eh_frame.*) } > PLO_IMAGE
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
After the modification (stm32l4) so that the plo is loaded into RAM, the `.init`, `.text`, `.rodata` sections were not mapped (map entries), which resulted in considering this area as unallocated. While loading applications to RAM below the first RAM map-entry resulted in overwriting the `plo` image when `plo` is running from the RAM.

The `ia32` scripts have been updated in a similar way to `stm32` to be consistent.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
