### PR TITLE
hal/ia32: Fix reboot hanging on some hardware

### DIFF
--- a/hal/ia32/cpu.c
+++ b/hal/ia32/cpu.c
@@ -52,15 +52,20 @@ int hal_cpuJump(void)
 void hal_cpuReboot(void)
 {
 	u8 status;
+	u16 timeout;
 
 	hal_interruptsDisableAll();
 
 	/* 1. Try to reboot using keyboard controller (8042) */
-	do {
+	for (timeout = 0xffff; timeout != 0; --timeout) {
 		status = hal_inb((void *)0x64);
-		if (status & 1)
+		if ((status & 1) != 0) {
 			(void)hal_inb((void *)0x60);
-	} while (status & 2);
+		}
+		if ((status & 2) == 0) {
+			break;
+		}
+	}
 	hal_outb((void *)0x64, 0xfe);
 
 	/* 2. Try to reboot by PCI reset */


### PR DESCRIPTION
- Fix kernel being stuck in an infinite loop, trying to reboot, if there is no 8042 keyboard controller

  DONE: RTOS-305

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-pc

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
