### PR TITLE
usb-cdc: Fix usb device dis/connect state

### DIFF
--- a/cmds/copy.c
+++ b/cmds/copy.c
@@ -46,7 +46,7 @@ static ssize_t cmd_cpphfs2phfs(handler_t srcHandler, addr_t srcAddr, size_t srcS
 	do {
 		chunk = ((srcSz - rsz) > sizeof(buff)) ? sizeof(buff) : (srcSz - rsz);
 		if ((res = phfs_read(srcHandler, srcAddr + rsz, buff, chunk)) < 0) {
-			log_error("\nCan't read data\n");
+			log_error("\nCan't read data");
 			return res;
 		}
 		rsz += res;
@@ -54,7 +54,7 @@ static ssize_t cmd_cpphfs2phfs(handler_t srcHandler, addr_t srcAddr, size_t srcS
 		chunk = res;
 		while (chunk) {
 			if ((res = phfs_write(dstHandler, dstAddr + wsz, buff, chunk)) < 0) {
-				log_error("\nCan't write data to address: 0x%x\n", dstAddr + wsz);
+				log_error("\nCan't write data to address: 0x%x", dstAddr + wsz);
 				return res;
 			}
 			chunk -= res;

--- a/devices/usbc-cdc/cdc.c
+++ b/devices/usbc-cdc/cdc.c
@@ -21,7 +21,7 @@
 #include <lib/lib.h>
 
 
-#define SIZE_USB_ENDPTS 2 * PHFS_ACM_PORTS_NB + 1 /* Add control endpoint */
+#define SIZE_USB_ENDPTS (2 * (PHFS_ACM_PORTS_NB) + 1) /* Add control endpoint */
 
 
 struct {

--- a/devices/usbc-cdc/cdc.c
+++ b/devices/usbc-cdc/cdc.c
@@ -342,8 +342,11 @@ const usb_string_desc_t dStrprod = {
 
 static ssize_t cdc_recv(unsigned int minor, addr_t offs, void *buff, size_t len, time_t timeout)
 {
-	if (minor > SIZE_USB_ENDPTS)
+	(void)offs;
+
+	if (minor > SIZE_USB_ENDPTS) {
 		return -EINVAL;
+	}
 
 	return usbclient_receive(minor, buff, len);
 }
@@ -351,8 +354,11 @@ static ssize_t cdc_recv(unsigned int minor, addr_t offs, void *buff, size_t len,
 
 static ssize_t cdc_send(unsigned int minor, addr_t offs, const void *buff, size_t len)
 {
-	if (minor > SIZE_USB_ENDPTS)
+	(void)offs;
+
+	if (minor > SIZE_USB_ENDPTS) {
 		return -EINVAL;
+	}
 
 	return usbclient_send(minor, buff, len);
 }
@@ -360,80 +366,90 @@ static ssize_t cdc_send(unsigned int minor, addr_t offs, const void *buff, size_
 
 static int cdc_initUsbClient(void)
 {
-	int i = 0;
-	int res = EOK;
+	int i;
+	int res;
 
-	if (cdc_common.init == 0) {
-		cdc_common.descList = NULL;
-		cdc_common.dev.descriptor = (usb_functional_desc_t *)&dDev;
-		LIST_ADD(&cdc_common.descList, &cdc_common.dev);
-
-		cdc_common.conf.descriptor = (usb_functional_desc_t *)&dConfig;
-		LIST_ADD(&cdc_common.descList, &cdc_common.conf);
-
-		for (i = 0; i < PHFS_ACM_PORTS_NB; ++i) {
-			cdc_common.ports[i].iad.descriptor = (usb_functional_desc_t *)&dIad[i];
-			LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].iad);
-
-			cdc_common.ports[i].comIface.descriptor = (usb_functional_desc_t *)&dComIntf[i];
-			LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].comIface);
-
-			cdc_common.ports[i].header.descriptor = (usb_functional_desc_t *)&dHeader[i];
-			LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].header);
-
-			cdc_common.ports[i].call.descriptor = (usb_functional_desc_t *)&dCall[i];
-			LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].call);
-
-			cdc_common.ports[i].acm.descriptor = (usb_functional_desc_t *)&dAcm[i];
-			LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].acm);
-
-			cdc_common.ports[i].unio.descriptor = (usb_functional_desc_t *)&dUnion[i];
-			LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].unio);
-
-			cdc_common.ports[i].comEp.descriptor = (usb_functional_desc_t *)&dComEp[i];
-			LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].comEp);
-
-			cdc_common.ports[i].dataIface.descriptor = (usb_functional_desc_t *)&dDataIntf[i];
-			LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].dataIface);
-
-			cdc_common.ports[i].dataEpOUT.descriptor = (usb_functional_desc_t *)&dEpOUT[i];
-			LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].dataEpOUT);
-
-			cdc_common.ports[i].dataEpIN.descriptor = (usb_functional_desc_t *)&dEpIN[i];
-			LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].dataEpIN);
-		}
-
-		cdc_common.str0.descriptor = (usb_functional_desc_t *)&dStr0;
-		LIST_ADD(&cdc_common.descList, &cdc_common.str0);
-
-		cdc_common.strman.descriptor = (usb_functional_desc_t *)&dStrman;
-		LIST_ADD(&cdc_common.descList, &cdc_common.strman);
-
-		cdc_common.strprod.descriptor = (usb_functional_desc_t *)&dStrprod;
-		LIST_ADD(&cdc_common.descList, &cdc_common.strprod);
-
-		cdc_common.strprod.next = NULL;
-
-		if ((res = usbclient_init(cdc_common.descList)) != EOK)
-			return res;
-
-		cdc_common.init = 1;
+	if (cdc_common.init != 0) {
+		/* Already initialized */
+		return EOK;
 	}
 
