### PR TITLE
imxrt: Add otp command with lib_getopt

### DIFF
--- a/cmds/Makefile
+++ b/cmds/Makefile
@@ -7,7 +7,7 @@
 #
 
 PLO_ALLCOMMANDS = alias app bankswitch bitstream call console copy dump echo erase go \
-	help kernel kernelimg map mpu phfs reboot script test-ddr wait
+	help kernel kernelimg map mpu otp phfs reboot script test-ddr wait
 PLO_COMMANDS ?= $(PLO_ALLCOMMANDS)
 PLO_APPLETS = $(filter $(PLO_ALLCOMMANDS), $(PLO_COMMANDS))
 

--- a/cmds/cmd.c
+++ b/cmds/cmd.c
@@ -137,6 +137,8 @@ int cmd_parse(const char *script)
 			if (hal_strcmp(argv[0], cmd_common.cmds[i]->name) != 0)
 				continue;
 
+			lib_getoptReset();
+
 			if ((ret = cmd_common.cmds[i]->run(argc, argv)) < 0)
 				return ret;
 

--- a/cmds/cmd.h
+++ b/cmds/cmd.h
@@ -27,6 +27,11 @@
 /* Reserve +1 for terminating NULL pointer in conformance to C standard */
 #define SIZE_CMD_ARGV (10 + 1)
 
