### PR TITLE
flash-flexspi: move nor_* functions to RAM

### DIFF
--- a/devices/flash-flexspi/nor/nor.c
+++ b/devices/flash-flexspi/nor/nor.c
@@ -81,7 +81,7 @@ static int nor_readID(flexspi_t *fspi, u8 port, u32 *retValue, time_t timeout)
 }
 
 
-int nor_readStatus(flexspi_t *fspi, u8 port, u8 *statusByte, time_t timeout)
+__attribute__((section(".noxip"))) int nor_readStatus(flexspi_t *fspi, u8 port, u8 *statusByte, time_t timeout)
 {
 	struct xferOp xfer;
 
@@ -98,7 +98,7 @@ int nor_readStatus(flexspi_t *fspi, u8 port, u8 *statusByte, time_t timeout)
 }
 
 
-int nor_waitBusy(flexspi_t *fspi, u8 port, time_t timeout)
+__attribute__((section(".noxip"))) int nor_waitBusy(flexspi_t *fspi, u8 port, time_t timeout)
 {
 	int res;
 	u8 status = 0;
@@ -114,7 +114,7 @@ int nor_waitBusy(flexspi_t *fspi, u8 port, time_t timeout)
 }
 
 
-int nor_writeEnable(flexspi_t *fspi, u8 port, int enable, time_t timeout)
+__attribute__((section(".noxip"))) int nor_writeEnable(flexspi_t *fspi, u8 port, int enable, time_t timeout)
 {
 	struct xferOp xfer;
 	int res, seqCode;
@@ -152,7 +152,7 @@ int nor_writeEnable(flexspi_t *fspi, u8 port, int enable, time_t timeout)
 }
 
 
-int nor_eraseSector(flexspi_t *fspi, u8 port, addr_t addr, time_t timeout)
+__attribute__((section(".noxip"))) int nor_eraseSector(flexspi_t *fspi, u8 port, addr_t addr, time_t timeout)
 {
 	struct xferOp xfer;
 
@@ -177,7 +177,7 @@ int nor_eraseSector(flexspi_t *fspi, u8 port, addr_t addr, time_t timeout)
 }
 
 
-int nor_eraseChip(flexspi_t *fspi, u8 port, time_t timeout)
+__attribute__((section(".noxip"))) int nor_eraseChip(flexspi_t *fspi, u8 port, time_t timeout)
 {
 	struct xferOp xfer;
 
@@ -202,7 +202,7 @@ int nor_eraseChip(flexspi_t *fspi, u8 port, time_t timeout)
 }
 
 
-int nor_pageProgram(flexspi_t *fspi, u8 port, addr_t dstAddr, const void *src, size_t pageSz, time_t timeout)
+__attribute__((section(".noxip"))) int nor_pageProgram(flexspi_t *fspi, u8 port, addr_t dstAddr, const void *src, size_t pageSz, time_t timeout)
 {
 	struct xferOp xfer;
 

--- a/ld/armv7m7-imxrt117x.ldt
+++ b/ld/armv7m7-imxrt117x.ldt
@@ -37,7 +37,7 @@ MEMORY
 {
 	/* TODO: use FLEXRAM_CONFIG value to setup ocram/itcm/dtcm partitioning (*32k/16kB) */
 	m_itcm    (rwx) : ORIGIN = 0x00000000, LENGTH = 8 * 32k
-	m_itext   (rwx) : ORIGIN = 0x0003f000, LENGTH = 4k
+	m_itext   (rwx) : ORIGIN = 0x0003ec00, LENGTH = 5k
 	m_dtcm    (rw)  : ORIGIN = 0x20000000 + AREA_KERNEL, LENGTH = (8 * 32k) - AREA_KERNEL
 	m_ocram1  (rwx) : ORIGIN = 0x20240000 + AREA_BOOTLOADER, LENGTH = (8 * 32k) - AREA_BOOTLOADER
 	m_ocram2  (rwx) : ORIGIN = 0x202c0000, LENGTH = 512k


### PR DESCRIPTION
All code between `flexspi_xferExec` and transfer finish (successful return from nor_waitBusy) needs to be runnable without prefetch.

Move all relevant functions to RAM.

JIRA: BES-239

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: BES

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
