### PR TITLE
make: simplify include paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ LDGEN ?= $(CC)
 
 # TODO: replace BOARD_CONFIG usage with board_config.h
 CFLAGS += $(BOARD_CONFIG)
-CFLAGS += -I../plo -I$(PROJECT_PATH)/
+CFLAGS += -I. -I$(PROJECT_PATH)/
 CFLAGS += -DVERSION=\"$(VERSION)\"
 
 include hal/$(TARGET_SUFF)/Makefile

--- a/hal/armv7a/Makefile
+++ b/hal/armv7a/Makefile
@@ -8,10 +8,10 @@
 
 ifneq (, $(findstring zynq7000, $(TARGET_SUBFAMILY)))
     include hal/armv7a/zynq7000/Makefile
-    CFLAGS += -I../plo/hal/armv7a/zynq7000
+    CFLAGS += -Ihal/armv7a/zynq7000
 else ifneq (, $(findstring imx6ull, $(TARGET_SUBFAMILY)))
    include hal/armv7a/imx6ull/Makefile
-    CFLAGS += -I../plo/hal/armv7a/imx6ull
+    CFLAGS += -Ihal/armv7a/imx6ull
 endif
 
 OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/, exceptions.o cpu.o string.o mmu.o _cache.o)

--- a/hal/armv7m/imxrt/Makefile
+++ b/hal/armv7m/imxrt/Makefile
@@ -9,13 +9,13 @@
 
 ifneq (, $(findstring imxrt117x, $(TARGET_SUBFAMILY)))
 	include hal/armv7m/imxrt/117x/Makefile
-	CFLAGS += -I../plo/hal/armv7m/imxrt/117x
+	CFLAGS += -Ihal/armv7m/imxrt/117x
 else ifneq (, $(findstring imxrt106x, $(TARGET_SUBFAMILY)))
 	include hal/armv7m/imxrt/10xx/Makefile
-	CFLAGS += -I../plo/hal/armv7m/imxrt/10xx
+	CFLAGS += -Ihal/armv7m/imxrt/10xx
 else ifneq (, $(findstring imxrt105x, $(TARGET_SUBFAMILY)))
 	include hal/armv7m/imxrt/10xx/Makefile
-	CFLAGS += -I../plo/hal/armv7m/imxrt/10xx
+	CFLAGS += -Ihal/armv7m/imxrt/10xx
 endif
 
 OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/imxrt/, hal.o)

--- a/hal/armv7m/stm32/Makefile
+++ b/hal/armv7m/stm32/Makefile
@@ -7,5 +7,5 @@
 #
 
 include hal/armv7m/stm32/l4/Makefile
-CFLAGS += -I../plo/hal/armv7m/stm32/l4
+CFLAGS += -Ihal/armv7m/stm32/l4
 OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/stm32/, hal.o)

--- a/hal/ia32/Makefile
+++ b/hal/ia32/Makefile
@@ -7,7 +7,7 @@
 #
 
 CFLAGS += -DVADDR_KERNEL_BASE=$(VADDR_KERNEL_BASE)
-CFLAGS += -I../plo/hal/ia32
+CFLAGS += -Ihal/ia32
 
 PLO_COMMANDS := alias app call console copy dump echo go help kernel map phfs script reboot syspage wait
 


### PR DESCRIPTION
## Description
Previous include paths (unnecessarily) exited from current build root.

## Motivation and Context

This fixes recent CI build errors.
JIRA: CI-147

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