+/* Command exit statuses */
+#define CMD_EXIT_FAILURE 1
+#define CMD_EXIT_SUCCESS 0
+
+
 typedef struct {
 	const char name[12];
 	int (*const run)(int, char *[]);

--- a/cmds/otp.c
+++ b/cmds/otp.c
@@ -1,0 +1,102 @@
+/*
+ * Phoenix-RTOS
+ *
+ * i.MX RT10XX/117X OTP tool
+ *
+ * Reads or writes OCOTP fuses
+ *
+ * Copyright 2020-2022 Phoenix Systems
+ * Author: Aleksander Kaminski, Gerard Swiderski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include "cmd.h"
+
+#include <hal/armv7m/imxrt/otp.h>
+#include <lib/lib.h>
+
+
+static void cmd_otpInfo(void)
+{
+	lib_printf("Reads or writes On-Chip OTP registers: otp <-r|-w value> <-f fuse>");
+}
+
+
+static void cmd_otpUsage(void)
+{
+	lib_printf("Usage: otp [-r | -w value] -f fuse\n"
+			   "  -r       Read fuse\n"
+			   "  -w val   Write fuse with value [val] (32-bit number)\n"
+			   "  -f num   Select fuse (num) to be read or written\n");
+}
+
+
+int cmd_otp(int argc, char *argv[])
+{
+	int opt, res, read = 0, write = 0, fuse = -1;
+	u32 val = 0;
+
+	lib_printf("\n");
+
+	while ((opt = lib_getopt(argc, argv, "f:rw:")) >= 0) {
+		switch (opt) {
+			case 'f':
+				fuse = (int)lib_strtol(optarg, NULL, 0);
+				break;
+
+			case 'r':
+				read = 1;
+				break;
+
+			case 'w':
+				write = 1;
+				val = (u32)lib_strtoul(optarg, NULL, 0);
+				break;
+
+			default:
+				cmd_otpUsage();
+				return CMD_EXIT_FAILURE;
+		}
+	}
+
+	if ((read ^ write) == 0) {
+		lib_printf("Specify either read or write mode\n");
+		cmd_otpUsage();
+		return CMD_EXIT_FAILURE;
+	}
+
+	if (otp_checkFuseValid(fuse) < 0) {
+		lib_printf("Invalid fuse number\n");
+		return CMD_EXIT_FAILURE;
+	}
+
+	if (read != 0) {
+		res = otp_read(fuse, &val);
+		if (res < 0) {
+			lib_printf("Fuse reading failed! (%d)\n", res);
+			return CMD_EXIT_FAILURE;
+		}
+
+		lib_printf("0x%08x\n", val);
+	}
+	else if (write != 0) {
+		res = otp_write(fuse, val);
+		if (res < 0) {
+			lib_printf("Fuse write failed! (%d)\n", res);
+			return CMD_EXIT_FAILURE;
+		}
+		lib_printf("write %x = %x\n", fuse, val);
+	}
+
+	return CMD_EXIT_SUCCESS;
+}
+
+
+__attribute__((constructor)) static void cmd_otpReg(void)
+{
+	const static cmd_t app_cmd = { .name = "otp", .run = cmd_otp, .info = cmd_otpInfo };
+	cmd_reg(&app_cmd);
+}

--- a/hal/armv7a/string.c
+++ b/hal/armv7a/string.c
@@ -225,6 +225,18 @@ char *hal_strncpy(char *dest, const char *src, size_t n)
 }
 
 
+char *hal_strchr(const char *s, int c)
+{
+	do {
+		if (*s == c) {
+			return (char *)s;
+		}
+	} while (*(s++));
+
+	return NULL;
+}
+
+
 int hal_i2s(char *prefix, char *s, unsigned int i, unsigned char b, char zero)
 {
 	static const char digits[] = "0123456789abcdef";

--- a/hal/armv7m/imxrt/10xx/Makefile
+++ b/hal/armv7m/imxrt/10xx/Makefile
@@ -14,10 +14,10 @@ CFLAGS+= -mfloat-abi=soft
 
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
-PLO_COMMANDS = alias app call console copy dump echo erase go help kernel kernelimg map mpu phfs reboot script wait
+PLO_COMMANDS = alias app call console copy dump echo erase go help kernel kernelimg map mpu otp phfs reboot script wait
 
 include devices/usbc-cdc/Makefile
 include devices/uart-imxrt106x/Makefile
 include devices/flash-flexspi/Makefile
 
-OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/imxrt/10xx/, _init.o imxrt.o timer.o console.o)
+OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/imxrt/10xx/, _init.o imxrt.o timer.o console.o otp.o)

--- a/hal/armv7m/imxrt/10xx/otp.c
+++ b/hal/armv7m/imxrt/10xx/otp.c
@@ -1,0 +1,156 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system loader
+ *
+ * On-Chip OTP Controller interface i.MX RT10xx
+ *
+ * Copyright 2021 Phoenix Systems
+ * Author: Gerard Swiderski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <hal/hal.h>
+#include <lib/errno.h>
+
+
+#define FUSE_MIN1 0x400u
+#define FUSE_MAX1 0x6f0u
+#define FUSE_MIN2 0x800u
+#define FUSE_MAX2 0x8f0u
+
+#define OCOTP_BASE ((void *)0x401f4000)
+
+
+/* clang-format off */
+
+enum { otp_ctrl = 0, otp_ctrl_set, otp_ctrl_clr, otp_ctrl_tog, otp_timing,
+	otp_data = 8, otp_read_ctrl = 12, otp_read_fuse_data = 16, otp_sw_sticky = 20,
+	otp_scs = 24, otp_scs_set, otp_scs_clr, otp_scs_tog, otp_crc_addr, otp_crc_value = 32,
+	otp_version = 36, otp_timing2 = 64 };
+
+/* clang-format on */
+
+
+static struct {
+	volatile u32 *base;
+} otp_common;
+
+
+static void otp_waitBusy(void)
+{
+	time_t start;
+
+	while (*(otp_common.base + otp_ctrl) & (1 << 8)) {
+		;
+	}
+
+	/* Wait some more (at least 2 us) */
+	for (start = hal_timerGet(); hal_timerGet() - start > 0;) {
+		;
+	}
+}
+
+
+int otp_checkFuseValid(int fuse)
+{
+	if ((fuse & 0xf) == 0) {
+		if (((fuse >= FUSE_MIN1) && (fuse <= FUSE_MAX1)) || ((fuse >= FUSE_MIN2) && (fuse < FUSE_MAX2))) {
+			return EOK;
+		}
+	}
+
+	return -ERANGE;
+}
+
+
+static u32 fuse2addr(int fuse)
+{
+	if (fuse >= FUSE_MIN2) {
+		fuse -= 0x100;
+	}
+
+	return ((fuse - FUSE_MIN1) >> 4) & 0x3f;
+}
+
+
+u32 otp_getVersion(void)
+{
+	return *(otp_common.base + otp_version);
+}
+
+
+int otp_read(int fuse, u32 *val)
+{
+	unsigned int t;
+
+	int res = otp_checkFuseValid(fuse);
+	if (res != EOK) {
+		return res;
+	}
+
+	/* Clear error flag */
+	*(otp_common.base + otp_ctrl_clr) |= 1 << 9;
+
+	otp_waitBusy();
+
+	/* Set fuse address */
+	t = *(otp_common.base + otp_ctrl) & ~0x3fu;
+	*(otp_common.base + otp_ctrl) = t | fuse2addr(fuse);
+
+	/* Start read */
+	t = *(otp_common.base + otp_read_ctrl) & ~1u;
+	*(otp_common.base + otp_read_ctrl) = t | 1;
+
+	otp_waitBusy();
+
+	*val = *(otp_common.base + otp_read_fuse_data);
+
+	if (*(otp_common.base + otp_ctrl) & (1 << 9)) {
+		*(otp_common.base + otp_ctrl_clr) |= 1 << 9;
+		return -EIO;
+	}
+
+	return EOK;
+}
+
+
+int otp_write(int fuse, u32 val)
+{
+	unsigned int t;
+
+	int res = otp_checkFuseValid(fuse);
+	if (res != EOK) {
+		return res;
+	}
+
+	/* Clear error flag */
+	*(otp_common.base + otp_ctrl_clr) = 1 << 9;
+
+	otp_waitBusy();
+
+	/* Set fuse address and unlock write */
+	t = *(otp_common.base + otp_ctrl) & ~0xffff003fu;
+	*(otp_common.base + otp_ctrl) = t | (0x3e77u << 16) | fuse2addr(fuse);
+
+	/* Program word */
+	*(otp_common.base + otp_data) = val;
+
+	otp_waitBusy();
+
+	if (*(otp_common.base + otp_ctrl) & (1 << 9)) {
+		*(otp_common.base + otp_ctrl_clr) |= 1 << 9;
+		return -EIO;
+	}
+
+	return res;
+}
+
+
+void otp_init(void)
+{
+	otp_common.base = OCOTP_BASE;
+}

--- a/hal/armv7m/imxrt/117x/Makefile
+++ b/hal/armv7m/imxrt/117x/Makefile
@@ -14,10 +14,10 @@ CFLAGS+= -mfloat-abi=soft
 
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
-PLO_COMMANDS = alias app call console copy dump echo erase go help kernel kernelimg map mpu phfs reboot script wait
+PLO_COMMANDS = alias app call console copy dump echo erase go help kernel kernelimg map mpu otp phfs reboot script wait
 
 include devices/usbc-cdc/Makefile
 include devices/uart-imxrt117x/Makefile
 include devices/flash-flexspi/Makefile
 
-OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/imxrt/117x/, _init.o imxrt.o timer.o console.o)
+OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/imxrt/117x/, _init.o imxrt.o timer.o console.o otp.o)

