### PR TITLE
Conform NULL pointer macro with MISRA rule 11.9

### DIFF
--- a/hal/armv7a/imx6ull/types.h
+++ b/hal/armv7a/imx6ull/types.h
@@ -17,7 +17,7 @@
 #define _TYPES_H_
 
 
-#define NULL 0
+#define NULL ((void *)0)
 
 typedef unsigned char u8;
 typedef unsigned short u16;

--- a/hal/armv7a/zynq7000/types.h
+++ b/hal/armv7a/zynq7000/types.h
@@ -17,7 +17,7 @@
 #define _TYPES_H_
 
 
-#define NULL 0
+#define NULL ((void *)0)
 
 typedef unsigned char u8;
 typedef unsigned short u16;

--- a/hal/armv7m/imxrt/types.h
+++ b/hal/armv7m/imxrt/types.h
@@ -16,7 +16,7 @@
 #ifndef _TYPES_H_
 #define _TYPES_H_
 
-#define NULL 0
+#define NULL ((void *)0)
 
 typedef unsigned char u8;
 typedef unsigned short u16;

--- a/hal/armv7m/stm32/types.h
+++ b/hal/armv7m/stm32/types.h
@@ -17,7 +17,7 @@
 #define _TYPES_H_
 
 
-#define NULL 0
+#define NULL ((void *)0)
 
 typedef unsigned char u8;
 typedef unsigned short u16;

--- a/hal/ia32/types.h
+++ b/hal/ia32/types.h
@@ -17,7 +17,7 @@
 #define _TYPES_H_
 
 
-#define NULL 0
+#define NULL ((void *)0)
 
 typedef unsigned char u8;
 typedef unsigned short u16;

--- a/lib/list.c
+++ b/lib/list.c
@@ -47,6 +47,6 @@ void lib_listRemove(void **list, void *t, size_t noff, size_t poff)
 		if (t == *list)
 			*list = (void *)*((addr_t *)(t + noff));
 	}
-	*((addr_t *)(t + noff)) = NULL;
-	*((addr_t *)(t + poff)) = NULL;
+	*((addr_t *)(t + noff)) = (addr_t)NULL;
+	*((addr_t *)(t + poff)) = (addr_t)NULL;
 }


### PR DESCRIPTION
`NULL pointer constant` of the form `(void *)0` is permitted, whether or not it was expanded from `NULL`. The use of `0` implies `integer constant`, not a `pointer constant`. Using `NULL` rather than `0` makes it clear that a `null pointer constant` was intended.

JIRA: RTOS-282

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