-	return res;
+	cdc_common.descList = NULL;
+	cdc_common.dev.descriptor = (usb_functional_desc_t *)&dDev;
+	LIST_ADD(&cdc_common.descList, &cdc_common.dev);
+
+	cdc_common.conf.descriptor = (usb_functional_desc_t *)&dConfig;
+	LIST_ADD(&cdc_common.descList, &cdc_common.conf);
+
+	for (i = 0; i < PHFS_ACM_PORTS_NB; ++i) {
+		cdc_common.ports[i].iad.descriptor = (usb_functional_desc_t *)&dIad[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].iad);
+
+		cdc_common.ports[i].comIface.descriptor = (usb_functional_desc_t *)&dComIntf[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].comIface);
+
+		cdc_common.ports[i].header.descriptor = (usb_functional_desc_t *)&dHeader[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].header);
+
+		cdc_common.ports[i].call.descriptor = (usb_functional_desc_t *)&dCall[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].call);
+
+		cdc_common.ports[i].acm.descriptor = (usb_functional_desc_t *)&dAcm[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].acm);
+
+		cdc_common.ports[i].unio.descriptor = (usb_functional_desc_t *)&dUnion[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].unio);
+
+		cdc_common.ports[i].comEp.descriptor = (usb_functional_desc_t *)&dComEp[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].comEp);
+
+		cdc_common.ports[i].dataIface.descriptor = (usb_functional_desc_t *)&dDataIntf[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].dataIface);
+
+		cdc_common.ports[i].dataEpOUT.descriptor = (usb_functional_desc_t *)&dEpOUT[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].dataEpOUT);
+
+		cdc_common.ports[i].dataEpIN.descriptor = (usb_functional_desc_t *)&dEpIN[i];
+		LIST_ADD(&cdc_common.descList, &cdc_common.ports[i].dataEpIN);
+	}
+
+	cdc_common.str0.descriptor = (usb_functional_desc_t *)&dStr0;
+	LIST_ADD(&cdc_common.descList, &cdc_common.str0);
+
+	cdc_common.strman.descriptor = (usb_functional_desc_t *)&dStrman;
+	LIST_ADD(&cdc_common.descList, &cdc_common.strman);
+
+	cdc_common.strprod.descriptor = (usb_functional_desc_t *)&dStrprod;
+	LIST_ADD(&cdc_common.descList, &cdc_common.strprod);
+
+	cdc_common.strprod.next = NULL;
+
+	res = usbclient_init(cdc_common.descList);
+	if (res != EOK) {
+		return res;
+	}
+
+	cdc_common.init = 1;
+
+	return EOK;
 }
 
 
 static int cdc_done(unsigned int minor)
 {
+	if (PHFS_ACM_PORTS_NB < 1 || PHFS_ACM_PORTS_NB > 2 || minor != endpt_bulk_acm0) {
+		return -EINVAL;
+	}
+
 	return usbclient_destroy();
 }
 
 
 static int cdc_sync(unsigned int minor)
 {
-	if (minor > SIZE_USB_ENDPTS)
+	if (minor > SIZE_USB_ENDPTS) {
 		return -EINVAL;
+	}
 
 	/* TBD */
 
@@ -443,12 +459,14 @@ static int cdc_sync(unsigned int minor)
 
 static int cdc_map(unsigned int minor, addr_t addr, size_t sz, int mode, addr_t memaddr, size_t memsz, int memmode, addr_t *a)
 {
-	if (minor > PHFS_ACM_PORTS_NB * 2)
+	if (minor > PHFS_ACM_PORTS_NB * 2) {
 		return -EINVAL;
+	}
 
 	/* Device mode cannot be higher than map mode to copy data */
-	if ((mode & memmode) != mode)
+	if ((mode & memmode) != mode) {
 		return -EINVAL;
+	}
 
 	/* Cdc is not mappable to any region */
 	return dev_isNotMappable;
@@ -457,13 +475,16 @@ static int cdc_map(unsigned int minor, addr_t addr, size_t sz, int mode, addr_t 
 
 static int cdc_init(unsigned int minor)
 {
-	int res = EOK;
+	int res;
 
-	if (PHFS_ACM_PORTS_NB < 1 || PHFS_ACM_PORTS_NB > 2 || minor != endpt_bulk_acm0)
+	if (PHFS_ACM_PORTS_NB < 1 || PHFS_ACM_PORTS_NB > 2 || minor != endpt_bulk_acm0) {
 		return -EINVAL;
+	}
 
-	if ((res = cdc_initUsbClient()) < 0)
+	res = cdc_initUsbClient();
+	if (res < 0) {
 		return res;
+	}
 
 	lib_printf("\ndev/usb: Initializing usb-cdc(%d.%d)", DEV_USB, minor);
 

--- a/devices/usbc-cdc/client.h
+++ b/devices/usbc-cdc/client.h
@@ -5,8 +5,8 @@
  *
  * USB client
  *
- * Copyright 2019-2021 Phoenix Systems
- * Author: Kamil Amanowicz, Hubert Buczynski
+ * Copyright 2019-2023 Phoenix Systems
+ * Author: Kamil Amanowicz, Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -93,10 +93,12 @@ typedef struct _usb_dc_t {
 	volatile dqh_t *endptqh;
 	u32 status;
 	u32 dev_addr;
+	u8 connected;
 
 	volatile u8 op;
 	usb_setup_packet_t setup;
 
+	volatile int endptFailed;
 	volatile u32 setupstat;
 } usb_dc_t;
 
@@ -158,13 +160,16 @@ extern int ctrl_init(usb_common_data_t *usb_data_in, usb_dc_t *dc_in);
 extern void ctrl_setAddress(u32 addr);
 
 
+extern void ctrl_initQtd(void);
+
+
 extern int ctrl_endptInit(int endpt, endpt_data_t *ctrl_endptInit);
 
 
-extern int ctrl_lfIrq(void);
+extern void ctrl_lfIrq(void);
 
 
-extern int ctrl_hfIrq(void);
+extern void ctrl_hfIrq(void);
 
 
 extern dtd_t *ctrl_execTransfer(int endpt, u32 paddr, u32 sz, int dir);

--- a/devices/usbc-cdc/ctrl.c
+++ b/devices/usbc-cdc/ctrl.c
@@ -5,8 +5,8 @@
  *
  * USB device controller driver
  *
- * Copyright 2019-2021 Phoenix Systems
- * Author: Kamil Amanowicz, Hubert Buczynski
+ * Copyright 2019-2023 Phoenix Systems
+ * Author: Kamil Amanowicz, Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -20,8 +20,11 @@
 #include <lib/errno.h>
 
 
-struct {
-	u32 qtdOffs;
+#define USBCTRL_TIMEOUT 250
+
+
+static struct {
+	volatile u32 qtdOffs;
 
 	usb_dc_t *dc;
 	usb_common_data_t *data;
@@ -52,10 +55,13 @@ enum {
 
 static int ctrl_allocBuff(int endpt, int dir)
 {
-	ctrl_common.data->endpts[endpt].buf[dir].buffer = usbclient_allocBuff(USB_BUFFER_SIZE);
-
-	if (ctrl_common.data->endpts[endpt].buf[dir].buffer == NULL)
-		return -ENOMEM;
+	/* Allocate buffer for the first time (initially is NULL) */
+	if (ctrl_common.data->endpts[endpt].buf[dir].buffer == NULL) {
+		ctrl_common.data->endpts[endpt].buf[dir].buffer = usbclient_allocBuff(USB_BUFFER_SIZE);
+		if (ctrl_common.data->endpts[endpt].buf[dir].buffer == NULL) {
+			return -ENOMEM;
+		}
+	}
 
 	ctrl_common.data->endpts[endpt].buf[dir].len = 0;
 
@@ -65,49 +71,49 @@ static int ctrl_allocBuff(int endpt, int dir)
 
 static void *ctrl_allocQtdMem(void)
 {
-	int i;
+	if (ctrl_common.qtdOffs == 0) {
+		/* Allocate buffer for the first time (initially dtdMem is NULL) */
+		if (ctrl_common.dc->dtdMem == NULL) {
+			ctrl_common.dc->dtdMem = usbclient_allocBuff(USB_BUFFER_SIZE);
+			if (ctrl_common.dc->dtdMem == NULL) {
+				return NULL;
+			}
+		}
 
-	if (!ctrl_common.qtdOffs) {
-		ctrl_common.dc->dtdMem = usbclient_allocBuff(USB_BUFFER_SIZE);
-
-		if (ctrl_common.dc->dtdMem == NULL)
-			return NULL;
-
-		for (i = 0; i < USB_BUFFER_SIZE; ++i)
-			((char *)ctrl_common.dc->dtdMem)[i] = 0;
+		hal_memset(ctrl_common.dc->dtdMem, 0, USB_BUFFER_SIZE);
 	}
 
-	return (void *)(ctrl_common.dc->dtdMem + 0x40 * (ctrl_common.qtdOffs++));
+	return (void *)(ctrl_common.dc->dtdMem + (addr_t)64 * (ctrl_common.qtdOffs++));
 }
 
 
-static int ctrl_dtdInit(int endpt, int inQH, int outQh)
+static int ctrl_dtdInit(int endpt, int inQH, int outQH)
 {
 	dtd_t *dtd;
 	int qh = endpt * 2;
 
-	if (!endpt)
-		return -1;
-
 	/* initialize dtd for selected endpoints */
-	if (outQh) {
+	if (outQH != 0) {
 		dtd = ctrl_allocQtdMem();
-		if (dtd == NULL)
+		if (dtd == NULL) {
 			return -ENOMEM;
+		}
 
-		ctrl_common.dc->endptqh[qh].base = (((u32)dtd) & ~0xfff);
-		ctrl_common.dc->endptqh[qh].size = 0x40;
+		ctrl_common.dc->endptqh[qh].base = (((u32)dtd) & ~(USB_BUFFER_SIZE - 1));
+		ctrl_common.dc->endptqh[qh].size = 64;
 		ctrl_common.dc->endptqh[qh].head = dtd;
 		ctrl_common.dc->endptqh[qh].tail = dtd;
 	}
 
-	if (inQH) {
+	if (inQH != 0) {
 		dtd = ctrl_allocQtdMem();
-		if (dtd == NULL)
+		if (dtd == NULL) {
 			return -ENOMEM;
+		}
 
-		ctrl_common.dc->endptqh[++qh].base = (((u32)dtd) & ~0xfff) + (64 * sizeof(dtd_t));
-		ctrl_common.dc->endptqh[qh].size = 0x40;
+		qh++;
+		ctrl_common.dc->endptqh[qh].base = (((u32)dtd) & ~(USB_BUFFER_SIZE - 1)) + (64 * sizeof(dtd_t));
+		ctrl_common.dc->endptqh[qh].size = 64;
 		ctrl_common.dc->endptqh[qh].head = dtd + 64;
 		ctrl_common.dc->endptqh[qh].tail = dtd + 64;
 	}
@@ -116,49 +122,70 @@ static int ctrl_dtdInit(int endpt, int inQH, int outQh)
 }
 
 
-static int ctrl_initEndptQh(int endpt, int dir, endpt_data_t *endpt_init)
+static u32 ctrl_initEndptQh(int endpt, int dir, endpt_data_t *endpt_init)
 {
-	u32 setup = 0, tmp;
+	u32 setup, caps;
 	int qh = endpt * 2 + dir;
 
-	ctrl_allocBuff(endpt, dir);
+	if (ctrl_allocBuff(endpt, dir) < 0) {
+		return -ENOMEM;
+	}
 
-	tmp = endpt_init->caps[dir].max_pkt_len << 16;
-	tmp |= endpt_init->caps[dir].ios << 15;
-	tmp |= endpt_init->caps[dir].zlt << 29;
-	tmp |= endpt_init->caps[dir].mult << 30;
-	ctrl_common.dc->endptqh[qh].caps = tmp;
+	caps = (endpt_init->caps[dir].max_pkt_len & 0x7ff) << 16;
+	caps |= (endpt_init->caps[dir].ios & 1) << 15;
+	caps |= (endpt_init->caps[dir].zlt & 1) << 29;
+	caps |= (endpt_init->caps[dir].mult & 3) << 30;
+	ctrl_common.dc->endptqh[qh].caps = caps;
 	ctrl_common.dc->endptqh[qh].dtd_next = 1;
 
-	setup |= endpt_init->ctrl[dir].data_toggle << (6 + dir * 16);
-	setup |= endpt_init->ctrl[dir].type << (2 + dir * 16);
+	setup = (endpt_init->ctrl[dir].data_toggle & 1) << 6;
+	setup |= (endpt_init->ctrl[dir].type & 3) << 2;
+	setup |= (endpt_init->ctrl[dir].stall & 1);
 
-	return setup;
+	return dir != 0 ? setup << 16 : setup;
+}
+
+
+void ctrl_initQtd(void)
+{
+	/*
+	 * Reset qtd offset for non control endpoints every time device is re/connected to
+	 * host, at any time when desc_setup(REQ_SET_ADDRESS) is initiated
+	 */
+
+	ctrl_common.qtdOffs = 0;
 }
 
 
 int ctrl_endptInit(int endpt, endpt_data_t *endpt_init)
 {
-	s8 i;
+	u8 i;
 	int res = EOK;
 	u32 setup = 0;
 
-	if (endpt == 0)
-		return -1;
+	if (endpt <= 0) {
+		return -ENXIO;
+	}
 
-	if ((res = ctrl_dtdInit(endpt, endpt_init->caps[USB_ENDPT_DIR_IN].init, endpt_init->caps[USB_ENDPT_DIR_OUT].init)) != EOK)
+	res = ctrl_dtdInit(endpt, endpt_init->caps[USB_ENDPT_DIR_IN].init, endpt_init->caps[USB_ENDPT_DIR_OUT].init);
+	if (res != EOK) {
 		return res;
+	}
 
+	/* Setup RX & TX endpoints */
 	for (i = 0; i < ENDPOINTS_DIR_NB; ++i) {
-		if (endpt_init->caps[i].init)
+		if (endpt_init->caps[i].init != 0) {
 			setup |= ctrl_initEndptQh(endpt, i, endpt_init);
+		}
 	}
 
 	*(ctrl_common.dc->base + endptctrl0 + endpt) = setup;
 
+	/* Enable endpoints */
 	for (i = 0; i < ENDPOINTS_DIR_NB; ++i) {
-		if (endpt_init->caps[i].init)
-			*(ctrl_common.dc->base + endptctrl0 + endpt) |= 1 << (7 + i * 16);
+		if (endpt_init->caps[i].init != 0) {
+			*(ctrl_common.dc->base + endptctrl0 + endpt) |= 1U << (7 + i * 16);
+		}
 	}
 
 	return res;
@@ -167,42 +194,46 @@ int ctrl_endptInit(int endpt, endpt_data_t *endpt_init)
 
 int ctrl_endpt0Init(void)
 {
-	int i;
-	u32 qh_addr, tmp;
+	u32 qh_addr, caps;
 
-	if (ctrl_allocBuff(0, USB_ENDPT_DIR_IN) < 0)
+	if (ctrl_allocBuff(0, USB_ENDPT_DIR_IN) != EOK) {
 		return -ENOMEM;
+	}
 
-	if (ctrl_allocBuff(0, USB_ENDPT_DIR_OUT) < 0)
+	if (ctrl_allocBuff(0, USB_ENDPT_DIR_OUT) != EOK) {
 		return -ENOMEM;
+	}
 
 	ctrl_common.data->endpts[0].caps[USB_ENDPT_DIR_IN].init = 1;
 	ctrl_common.data->endpts[0].caps[USB_ENDPT_DIR_OUT].init = 1;
 
-	/* map queue head list */
-	ctrl_common.dc->endptqh = usbclient_allocBuff(USB_BUFFER_SIZE);
+	/* map queue head list for the first time (initially endptqh is NULL) */
+	if (ctrl_common.dc->endptqh == NULL) {
+		ctrl_common.dc->endptqh = usbclient_allocBuff(USB_BUFFER_SIZE);
 
-	if (ctrl_common.dc->endptqh == NULL)
-		return -ENOMEM;
+		if (ctrl_common.dc->endptqh == NULL) {
+			return -ENOMEM;
+		}
+	}
 
-	for (i = 0; i < USB_BUFFER_SIZE; ++i)
-		((char *)ctrl_common.dc->endptqh)[i] = 0;
+	hal_memset((void *)ctrl_common.dc->endptqh, 0, USB_BUFFER_SIZE);
 
-	qh_addr = ((u32)((void *)ctrl_common.dc->endptqh)) & ~0xfff;
+	qh_addr = ((u32)((void *)ctrl_common.dc->endptqh)) & ~(USB_BUFFER_SIZE - 1);
 
-	tmp = 0x40 << 16 /* max 64 bytes */ | 0x1 << 29 | 0x1 << 15 /* ios */;
-	ctrl_common.dc->endptqh[0].caps = tmp;
-	ctrl_common.dc->endptqh[0].dtd_next = 0x1; /* invalid */
-	ctrl_common.dc->endptqh[1].caps = tmp;
-	ctrl_common.dc->endptqh[1].dtd_next = 1;
+	/* ctrl packet_len=64, zlt=1, ios=1 */
+	caps = (64 << 16) | (1 << 29) | (1 << 15);
 
+	ctrl_common.dc->endptqh[0].size = 64;
+	ctrl_common.dc->endptqh[0].caps = caps;
+	ctrl_common.dc->endptqh[0].dtd_next = 1;
 	ctrl_common.dc->endptqh[0].base = qh_addr + (32 * sizeof(dqh_t));
-	ctrl_common.dc->endptqh[0].size = 0x40;
 	ctrl_common.dc->endptqh[0].head = (dtd_t *)(ctrl_common.dc->endptqh + 32);
 	ctrl_common.dc->endptqh[0].tail = (dtd_t *)(ctrl_common.dc->endptqh + 32);
 
+	ctrl_common.dc->endptqh[1].size = 16;
+	ctrl_common.dc->endptqh[1].caps = caps;
+	ctrl_common.dc->endptqh[1].dtd_next = 1;
 	ctrl_common.dc->endptqh[1].base = qh_addr + (48 * sizeof(dqh_t));
-	ctrl_common.dc->endptqh[1].size = 0x10;
 	ctrl_common.dc->endptqh[1].head = (dtd_t *)(ctrl_common.dc->endptqh + 48);
 	ctrl_common.dc->endptqh[1].tail = (dtd_t *)(ctrl_common.dc->endptqh + 48);
 
@@ -218,13 +249,9 @@ int ctrl_endpt0Init(void)
 static dtd_t *ctrl_getDtd(int endpt, int dir)
 {
 	int qh = endpt * 2 + dir;
-	u32 base_addr;
-	dtd_t *ret;
-
-	base_addr = ((u32)ctrl_common.dc->endptqh[qh].head & ~((ctrl_common.dc->endptqh[qh].size * sizeof(dtd_t)) - 1));
-
-	ret = ctrl_common.dc->endptqh[qh].tail++;
-	ctrl_common.dc->endptqh[qh].tail = (dtd_t *)(base_addr | ((u32)ctrl_common.dc->endptqh[qh].tail & (((ctrl_common.dc->endptqh[qh].size) * sizeof(dtd_t)) - 1)));
+	dtd_t *ret = ctrl_common.dc->endptqh[qh].tail;
+	u32 qhmask = ((ctrl_common.dc->endptqh[qh].size) * sizeof(dtd_t)) - 1;
+	ctrl_common.dc->endptqh[qh].tail = (dtd_t *)((u32)(ctrl_common.dc->endptqh[qh].tail + 1) & ~qhmask);
 
 	return ret;
 }
@@ -235,8 +262,9 @@ static int ctrl_buildDtd(dtd_t *dtd, u32 paddr, u32 size)
 	int i = 0;
 	int tempSize = size;
 
-	if (size > USB_BUFFER_SIZE)
-		return -1;
+	if (size > USB_BUFFER_SIZE) {
+		return -ENOMEM;
+	}
 
 	dtd->dtd_next = 1;
 	dtd->dtd_token = size << 16;
@@ -255,101 +283,147 @@ static int ctrl_buildDtd(dtd_t *dtd, u32 paddr, u32 size)
 
 dtd_t *ctrl_execTransfer(int endpt, u32 paddr, u32 sz, int dir)
 {
+	time_t endts;
 	int shift;
 	u32 offs;
 	volatile dtd_t *dtd;
 
 	int qh = (endpt << 1) + dir;
 
-	dtd = ctrl_getDtd(endpt, dir);
+	if (ctrl_common.dc->connected != 0) {
+		dtd = ctrl_getDtd(endpt, dir);
 
-	ctrl_buildDtd((dtd_t *)dtd, paddr, sz);
+		ctrl_buildDtd((dtd_t *)dtd, paddr, sz);
 
-	shift = endpt + ((qh & 1) ? 16 : 0);
-	offs = (u32)dtd & (((ctrl_common.dc->endptqh[qh].size) * sizeof(dtd_t)) - 1);
+		shift = endpt + ((qh & 1) ? 16 : 0);
+		offs = (u32)dtd & (((ctrl_common.dc->endptqh[qh].size) * sizeof(dtd_t)) - 1);
 
-	ctrl_common.dc->endptqh[qh].dtd_next = (ctrl_common.dc->endptqh[qh].base + offs) & ~1;
-	ctrl_common.dc->endptqh[qh].dtd_token &= ~(1 << 6);
-	ctrl_common.dc->endptqh[qh].dtd_token &= ~(1 << 7);
+		ctrl_common.dc->endptqh[qh].dtd_next = (ctrl_common.dc->endptqh[qh].base + offs) & ~1;
+		ctrl_common.dc->endptqh[qh].dtd_token &= ~(1 << 6);
+		ctrl_common.dc->endptqh[qh].dtd_token &= ~(1 << 7);
 
-	while ((*(ctrl_common.dc->base + endptprime) & (1 << shift)))
-		;
+		while ((*(ctrl_common.dc->base + endptprime) & (1U << shift)) != 0) {
+		}
 
-	*(ctrl_common.dc->base + endptprime) |= 1 << shift;
+		*(ctrl_common.dc->base + endptprime) |= 1U << shift;
 
-	/* prime the endpoint and wait for it to prime */
-	while ((*(ctrl_common.dc->base + endptprime) & (1 << shift)))
-		;
-	*(ctrl_common.dc->base + endptprime) |= 1 << shift;
-	while (!(*(ctrl_common.dc->base + endptprime) & (1 << shift)) && (*(ctrl_common.dc->base + endptstat) & (1 << shift)))
-		;
+		/* prime the endpoint and wait for it to prime */
+		while ((*(ctrl_common.dc->base + endptprime) & (1U << shift)) != 0) {
+		}
 
-	/* wait to finish transaction */
-	while (DTD_ACTIVE(dtd) && !DTD_ERROR(dtd))
-		;
+		*(ctrl_common.dc->base + endptprime) |= 1U << shift;
 
-	return (dtd_t *)dtd;
+		endts = hal_timerGet() + USBCTRL_TIMEOUT;
+		while ((*(ctrl_common.dc->base + endptprime) & (1U << shift)) == 0 &&
+			(*(ctrl_common.dc->base + endptstat) & (1U << shift)) != 0 &&
+			(*(ctrl_common.dc->base + portsc1) & 1) != 0) {
+			if (hal_timerGet() > endts) {
+				return NULL;
+			}
+		}
+
+		/* wait to finish transaction while device is attached to the host */
+		while (DTD_ACTIVE(dtd) != 0 &&
+			DTD_ERROR(dtd) == 0 &&
+			(*(ctrl_common.dc->base + portsc1) & 1) != 0) {
+			if (hal_timerGet() > endts) {
+				return NULL;
+			}
+		}
+
+		/* check if device is attached */
+		if ((*(ctrl_common.dc->base + portsc1) & 1) != 0) {
+			return (dtd_t *)dtd;
+		}
+	}
+
+	return NULL;
 }
 
 
-int ctrl_hfIrq(void)
+void ctrl_hfIrq(void)
 {
 	int endpt = 0;
 
-	if ((ctrl_common.dc->setupstat = *(ctrl_common.dc->base + endptsetupstat)) & 0x1) {
+	ctrl_common.dc->setupstat = *(ctrl_common.dc->base + endptsetupstat);
+	if ((ctrl_common.dc->setupstat & 1) != 0) {
 		/* trip winre set */
-		while (!((ctrl_common.dc->setupstat >> endpt) & 1)) {
-			if (++endpt > 15)
-				return -1;
+		while (((ctrl_common.dc->setupstat >> endpt) & 1) == 0) {
+			if (++endpt > 15) {
+				/* Clear USB interrupt */
+				*(ctrl_common.dc->base + usbsts) |= 1;
+				return;
+			}
 		}
 
+		/* Trip wire: ensure that the setup data payload is extracted from a QH by the DCD without being corrupted */
 		do {
 			*(ctrl_common.dc->base + usbcmd) |= 1 << 13;
 			hal_memcpy(&ctrl_common.dc->setup, (void *)ctrl_common.dc->endptqh[endpt].setup_buff, sizeof(usb_setup_packet_t));
-		} while (!(*(ctrl_common.dc->base + usbcmd) & 1 << 13));
+		} while ((*(ctrl_common.dc->base + usbcmd) & 1 << 13) == 0);
 
-		*(ctrl_common.dc->base + endptsetupstat) |= 1 << endpt;
+		/* Acknowledge setup transfer */
+		*(ctrl_common.dc->base + endptsetupstat) |= 1U << endpt;
+
+		/* Trip wire semaphore clear */
 		*(ctrl_common.dc->base + usbcmd) &= ~(1 << 13);
+
+		/* Clear USB interrupt */
 		*(ctrl_common.dc->base + usbsts) |= 1;
 
 		ctrl_common.dc->endptqh[0].head = ctrl_common.dc->endptqh[0].tail;
 		ctrl_common.dc->endptqh[1].head = ctrl_common.dc->endptqh[1].tail;
 
-		while (*(ctrl_common.dc->base + endptsetupstat) & 1)
-			;
+		while ((*(ctrl_common.dc->base + endptsetupstat) & 1) != 0) {
+		}
 
 		desc_setup(&ctrl_common.dc->setup);
 	}
-
-	return 1;
+	else {
+		/* Clear USB interrupt */
+		*(ctrl_common.dc->base + usbsts) |= 1;
+	}
 }
 
 
-int ctrl_lfIrq(void)
+void ctrl_lfIrq(void)
 {
-	if ((*(ctrl_common.dc->base + usbsts) & 1 << 6)) {
+	u8 prevState = ctrl_common.dc->connected;
+
+	ctrl_common.dc->connected = (*(ctrl_common.dc->base + portsc1) & 1) && (*(ctrl_common.dc->base + otgsc) & 1 << 9);
+
+	/* Reset received */
+	if ((*(ctrl_common.dc->base + usbsts) & 1 << 6) != 0) {
 
 		*(ctrl_common.dc->base + endptsetupstat) = *(ctrl_common.dc->base + endptsetupstat);
 		*(ctrl_common.dc->base + endptcomplete) = *(ctrl_common.dc->base + endptcomplete);
 
-		while (*(ctrl_common.dc->base + endptprime))
-			;
+		while ((*(ctrl_common.dc->base + endptprime)) != 0) {
+		}
 
 		*(ctrl_common.dc->base + endptflush) = 0xffffffff;
 
-		while (*(ctrl_common.dc->base + portsc1) & 1 << 8)
-			;
+		while ((*(ctrl_common.dc->base + portsc1) & 1 << 8) != 0) {
+		}
 
 		*(ctrl_common.dc->base + usbsts) |= 1 << 6;
 		ctrl_common.dc->status = DC_DEFAULT;
 	}
 
-	return 1;
+	/* Connect state has changed */
+	if (ctrl_common.dc->connected != prevState) {
+		while ((*(ctrl_common.dc->base + endptprime)) != 0) {
+		}
+
+		*(ctrl_common.dc->base + endptflush) = 0xffffffff;
+	}
 }
 
 
-static void ctrl_devInit(void)
+static int ctrl_devInit(void)
 {
+	time_t endts = hal_timerGet() + USBCTRL_TIMEOUT;
+
 	*(ctrl_common.dc->base + endptflush) = 0xffffffff;
 	/* Run/Stop bit */
 	*(ctrl_common.dc->base + usbcmd) &= ~1;
@@ -358,8 +432,11 @@ static void ctrl_devInit(void)
 	ctrl_common.dc->status = DC_POWERED;
 
 	/* Run/Stop register is set to 0 when the reset process is complete. */
-	while (*(ctrl_common.dc->base + usbcmd) & (1 << 1))
-		;
+	while ((*(ctrl_common.dc->base + usbcmd) & (1 << 1)) != 0) {
+		if (hal_timerGet() > endts) {
+			return -ETIME;
+		}
+	}
 
 	/* set usb mode to device */
 	*(ctrl_common.dc->base + usbmode) |= 2;
@@ -374,16 +451,25 @@ static void ctrl_devInit(void)
 
 	ctrl_common.dc->status = DC_ATTACHED;
 	*(ctrl_common.dc->base + usbcmd) |= 1;
+
+	return EOK;
 }
 
 
 int ctrl_init(usb_common_data_t *usb_data_in, usb_dc_t *dc_in)
 {
+	int res;
+
 	ctrl_common.dc = dc_in;
-	ctrl_common.qtdOffs = 0;
 	ctrl_common.data = usb_data_in;
 
-	ctrl_devInit();
+	ctrl_initQtd();
+
+	res = ctrl_devInit();
+	if (res != EOK) {
+		ctrl_reset();
+		return res;
+	}
 
 	return ctrl_endpt0Init();
 }

--- a/devices/usbc-cdc/usb.h
+++ b/devices/usbc-cdc/usb.h
@@ -31,7 +31,7 @@
 #define REQUEST_RECIPIENT_ENDPOINT  2
 #define REQUEST_RECIPIENT_OTHER     3
 
-#define EXTRACT_REQ_TYPE(req_type) ((0x3 << 5) & req_type)
+#define EXTRACT_REQ_TYPE(req_type) ((3 << 5) & (req_type))
 
 /* request types */
 #define REQ_GET_STATUS        0


### PR DESCRIPTION
This change fixes, adds:
* the ability to respond to disconnection and re/connection of the USB cable
* response to faults in the result of a broken USB connection (faulty cable),
* timeout check for stalled endpoints,
* errno like results,
* fixes allocations and improves memory access (unexpected hang-ups during bad qtd access and usb enumeration (in the third, fourth turn after cable reconection),
* resolves issues with hangups and restarts after the third-fourth`copy usb0 ..` command (bus fault exception),
* adjusts the style to be more MISRA compliant.

JIRA: RTOS-324

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
 https://github.com/phoenix-rtos/phoenix-rtos-project/issues/489
 https://github.com/phoenix-rtos/phoenix-rtos-project/issues/488
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1176-nil, mimxrt1176-evk, mimxrt1064-evk).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
