### PR TITLE
imx6ull: usb phy_init implementation

### DIFF
--- a/devices/usbc-cdc/usbphy-imx6ull.c
+++ b/devices/usbc-cdc/usbphy-imx6ull.c
@@ -5,8 +5,8 @@
  *
  * USB physical layer controller
  *
- * Copyright 2021 Phoenix Systems
- * Author: Hubert Buczynski
+ * Copyright 2021, 2023 Phoenix Systems
+ * Author: Hubert Buczynski, Hubert Badocha
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -15,10 +15,24 @@
 
 #include "client.h"
 #include "usbphy.h"
-#include <lib/lib.h>
+
+#define USB0_PHY (0x020c9000)
+
+#define USB_PHY_CTRL         (0x30u / sizeof(u32))
+#define USB_PHY_CTRL_CLKGATE (1u << 30)
+#define USB_PHY_CTRL_SFTRST  (1u << 31)
+
+#define USB_PHY_PWD (0)
+
+#define CCM_ANALOG_PLL_USB0             (0x20c8010)
+#define CCM_ANALOG_PLL_USB0_ENABLE      (1u << 13)
+#define CCM_ANALOG_PLL_USB0_POWER       (1u << 12)
+#define CCM_ANALOG_PLL_USB0_LOCK        (1u << 31)
+#define CCM_ANALOG_PLL_USB0_BYPASS      (1u << 16)
+#define CCM_ANALOG_PLL_USB0_EN_USB_CLKS (1u << 6)
 
 
-struct {
+static struct {
 	u8 pool[USB_POOL_SIZE];
 	size_t usedPools;
 } phyusb_common __attribute__((section(".uncached_ddr"), aligned(USB_BUFFER_SIZE)));
@@ -28,8 +42,9 @@ void *usbclient_allocBuff(u32 size)
 {
 	size_t org = USB_BUFFER_SIZE * phyusb_common.usedPools;
 
-	if ((size % USB_BUFFER_SIZE) != 0 || org + size > USB_POOL_SIZE)
+	if (((size % USB_BUFFER_SIZE) != 0u) || ((org + size) > USB_POOL_SIZE)) {
 		return NULL;
+	}
 
 	phyusb_common.usedPools += size / USB_BUFFER_SIZE;
 
@@ -42,6 +57,7 @@ void usbclient_buffReset(void)
 	phyusb_common.usedPools = 0;
 }
 
+
 void *phy_getBase(void)
 {
 	return (void *)0x02184000;
@@ -50,19 +66,56 @@ void *phy_getBase(void)
 
 u32 phy_getIrq(void)
 {
-	return 75;
+	return 75u;
 }
 
+
+static void phy_setClock(void)
+{
+	volatile u32 *ccmAnalogPllUSB0 = (u32 *)CCM_ANALOG_PLL_USB0;
+
+	imx6ull_setDevClock(clk_usboh3, 0x03);
+
+	*ccmAnalogPllUSB0 |= CCM_ANALOG_PLL_USB0_ENABLE;
+	hal_cpuDataMemoryBarrier();
+	*ccmAnalogPllUSB0 |= CCM_ANALOG_PLL_USB0_POWER;
+	hal_cpuDataMemoryBarrier();
+	while ((*ccmAnalogPllUSB0 & CCM_ANALOG_PLL_USB0_LOCK) == 0u) {
+	}
+	*ccmAnalogPllUSB0 &= ~CCM_ANALOG_PLL_USB0_BYPASS;
+	*ccmAnalogPllUSB0 |= CCM_ANALOG_PLL_USB0_EN_USB_CLKS;
+	hal_cpuDataMemoryBarrier();
+}
 
 void phy_reset(void)
 {
-	/* TODO: reset phy controller */
+	volatile u32 *usbphy = (u32 *)USB0_PHY;
+
+	*(usbphy + USB_PHY_CTRL) |= USB_PHY_CTRL_SFTRST;
+	hal_cpuDataMemoryBarrier();
+	*(usbphy + USB_PHY_CTRL) &= ~USB_PHY_CTRL_CLKGATE;
+	hal_cpuDataMemoryBarrier();
+	*(usbphy + USB_PHY_CTRL) &= ~USB_PHY_CTRL_SFTRST;
+	hal_cpuDataMemoryBarrier();
+	*(usbphy + USB_PHY_PWD) = 0u;
+	hal_cpuDataMemoryBarrier();
 }
 
 
-/* TODO: add phy controller
- * Currently PHY controller is initialized by bootROM. */
+static void phy_config(void)
+{
+	volatile u32 *usbphy = (u32 *)USB0_PHY;
+
+	*(usbphy + USB_PHY_CTRL) |= (3u << 14) | (1u << 11) | 2u;
+	hal_cpuDataMemoryBarrier();
+}
+
+
 void phy_init(void)
 {
 	phyusb_common.usedPools = 0;
+
+	phy_setClock();
+	phy_reset();
+	phy_config();
 }


### PR DESCRIPTION
JIRA: RTOS-386

<!--- Provide a general summary of your changes in the Title above -->

## Description
Implements usb phy on imx6ull.

## Motivation and Context
Usb phy relied on bootrom initialiation. Booting from flash doesn't provide this initialization.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imx6ull

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
