### PR TITLE
cmds/dump.c: remove unnecessary conditions

### DIFF
--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -182,9 +182,7 @@ static int cmd_dump(int argc, char *argv[])
 				memdump = 0;
 				if (argn + 1 < argc) {
 					devname = argv[++argn];
-					if (*devname != '\0') {
-						break;
-					}
+					break;
 				}
 				/* fall-through */
 
@@ -202,7 +200,7 @@ static int cmd_dump(int argc, char *argv[])
 	}
 
 	start = lib_strtoul(argv[argn], &endptr, 16);
-	if (*endptr || ((start == 0) && (endptr == argv[argn]))) {
+	if (*endptr != '\0') {
 		log_error("\n%s: Wrong arguments", argv[0]);
 		return -EINVAL;
 	}
@@ -210,7 +208,7 @@ static int cmd_dump(int argc, char *argv[])
 	argn++;
 	if (argn < argc) {
 		length = lib_strtoul(argv[argn], &endptr, 0);
-		if (*endptr || ((length == 0) && (endptr == argv[argn]))) {
+		if ((*endptr != '\0') || (length == 0)) {
 			log_error("\n%s: Wrong arguments", argv[0]);
 			return -EINVAL;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Arguments cannot be empty strings, so checking if they are empty is unnecessary.
I added a check if the variable`length` is different from zero.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