--- a/hal/armv7m/imxrt/117x/otp.c
+++ b/hal/armv7m/imxrt/117x/otp.c
@@ -1,0 +1,162 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system loader
+ *
+ * On-Chip OTP Controller interface i.MX RT117x
+ *
+ * Copyright 2020-2022 Phoenix Systems
+ * Author: Aleksander Kaminski, Gerard Swiderski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include <hal/hal.h>
+#include <lib/errno.h>
+
+
+#define FUSE_MIN   0x0800u
+#define FUSE_MAX   0x18f0u
+#define OCOTP_BASE ((void *)0x40cac000)
+
+
+/* clang-format off */
+
+enum { otp_ctrl = 0, otp_ctrl_set, otp_ctrl_clr, otp_ctrl_tog, otp_pdn,
+	otp_data = 8, otp_read_ctrl = 12, otp_out_status = 36, otp_out_status_set, otp_out_status_clr,
+	otp_out_status_tog, otp_version = 44, otp_read_fuse_data0 = 64, otp_read_fuse_data1 = 68,
+	otp_read_fuse_data2 = 72, otp_read_fuse_data3 = 76, otp_sw_lock = 80, otp_bit_lock = 84,
+	otp_locked0 = 384, otp_locked1 = 388, otp_locked2 = 392, otp_locked3 = 396, otp_locked4 = 400,
+	otp_fuse = 512 };
+
+/* clang-format on */
+
+
+static struct {
+	volatile u32 *base;
+} otp_common;
+
+
+static void otp_clrError(void)
+{
+	*(otp_common.base + otp_ctrl_clr) = 1 << 11;
+	*(otp_common.base + otp_out_status_clr) = ~0u;
+}
+
+
+static void otp_waitBusy(void)
+{
+	time_t start;
+
+	while (*(otp_common.base + otp_ctrl) & (1 << 10)) {
+		;
+	}
+
+	/* Wait some more (at least 2 us) */
+	for (start = hal_timerGet(); hal_timerGet() - start > 0;) {
+		;
+	}
+}
+
+
+int otp_checkFuseValid(int fuse)
+{
+	if ((fuse >= FUSE_MIN) && (fuse <= FUSE_MAX) && ((fuse & 0xf) == 0)) {
+		return EOK;
+	}
+
+	return -ERANGE;
+}
+
+
+static u32 fuse2addr(int fuse)
+{
+	return ((fuse - FUSE_MIN) >> 4) & 0x3ff;
+}
+
+
+u32 otp_getVersion(void)
+{
+	return *(otp_common.base + otp_version);
+}
+
+
+int otp_read(int fuse, u32 *val)
+{
+	unsigned int t;
+
+	int res = otp_checkFuseValid(fuse);
+	if (res != EOK) {
+		return res;
+	}
+
+	otp_clrError();
+	otp_waitBusy();
+
+	/* Set fuse address */
+	t = *(otp_common.base + otp_ctrl) & ~0x3ffu;
+	*(otp_common.base + otp_ctrl) = t | fuse2addr(fuse);
+
+	/* Start read */
+	t = *(otp_common.base + otp_read_ctrl) & ~0x1fu;
+	*(otp_common.base + otp_read_ctrl) = t | (3 << 1) | 1;
+
+	otp_waitBusy();
+
+	*val = *(otp_common.base + otp_read_fuse_data0);
+
+	if (*(otp_common.base + otp_out_status) & (1 << 24)) {
+		*(otp_common.base + otp_out_status_clr) |= 1 << 24;
+
+		return -EIO;
+	}
+
+	return EOK;
+}
+
+
+int otp_write(int fuse, u32 val)
+{
+	unsigned int t;
+
+	int res = otp_checkFuseValid(fuse);
+	if (res != EOK) {
+		return res;
+	}
+
+	otp_clrError();
+	otp_waitBusy();
+
+	/* Set fuse address and unlock write */
+	t = *(otp_common.base + otp_ctrl) & ~0xffff03ffu;
+	*(otp_common.base + otp_ctrl) = t | (0x3e77u << 16) | fuse2addr(fuse);
+
+	/* Program the word */
+	*(otp_common.base + otp_data) = val;
+
+	otp_waitBusy();
+
+	t = *(otp_common.base + otp_out_status);
+
+	if (t & (1 << 12)) {
+		res = -EIO;
+	}
+
+	if (t & (1u << 11)) {
+		res = -EPERM;
+	}
+
+	if (res != 0) {
+		*(otp_common.base + otp_out_status_clr) |= 0x3 << 11;
+	}
+
+	return res;
+}
+
+
+void otp_init(void)
+{
+	otp_common.base = OCOTP_BASE;
+}

