### PR TITLE
Allow to enable/disable specific interrupt in IRQ controller

### DIFF
--- a/cmds/reboot.c
+++ b/cmds/reboot.c
@@ -36,7 +36,7 @@ static int cmd_reboot(int argc, char *argv[])
 	log_info("\nRebooting\n");
 	devs_done();
 	hal_done();
-	hal_interruptsDisable();
+	hal_interruptsDisableAll();
 	hal_cpuReboot();
 	return EOK;
 }

--- a/devices/flash-flexspi/fspi/fspi.c
+++ b/devices/flash-flexspi/fspi/fspi.c
@@ -106,7 +106,7 @@ __attribute__((section(".noxip"))) int flexspi_init(flexspi_t *fspi, int instanc
 		return res;
 	}
 
-	hal_interruptsDisable();
+	hal_interruptsDisableAll();
 
 	hal_disableDCache();
 	hal_disableICache();
@@ -202,7 +202,7 @@ __attribute__((section(".noxip"))) int flexspi_init(flexspi_t *fspi, int instanc
 	hal_enableICache();
 	hal_enableDCache();
 
-	hal_interruptsEnable();
+	hal_interruptsEnableAll();
 
 	return EOK;
 }

--- a/devices/uart-16550/uart-16550.c
+++ b/devices/uart-16550/uart-16550.c
@@ -140,7 +140,7 @@ static ssize_t uart_read(unsigned int minor, addr_t offs, void *buff, size_t len
 			return -ETIME;
 	}
 
-	hal_interruptsDisable();
+	hal_interruptsDisableAll();
 
 	l = (uart->rh > uart->rt) ? min(uart->rh - uart->rt, len) : min(SIZE_RX - uart->rt, len);
 	hal_memcpy(buff, &uart->rx[uart->rt], l);
@@ -151,7 +151,7 @@ static ssize_t uart_read(unsigned int minor, addr_t offs, void *buff, size_t len
 	}
 	uart->rt = (uart->rt + l) % SIZE_RX;
 
-	hal_interruptsEnable();
+	hal_interruptsEnableAll();
 
 	return l;
 }
@@ -172,7 +172,7 @@ static ssize_t uart_write(unsigned int minor, const void *buff, size_t len)
 	while (uart->tf)
 		;
 
-	hal_interruptsDisable();
+	hal_interruptsDisableAll();
 
 	l = (uart->th > uart->tt) ? min(uart->th - uart->tt, len) : min(SIZE_TX - uart->tt, len);
 	hal_memcpy(&uart->tx[uart->tt], buff, l);
@@ -192,7 +192,7 @@ static ssize_t uart_write(unsigned int minor, const void *buff, size_t len)
 	if ((uart->tt = (uart->tt + l) % SIZE_TX) == uart->th)
 		uart->tf = 1;
 
-	hal_interruptsEnable();
+	hal_interruptsEnableAll();
 
 	return l;
 }

--- a/devices/uart-imx6ull/uart.c
+++ b/devices/uart-imx6ull/uart.c
@@ -225,9 +225,9 @@ static ssize_t uart_read(unsigned int minor, addr_t offs, void *buff, size_t len
 			return -ETIME;
 	}
 
-	hal_interruptsDisable();
+	hal_interruptsDisable(info[minor].irq);
 	res = lib_cbufRead(&uart->cbuffRx, buff, len);
-	hal_interruptsEnable();
+	hal_interruptsEnable(info[minor].irq);
 
 	return res;
 }
@@ -246,12 +246,12 @@ static ssize_t uart_write(unsigned int minor, const void *buff, size_t len)
 	while (uart->cbuffTx.full)
 		;
 
-	hal_interruptsDisable();
+	hal_interruptsDisable(info[minor].irq);
 	res = lib_cbufWrite(&uart->cbuffTx, buff, len);
 
 	/* Enable TX FIFO empty irq */
 	*(uart->base + ucr1) |= 1 << 6;
-	hal_interruptsEnable();
+	hal_interruptsEnable(info[minor].irq);
 
 	return res;
 }

--- a/devices/uart-imxrt106x/uart.c
+++ b/devices/uart-imxrt106x/uart.c
@@ -442,9 +442,9 @@ static ssize_t uart_read(unsigned int minor, addr_t offs, void *buff, size_t len
 			return -ETIME;
 	}
 
-	hal_interruptsDisable();
+	hal_interruptsDisable(info[minor].irq);
 	res = lib_cbufRead(&uart->cbuffRx, buff, len);
