### PR TITLE
copy: fix arg parsing

### DIFF
--- a/cmds/copy.c
+++ b/cmds/copy.c
@@ -93,7 +93,6 @@ static int cmd_devParse(handler_t *h, addr_t *offs, size_t *sz, unsigned int arg
 			log_error("\nCan't open file '%s' on %s", argv[*argvID], alias);
 			return res;
 		}
-		(*argvID)++;
 	}
 	/* Open device using direct access to memory */
 	else {
@@ -109,6 +108,7 @@ static int cmd_devParse(handler_t *h, addr_t *offs, size_t *sz, unsigned int arg
 			return res;
 		}
 	}
+	(*argvID)++;
 
 	return EOK;
 }


### PR DESCRIPTION
JIRA: RTOS-375

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed parsing of arguments in copy.

## Motivation and Context
If offset and size was provided to copy the options would parse properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imx6ull

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