--- a/hal/armv7m/imxrt/hal.c
+++ b/hal/armv7m/imxrt/hal.c
@@ -14,6 +14,7 @@
  */
 
 #include <hal/hal.h>
+#include "otp.h"
 
 
 struct {
@@ -48,6 +49,7 @@ void hal_init(void)
 
 	mpu_init();
 	timer_init();
+	otp_init();
 	console_init();
 
 	hal_common.entry = (addr_t)-1;

--- a/hal/armv7m/imxrt/otp.h
+++ b/hal/armv7m/imxrt/otp.h
@@ -1,0 +1,40 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system loader
+ *
+ * On-Chip OTP Controller interface i.MX RT series
+ *
+ * Copyright 2020-2022 Phoenix Systems
+ * Author: Aleksander Kaminski, Gerard Swiderski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef _OTP_H_
+#define _OTP_H_
+
+
+#define OTP_VERSION_MAJOR(v) (((v) >> 24) & 0xff)
+#define OTP_VERSION_MINOR(v) (((v) >> 16) & 0xff)
+#define OTP_VERSION_STEP(v)  ((v)&0xffff)
+
+
+u32 otp_getVersion(void);
+
+
+int otp_checkFuseValid(int fuse);
+
+
+int otp_read(int fuse, u32 *val);
+
+
+int otp_write(int fuse, u32 val);
+
+
+void otp_init(void);
+
+
+#endif /* _OTP_H_ */

--- a/hal/armv7m/string.c
+++ b/hal/armv7m/string.c
@@ -225,6 +225,18 @@ char *hal_strncpy(char *dest, const char *src, size_t n)
 }
 
 
