### PR TITLE
Add  exception handler on `armv7m`

### DIFF
--- a/hal/armv7m/Makefile
+++ b/hal/armv7m/Makefile
@@ -14,4 +14,4 @@ ifneq (, $(findstring stm32, $(TARGET_SUBFAMILY)))
 	include hal/armv7m/stm32/Makefile
 endif
 
-OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/, cpu.o interrupts.o mpu.o string.o)
+OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/, cpu.o exceptions.o interrupts.o mpu.o string.o)

--- a/hal/armv7m/exceptions.c
+++ b/hal/armv7m/exceptions.c
@@ -1,0 +1,143 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system loader
+ *
+ * Exception handling
+ *
+ * Copyright 2017 Phoenix Systems
+ * Author: Pawel Pisarczyk, Jakub Sejdak, Aleksander Kaminski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#include <hal/hal.h>
+
+#define SIZE_FPUCTX (16 * sizeof(u32))
+
+#ifdef CPU_IMXRT
+#define EXCRET_PSP 0xffffffed
+#else
+#define EXCRET_PSP 0xfffffffd
+#endif
+
+
+typedef struct {
+	u32 r0;
+	u32 r1;
+	u32 r2;
+	u32 r3;
+	u32 r12;
+	u32 lr;
+	u32 pc;
+	u32 psr;
+} cpu_hwContext_t;
+
+
+typedef struct _exc_context_t {
+	u32 psp;
+	u32 r4;
+	u32 r5;
+	u32 r6;
+	u32 r7;
+	u32 r8;
+	u32 r9;
+	u32 r10;
+	u32 r11;
+	u32 excret;
+
+	/* Saved by hardware */
+	cpu_hwContext_t mspctx;
+} exc_context_t;
+
+
+__attribute__((section(".noxip"))) void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
+{
+	static const char *const mnemonics[] = {
+		"0 #InitialSP", "1 #Reset", "2 #NMI", "3 #HardFault",
+		"4 #MemMgtFault", "5 #BusFault", "6 #UsageFault", "7 #",
+		"8 #", "9 #", "10 #", "11 #SVC",
+		"12 #Debug", "13 #", "14 #PendSV", "15 #SysTick"
+	};
+
+	size_t i = 0;
+	cpu_hwContext_t *hwctx;
+	u32 msp = (u32)ctx + sizeof(*ctx);
+	u32 psp = ctx->psp;
+
+	/* If we came from userspace HW ctx in on psp stack */
+	if (ctx->excret == EXCRET_PSP) {
+		hwctx = (void *)ctx->psp;
+		msp -= sizeof(cpu_hwContext_t);
+		psp += sizeof(cpu_hwContext_t);
+#ifdef CPU_IMXRT /* FIXME - check if FPU was enabled instead */
+			psp += SIZE_FPUCTX;
+#endif
+	}
+	else {
+		hwctx = &ctx->mspctx;
+#ifdef CPU_IMXRT
+			msp += SIZE_FPUCTX;
+#endif
+	}
+
+	n &= 0xf;
+
+	hal_strcpy(buff, "\nException: ");
+	hal_strcpy(buff += hal_strlen(buff), mnemonics[n]);
+	hal_strcpy(buff += hal_strlen(buff), "\n");
+	buff += hal_strlen(buff);
+
+	i += hal_i2s(" r0=", &buff[i], hwctx->r0, 16, 1);
+	i += hal_i2s("  r1=", &buff[i], hwctx->r1, 16, 1);
+	i += hal_i2s("  r2=", &buff[i], hwctx->r2, 16, 1);
+	i += hal_i2s("  r3=", &buff[i], hwctx->r3, 16, 1);
+
+	i += hal_i2s("\n r4=", &buff[i], ctx->r4, 16, 1);
+	i += hal_i2s("  r5=", &buff[i], ctx->r5, 16, 1);
+	i += hal_i2s("  r6=", &buff[i], ctx->r6, 16, 1);
+	i += hal_i2s("  r7=", &buff[i], ctx->r7, 16, 1);
+
+	i += hal_i2s("\n r8=", &buff[i], ctx->r8, 16, 1);
+	i += hal_i2s("  r9=", &buff[i], ctx->r9, 16, 1);
+	i += hal_i2s(" r10=", &buff[i], ctx->r10, 16, 1);
+	i += hal_i2s(" r11=", &buff[i], ctx->r11, 16, 1);
+
+	i += hal_i2s("\nr12=", &buff[i], hwctx->r12, 16, 1);
+	i += hal_i2s(" psr=", &buff[i], hwctx->psr, 16, 1);
+	i += hal_i2s("  lr=", &buff[i], hwctx->lr, 16, 1);
+	i += hal_i2s("  pc=", &buff[i], hwctx->pc, 16, 1);
+
+	i += hal_i2s("\npsp=", &buff[i], psp, 16, 1);
+	i += hal_i2s(" msp=", &buff[i], msp, 16, 1);
+	i += hal_i2s(" exr=", &buff[i], ctx->excret, 16, 1);
+	i += hal_i2s(" bfa=", &buff[i], *(u32 *)0xe000ed38, 16, 1);
+
+	i += hal_i2s("\ncfs=", &buff[i], *(u32 *)0xe000ed28, 16, 1);
+
+	buff[i++] = '\n';
+
+	buff[i] = 0;
+}
+
+
+__attribute__((section(".noxip"))) void hal_exceptionsDispatch(unsigned int n, exc_context_t *ctx)
+{
+	static char buff[512];
+
+	hal_exceptionsDumpContext(buff, ctx, n);
+	hal_consolePrint(buff);
+
+#ifdef NDEBUG
+#ifdef CPU_STM32
+	_stm32_nvicSystemReset();
+#elif defined(CPU_IMXRT)
+	_imxrt_nvicSystemReset();
+#endif
+#else
+	hal_cpuHalt();
+#endif
+}