-	hal_interruptsEnable();
+	hal_interruptsEnable(info[minor].irq);
 
 	return res;
 }
@@ -461,11 +461,11 @@ static ssize_t uart_write(unsigned int minor, const void *buff, size_t len)
 	while (uart->cbuffTx.full)
 		;
 
-	hal_interruptsDisable();
+	hal_interruptsDisable(info[minor].irq);
 	res = lib_cbufWrite(&uart->cbuffTx, buff, len);
 	*(uart->base + ctrlr) |= 1 << 23;
 
-	hal_interruptsEnable();
+	hal_interruptsEnable(info[minor].irq);
 
 	return res;
 }

--- a/devices/uart-imxrt117x/uart.c
+++ b/devices/uart-imxrt117x/uart.c
@@ -463,7 +463,7 @@ static ssize_t uart_read(unsigned int minor, addr_t offs, void *buff, size_t len
 		if ((hal_timerGet() - start) >= timeout)
 			return -ETIME;
 	}
-	hal_interruptsDisable();
+	hal_interruptsDisable(infoUarts[minor].irq);
 
 	if (uart->rxHead > uart->rxTail)
 		l = min(uart->rxHead - uart->rxTail, len);
@@ -478,7 +478,7 @@ static ssize_t uart_read(unsigned int minor, addr_t offs, void *buff, size_t len
 	}
 	uart->rxTail = ((uart->rxTail + cnt) % BUFFER_SIZE);
 
-	hal_interruptsEnable();
+	hal_interruptsEnable(infoUarts[minor].irq);
 
 	return cnt;
 }
@@ -495,7 +495,7 @@ static ssize_t uart_write(unsigned int minor, const void *buff, size_t len)
 	while (uart->txHead == uart->txTail && uart->tFull)
 		;
 
-	hal_interruptsDisable();
+	hal_interruptsDisable(infoUarts[minor].irq);
 	if (uart->txHead > uart->txTail)
 		l = min(uart->txHead - uart->txTail, len);
 	else
@@ -519,7 +519,7 @@ static ssize_t uart_write(unsigned int minor, const void *buff, size_t len)
 
 	*(uart->base + ctrlr) |= 1 << 23;
 
-	hal_interruptsEnable();
+	hal_interruptsEnable(infoUarts[minor].irq);
 
 	return cnt;
 }

--- a/devices/uart-stm32l4x6/uart.c
+++ b/devices/uart-stm32l4x6/uart.c
@@ -105,22 +105,22 @@ static ssize_t uart_read(unsigned int minor, addr_t offs, void *buff, size_t len
 	if (len == 0)
 		return 0;
 
-	hal_interruptsDisable();
+	hal_interruptsDisable(uartInfo[minor].irq);
 	for (cnt = 0; cnt < len; ++cnt) {
 		uart->rxflag = 0;
 		if (uart->rxdr == uart->rxdw) {
-			hal_interruptsEnable();
+			hal_interruptsEnable(uartInfo[minor].irq);
 			start = hal_timerGet();
 			while (!uart->rxflag) {
 				if ((hal_timerGet() - start) >= timeout)
 					return -ETIME;
 			}
-			hal_interruptsDisable();
+			hal_interruptsDisable(uartInfo[minor].irq);
 		}
 		((unsigned char *)buff)[cnt] = uart->rxdfifo[uart->rxdr++];
 		uart->rxdr %= sizeof(uart->rxdfifo);
 	}
-	hal_interruptsEnable();
+	hal_interruptsEnable(uartInfo[minor].irq);
 
 	return (ssize_t)cnt;
 }

--- a/devices/uart-zynq7000/uart.c
+++ b/devices/uart-zynq7000/uart.c
@@ -213,9 +213,9 @@ static ssize_t uart_read(unsigned int minor, addr_t offs, void *buff, size_t len
 			return -ETIME;
 	}
 
-	hal_interruptsDisable();
+	hal_interruptsDisable(info[minor].irq);
 	res = lib_cbufRead(&uart->cbuffRx, buff, len);
-	hal_interruptsEnable();
+	hal_interruptsEnable(info[minor].irq);
 
 	return res;
 }
@@ -234,9 +234,9 @@ static ssize_t uart_write(unsigned int minor, const void *buff, size_t len)
 	while (uart->cbuffTx.full)
 		;
 
-	hal_interruptsDisable();
+	hal_interruptsDisable(info[minor].irq);
 	res = lib_cbufWrite(&uart->cbuffTx, buff, len);