+char *hal_strchr(const char *s, int c)
+{
+	do {
+		if (*s == c) {
+			return (char *)s;
+		}
+	} while (*(s++));
+
+	return NULL;
+}
+
+
 int hal_i2s(char *prefix, char *s, unsigned int i, unsigned char b, char zero)
 {
 	static const char digits[] = "0123456789abcdef";

--- a/hal/armv8m/string.c
+++ b/hal/armv8m/string.c
@@ -229,6 +229,18 @@ char *hal_strncpy(char *dest, const char *src, size_t n)
 /* clang-format on */
 
 
+char *hal_strchr(const char *s, int c)
+{
+	do {
+		if (*s == c) {
+			return (char *)s;
+		}
+	} while (*(s++));
+
+	return NULL;
+}
+
+
 int hal_i2s(char *prefix, char *s, unsigned int i, unsigned char b, char zero)
 {
 	static const char digits[] = "0123456789abcdef";

--- a/hal/ia32/string.c
+++ b/hal/ia32/string.c
@@ -151,6 +151,18 @@ char *hal_strncpy(char *dest, const char *src, size_t n)
 }
 
 
+char *hal_strchr(const char *s, int c)
+{
+	do {
+		if (*s == c) {
+			return (char *)s;
+		}
+	} while (*(s++));
+
+	return NULL;
+}
+
+
 int hal_i2s(char *prefix, char *s, unsigned int i, unsigned char b, char zero)
 {
 	static const char digits[] = "0123456789abcdef";

--- a/hal/string.h
+++ b/hal/string.h
@@ -43,6 +43,9 @@ extern char *hal_strcpy(char *dest, const char *src);
 extern char *hal_strncpy(char *dest, const char *src, size_t n);
 
 
+extern char *hal_strchr(const char *str, int z);
+
+
 extern int hal_i2s(char *prefix, char *s, unsigned int i, unsigned char b, char zero);
 
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -6,4 +6,4 @@
 # %LICENSE%
 #
 
-OBJS += $(addprefix $(PREFIX_O)lib/, console.o ctype.o cbuffer.o format.o list.o log.o printf.o prompt.o sprintf.o strtoul.o)
+OBJS += $(addprefix $(PREFIX_O)lib/, console.o ctype.o cbuffer.o format.o getopt.o list.o log.o printf.o prompt.o sprintf.o strtoul.o)

--- a/lib/getopt.c
+++ b/lib/getopt.c
@@ -1,0 +1,119 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system loader
+ *
+ * getopt - command arguments parser
+ *
+ * Copyright 2018-2022 Phoenix Systems
+ * Author: Jan Sikorski, Krystian Wasik
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include "lib.h"
+#include <hal/string.h>
+
+
+/* globals */
+char *optarg;
+int optind;
+int opterr;
+int optopt;
+
+
+static struct {
+	int optwhere;
+} getopt_common;
+
+
+void lib_getoptReset(void)
+{
+	optarg = NULL;
+	optind = 1;
+	opterr = 1;
+	optopt = 0;
+	getopt_common.optwhere = 1;
+}
+
+
+int lib_getopt(int argc, char *const argv[], const char *optstring)
+{
+	char opt;
+	char *optspec;
+	int leading_colon;
+
+	if (optind == 0) {
+		lib_getoptReset();
+	}
+
+	if (argc == 0 || argv == NULL || optind >= argc) {
+		return -1;
+	}
+
+	if (argv[optind] == NULL || argv[optind][0] != '-' || argv[optind][1] == '\0') {
+		return -1;
+	}
+
+	if (argv[optind][1] == '-' && argv[optind][2] == '\0') {
+		optind++;
+		return -1;
+	}
+
+	opt = argv[optind][getopt_common.optwhere++];
+	leading_colon = *optstring == ':';
+
+	optspec = hal_strchr(optstring, opt);
+	if (optspec == NULL) {
+		/* Unrecognized option */
+		optopt = opt;
+		if (opterr != 0 && leading_colon == 0) {
+			lib_printf("%s: illegal option -- %c\n", argv[0], opt);
+		}
+
+		if (argv[optind][getopt_common.optwhere] == '\0') {
+			optind++;
+			getopt_common.optwhere = 1;
+		}
+
+		return '?';
+	}
+
+	if (*(++optspec) == ':') {
+		if (argv[optind][getopt_common.optwhere] != '\0') {
+			/* Argument in the same argv */
+			optarg = &argv[optind][getopt_common.optwhere];
+		}
+		else if (optind + 1 < argc) {
+			/* Argument in the next argv */
+			optarg = argv[optind + 1];
+			optind++;
+		}
+		else {
+			/* Argument not provided */
+			optopt = opt;
+			optind++;
+			getopt_common.optwhere = 1;
+			if (leading_colon != 0) {
+				return ':';
+			}
+			else {
+				if (opterr != 0) {
+					lib_printf("%s: option requires an argument -- %c\n", argv[0], opt);
+				}
+				return '?';
+			}
+		}
+	}
+	else if (argv[optind][getopt_common.optwhere] != '\0') {
+		/* More options in the same argv */
+		return opt;
+	}
+
+	optind++;
+	getopt_common.optwhere = 1;
+
+	return opt;
+}

--- a/lib/getopt.h
+++ b/lib/getopt.h
@@ -1,0 +1,34 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system loader
+ *
+ * getopt - command arguments parser
+ *
+ * Copyright 2022 Phoenix Systems
+ * Author: Jan Sikorski, Krystian Wasik
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef _LIB_GETOPT_H_
+#define _LIB_GETOPT_H_
+
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+
+
+/* Resets getopt "opt*" globals to initial state */
+extern void lib_getoptReset(void);
+
+
+/* Parses command-line arguments */
+extern int lib_getopt(int argc, char *const argv[], const char *optstring);
+
+
+#endif

--- a/lib/lib.h
+++ b/lib/lib.h
@@ -20,6 +20,7 @@
 #include "console.h"
 #include "ctype.h"
 #include "errno.h"
+#include "getopt.h"
 #include "list.h"
 #include "log.h"
 #include "stdarg.h"


### PR DESCRIPTION
This change adds the `otp` command for reading and writing the `OCOTP` memory/registers on  the i.MX RT 117x and 10xx family.

And additionally introduces `lib_getopt()`, this functionality will simplify the portability of commands, as well as simplify parsing of commands (which is currently performed by each command on its own and increase the plo code size), using common parser will also potentially reduce the plo size (on a `DRY principle`) if all commands will be updated to use the `well known` common argument parser.

JIRA: NIL-374

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (nil-imxrt1176, mimxrt1064-evk).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