--- a/hal/armv7m/imxrt/10xx/_init.S
+++ b/hal/armv7m/imxrt/10xx/_init.S
@@ -154,7 +154,6 @@ _init_vectors:
 .word _stack
 .word _start
 
-/* TODO: define exception_dispatch */
 .word _exceptions_dispatch                     /* NMI */
 .word _exceptions_dispatch                     /* HardFault */
 .word _exceptions_dispatch                     /* MemMgtFault */
@@ -227,7 +226,13 @@ _interrupts_dispatch:
 
 _exceptions_dispatch:
 	cpsid if
-	/* TODO: implement exception dispatcher */
-	1: b 1b
+
+	mrs r0, psp
+	stmdb sp!, {r0, r4-r11, lr}
+
+	mrs r0, ipsr
+	mov r1, sp
+
+	b hal_exceptionsDispatch
 .size _exceptions_dispatch, .-_exceptions_dispatch
 .ltorg

--- a/hal/armv7m/imxrt/117x/_init.S
+++ b/hal/armv7m/imxrt/117x/_init.S
@@ -240,8 +240,13 @@ _interrupts_dispatch:
 
 _exceptions_dispatch:
 	cpsid if
-	/* TODO: implement exception dispatcher */
-	1: b 1b
+
+	mrs r0, psp
+	stmdb sp!, {r0, r4-r11, lr}
+
+	mrs r0, ipsr
+	mov r1, sp
+
+	b hal_exceptionsDispatch
 .size _exceptions_dispatch, .-_exceptions_dispatch
 .ltorg
-

--- a/hal/armv7m/stm32/l4/_init.S
+++ b/hal/armv7m/stm32/l4/_init.S
@@ -109,7 +109,13 @@ _interrupts_dispatch:
 
 _exceptions_dispatch:
 	cpsid if
-	/* TODO: implement exception dispatcher */
-	1: b 1b
+
+	mrs r0, psp
+	stmdb sp!, {r0, r4-r11, lr}
+
+	mrs r0, ipsr
+	mov r1, sp
+
+	b hal_exceptionsDispatch
 .size _exceptions_dispatch, .-_exceptions_dispatch
 .ltorg

--- a/ld/armv7m7-imxrt117x.ldt
+++ b/ld/armv7m7-imxrt117x.ldt
@@ -5,7 +5,7 @@
  *
  * Linker Template and Platform Config for ARMv7 M7 i.MX RT117x
  *
- * Copyright 2021-2022 Phoenix Systems
+ * Copyright 2021-2023 Phoenix Systems
  * Author: Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
@@ -32,13 +32,28 @@
 
 #if defined(__LINKER__)
 
+/* FlexRAM configuration */
+#if defined(CUSTOM_FLEXRAM_CONFIG)
+FLEXRAM_CONFIG = CUSTOM_FLEXRAM_CONFIG;
+FLEXRAM_ITCM_BANKS = CUSTOM_FLEXRAM_ITCM_BANKS;
+FLEXRAM_DTCM_BANKS = CUSTOM_FLEXRAM_DTCM_BANKS;
+#else
+FLEXRAM_CONFIG = 0xaaaaffff;
+FLEXRAM_ITCM_BANKS = 8;
+FLEXRAM_DTCM_BANKS = 8;
+#endif
+
+FLEXRAM_ITCM_AREA = FLEXRAM_ITCM_BANKS * 32k;
+FLEXRAM_ITEXT_AREA = 11 * SIZE_PAGE;
+FLEXRAM_ITEXT_ADDR = FLEXRAM_ITCM_AREA - FLEXRAM_ITEXT_AREA;
+FLEXRAM_DTCM_AREA = FLEXRAM_DTCM_BANKS * 32k;
+
 /* Memory map setup */
 MEMORY
 {
-	/* TODO: use FLEXRAM_CONFIG value to setup ocram/itcm/dtcm partitioning (*32k/16kB) */
-	m_itcm    (rwx) : ORIGIN = 0x00000000, LENGTH = 8 * 32k
-	m_itext   (rwx) : ORIGIN = 0x0003ec00, LENGTH = 5k
-	m_dtcm    (rw)  : ORIGIN = 0x20000000 + AREA_KERNEL, LENGTH = (8 * 32k) - AREA_KERNEL
+	m_itcm    (rwx) : ORIGIN = 0x00000000, LENGTH = FLEXRAM_ITCM_AREA
+	m_itext   (rwx) : ORIGIN = 0x00000000 + FLEXRAM_ITEXT_ADDR, LENGTH = FLEXRAM_ITEXT_AREA
+	m_dtcm    (rw)  : ORIGIN = 0x20002000 + AREA_KERNEL, LENGTH = FLEXRAM_DTCM_AREA - AREA_KERNEL
 	m_ocram1  (rwx) : ORIGIN = 0x20240000 + AREA_BOOTLOADER, LENGTH = (8 * 32k) - AREA_BOOTLOADER
 	m_ocram2  (rwx) : ORIGIN = 0x202c0000, LENGTH = 512k
 	m_flash   (rx)  : ORIGIN = 0x30000000, LENGTH = 4M


### PR DESCRIPTION
This change adds exception handler (on imxrt and stm32l4 targets) which dumps CPU context when exception occurs.

### The implementation from phoenix-rtos-kernel was used.

JIRA: RTOS-368

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt1176-nil, imxrt1064-evk, stm32l4a6-nucleo.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