-	hal_interruptsEnable();
+	hal_interruptsEnable(info[minor].irq);
 
 	if (res > 0) {
 		uart_txData(uart);

--- a/hal/armv7a/cpu.c
+++ b/hal/armv7a/cpu.c
@@ -16,13 +16,13 @@
 #include <hal/hal.h>
 
 
-void hal_interruptsDisable(void)
+void hal_interruptsDisableAll(void)
 {
 	__asm__ volatile("cpsid if");
 }
 
 
-void hal_interruptsEnable(void)
+void hal_interruptsEnableAll(void)
 {
 	__asm__ volatile("cpsie if");
 }

--- a/hal/armv7a/exceptions.c
+++ b/hal/armv7a/exceptions.c
@@ -128,7 +128,7 @@ void exceptions_dispatch(unsigned int n, exc_context_t *ctx)
 {
 	char buff[512];
 
-	extern void hal_interruptsDisable(void);
+	hal_interruptsDisableAll();
 
 	hal_exceptionsDumpContext(buff, ctx, n);
 	hal_consolePrint(buff);

--- a/hal/armv7a/imx6ull/hal.c
+++ b/hal/armv7a/imx6ull/hal.c
@@ -121,7 +121,7 @@ int hal_cpuJump(void)
 	if (hal_common.entry == (addr_t)-1)
 		return -1;
 
-	hal_interruptsDisable();
+	hal_interruptsDisableAll();
 
 	hal_dcacheEnable(0);
 	hal_dcacheFlush((addr_t)ADDR_OCRAM_LOW, (addr_t)ADDR_OCRAM_LOW + SIZE_OCRAM_LOW);

--- a/hal/armv7a/imx6ull/timer.c
+++ b/hal/armv7a/imx6ull/timer.c
@@ -16,6 +16,7 @@
 
 #include <hal/hal.h>
 
+#define TIMER_IRQN 87
 
 enum { gpt_cr = 0, gpt_pr, gpt_sr, gpt_ir, gpt_ocr1, gpt_ocr2, gpt_ocr3, gpt_icr1, gpt_icr2, gpt_cnt };
 
@@ -42,9 +43,9 @@ time_t hal_timerGet(void)
 {
 	time_t val;
 
-	hal_interruptsDisable();
+	hal_interruptsDisable(TIMER_IRQN);
 	val = timer_common.time;
-	hal_interruptsEnable();
+	hal_interruptsEnable(TIMER_IRQN);
 
 	return val;
 }
@@ -59,7 +60,7 @@ void timer_done(void)
 	/* Clear status register */
 	*(timer_common.base + gpt_sr) = *(timer_common.base + gpt_sr);
 
-	hal_interruptsSet(87, NULL, NULL);
+	hal_interruptsSet(TIMER_IRQN, NULL, NULL);
 }
 
 

--- a/hal/armv7a/zynq7000/hal.c
+++ b/hal/armv7a/zynq7000/hal.c
@@ -241,7 +241,7 @@ int hal_cpuJump(void)
 	if (hal_common.entry == (addr_t)-1)
 		return -1;
 
-	hal_interruptsDisable();
+	hal_interruptsDisableAll();
 
 	hal_dcacheEnable(0);
 	hal_dcacheFlush((addr_t)ADDR_OCRAM_LOW, (addr_t)ADDR_OCRAM_LOW + SIZE_OCRAM_LOW);

--- a/hal/armv7a/zynq7000/timer.c
+++ b/hal/armv7a/zynq7000/timer.c
@@ -80,9 +80,9 @@ time_t hal_timerGet(void)
 {
 	time_t val;
 
-	hal_interruptsDisable();
+	hal_interruptsDisable(TTC0_1_IRQ);
 	val = timer_common.time;
-	hal_interruptsEnable();
+	hal_interruptsEnable(TTC0_1_IRQ);
 
 	return val;
 }

--- a/hal/armv7m/imxrt/10xx/timer.c
+++ b/hal/armv7m/imxrt/10xx/timer.c
@@ -43,9 +43,9 @@ __attribute__((section(".noxip"))) time_t hal_timerGet(void)
 {
 	time_t val;
 
-	hal_interruptsDisable();
+	hal_interruptsDisable(GPT1_IRQ);
 	val = timer_common.time;
-	hal_interruptsEnable();
+	hal_interruptsEnable(GPT1_IRQ);
 
 	return val;
 }

--- a/hal/armv7m/imxrt/117x/timer.c
+++ b/hal/armv7m/imxrt/117x/timer.c
@@ -43,9 +43,9 @@ __attribute__((section(".noxip"))) time_t hal_timerGet(void)
 {
 	time_t val;
 
-	hal_interruptsDisable();
+	hal_interruptsDisable(GPT1_IRQ);
 	val = timer_common.time;
-	hal_interruptsEnable();
+	hal_interruptsEnable(GPT1_IRQ);
 
 	return val;
 }

--- a/hal/armv7m/imxrt/hal.c
+++ b/hal/armv7m/imxrt/hal.c
@@ -176,7 +176,7 @@ int hal_cpuJump(void)
 	if (hal_common.entry == (addr_t)-1)
 		return -1;
 
-	hal_interruptsDisable();
+	hal_interruptsDisableAll();
 
 	mpu_getHalData(hal_common.hs);
 

--- a/hal/armv7m/stm32/hal.c
+++ b/hal/armv7m/stm32/hal.c
@@ -183,7 +183,7 @@ int hal_cpuJump(void)
 	if (hal_common.entry == (addr_t)-1)
 		return -1;
 
-	hal_interruptsDisable();
+	hal_interruptsDisableAll();
 
 	mpu_getHalData(hal_common.hs);
 

--- a/hal/armv7m/stm32/l4/timer.c
+++ b/hal/armv7m/stm32/l4/timer.c
@@ -39,9 +39,9 @@ time_t hal_timerGet(void)
 {
 	time_t val;
 
-	hal_interruptsDisable();
+	hal_interruptsDisableAll();
 	val = timer_common.time;
-	hal_interruptsEnable();
+	hal_interruptsEnableAll();
 
 	return val;
 }

--- a/hal/hal.h
+++ b/hal/hal.h
@@ -70,12 +70,19 @@ extern int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId);
 extern int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry);
 
 
-/* Function enables interrupts */
-extern void hal_interruptsEnable(void);
+/* Functions enables/disable all interrupts */
+extern void hal_interruptsEnableAll(void);
 
 
-/* Function disables interrupts */
-extern void hal_interruptsDisable(void);
+extern void hal_interruptsDisableAll(void);
+
+
+/* Functions enables/disable specific interrupt */
+
+extern void hal_interruptsEnable(unsigned int irqn);
+
+
+extern void hal_interruptsDisable(unsigned int irqn);
 
 
 /* Function registers interrupts in controller */

--- a/hal/ia32/cpu.c
+++ b/hal/ia32/cpu.c
@@ -53,7 +53,7 @@ void hal_cpuReboot(void)
 {
 	u8 status;
 
-	hal_interruptsDisable();
+	hal_interruptsDisableAll();
 
 	/* 1. Try to reboot using keyboard controller (8042) */
 	do {

--- a/hal/ia32/exceptions.c
+++ b/hal/ia32/exceptions.c
@@ -157,7 +157,7 @@ static void exceptions_defaultHandler(unsigned int n, exc_context_t *ctx)
 	hal_consolePrint("\033[1m");
 	hal_consolePrint(buff);
 	hal_consolePrint("\033[0m");
-	hal_interruptsDisable();
+	hal_interruptsDisableAll();
 	hal_cpuHalt();
 }
 

--- a/hal/ia32/interrupts.c
+++ b/hal/ia32/interrupts.c
@@ -84,13 +84,13 @@ int interrupts_ack(unsigned int n)
 }
 
 
-void hal_interruptsDisable(void)
+void hal_interruptsDisableAll(void)
 {
 	__asm__ volatile("cli":);
 }
 
 
-void hal_interruptsEnable(void)
+void hal_interruptsEnableAll(void)
 {
 	__asm__ volatile("sti":);
 }
@@ -101,12 +101,12 @@ int hal_interruptsSet(unsigned int irq, int (*f)(unsigned int, void *), void *da
 	if (irq >= SIZE_INTERRUPTS)
 		return -EINVAL;
 
-	hal_interruptsDisable();
+	hal_interruptsDisableAll();
 
 	interrupts_common.handlers[irq].f = f;
 	interrupts_common.handlers[irq].data = data;
 
-	hal_interruptsEnable();
+	hal_interruptsEnableAll();
 
 	return EOK;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
New hal API:
 - `hal_interruptsEnable` -> `hal_interruptsEnableAll`
 - `hal_interruptsDisable` -> `hal_interruptsDisableAll`
 - `hal_interruptsEnable(unsigned int irqn)`
 - `hal_interruptsDisable(unsigned int irqn)`

Changes are applied to all architectures and device drivers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Device drivers disabled all interrupts which is not an optimal method of synchronization. In the new approach, the device disable only specific interrupt.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (zedboard, ia32-generic-qemu, zynq7000-qemu).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
