### PR TITLE
hal: Implement reason of cpu reset flags handling

### DIFF
--- a/hal/armv7a/imx6ull/hal.c
+++ b/hal/armv7a/imx6ull/hal.c
@@ -142,6 +142,14 @@ int hal_cpuJump(void)
 	return 0;
 }
 
+
+int hal_cpuReasonOfReset(u32 *val)
+{
+	/* TODO: Implement reading of the source of reset register */
+	return -1;
+}
+
+
 addr_t hal_kernelGetAddress(addr_t addr)
 {
 	addr_t offs;

--- a/hal/armv7a/imx6ull/hal.c
+++ b/hal/armv7a/imx6ull/hal.c
@@ -145,8 +145,11 @@ int hal_cpuJump(void)
 
 int hal_cpuReasonOfReset(u32 *val)
 {
-	/* TODO: Implement reading of the source of reset register */
-	return -1;
+	if (imx6ull_getResetFlags() >= 0) {
+		*val = imx6ull_getResetFlags();
+		return 1;
+	}
+	return 0;
 }
 
 

--- a/hal/armv7a/imx6ull/imx6ull.h
+++ b/hal/armv7a/imx6ull/imx6ull.h
@@ -160,6 +160,9 @@ enum {
 };
 
 
+extern u32 imx6ull_getResetFlags(void);
+
+
 extern int imx6ull_setDevClock(int dev, unsigned int state);
 
 

--- a/hal/armv7a/zynq7000/hal.c
+++ b/hal/armv7a/zynq7000/hal.c
@@ -260,3 +260,10 @@ int hal_cpuJump(void)
 
 	return 0;
 }
+
+
+int hal_cpuReasonOfReset(u32 *val)
+{
+	/* TODO: Implement reading of the source of reset register */
+	return -1;
+}

--- a/hal/armv7m/imxrt/10xx/imxrt.h
+++ b/hal/armv7m/imxrt/10xx/imxrt.h
@@ -556,6 +556,9 @@ extern int _imxrt_setIOpad(int pad, char hys, char pus, char pue, char pke, char
 extern int _imxrt_setIOisel(int isel, char daisy);
 
 
+extern u32 _imxrt_getResetFlags(void);
+
+
 extern void _imxrt_init(void);
 
 

--- a/hal/armv7m/imxrt/117x/imxrt.h
+++ b/hal/armv7m/imxrt/117x/imxrt.h
@@ -331,6 +331,9 @@ extern int _imxrt_getDevClock(int clock, int *div, int *mux, int *mfd, int *mfn,
 extern int _imxrt_setDevClock(int clock, int div, int mux, int mfd, int mfn, int state);
 
 
+extern u32 _imxrt_getResetFlags(void);
+
+
 extern void _imxrt_init(void);
 
 

--- a/hal/armv7m/imxrt/hal.c
+++ b/hal/armv7m/imxrt/hal.c
@@ -5,7 +5,7 @@
  *
  * Hardware Abstraction Layer
  *
- * Copyright 2020-2022 Phoenix Systems
+ * Copyright 2020-2023 Phoenix Systems
  * Author: Hubert Buczynski, Marcin Baran, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
@@ -163,6 +163,16 @@ int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 	}
 
 	return -1;
+}
+
+
+int hal_cpuReasonOfReset(u32 *val)
+{
+	if (_imxrt_getResetFlags() != 0) {
+		*val = _imxrt_getResetFlags();
+		return 1;
+	}
+	return 0;
 }
 
 

--- a/hal/armv7m/stm32/hal.c
+++ b/hal/armv7m/stm32/hal.c
@@ -194,3 +194,13 @@ int hal_cpuJump(void)
 
 	return 0;
 }
+
+
+int hal_cpuReasonOfReset(u32 *val)
+{
+	if (_stm32_rccGetResetFlags() != 0) {
+		*val = _stm32_rccGetResetFlags();
+		return 1;
+	}
+	return 0;
+}

--- a/hal/armv7m/stm32/l4/stm32l4.c
+++ b/hal/armv7m/stm32/l4/stm32l4.c
@@ -235,6 +235,12 @@ u32 _stm32_rccGetCPUClock(void)
 }
 
 
+u32 _stm32_rccGetResetFlags(void)
+{
+	return stm32_common.resetFlags;
+}
+
+
 void _stm32_rccClearResetFlags(void)
 {
 	*(stm32_common.rcc + rcc_csr) |= 1 << 23;
@@ -478,6 +484,9 @@ void _stm32_init(void)
 	*(stm32_common.rcc + rcc_cier) = 0;
 
 	hal_cpuDataMemoryBarrier();
+
+	/* Save cpu reset flags */
+	stm32_common.resetFlags = (*(stm32_common.rcc + rcc_csr) & (0xffu << 24));
 
 	/* GPIO init */
 	for (i = 0; i < sizeof(stm32_common.gpio) / sizeof(stm32_common.gpio[0]); ++i)

--- a/hal/armv7m/stm32/l4/stm32l4.h
+++ b/hal/armv7m/stm32/l4/stm32l4.h
@@ -81,6 +81,9 @@ extern u32 _stm32_rccGetCPUClock(void);
 extern void _stm32_rccClearResetFlags(void);
 
 
+extern u32 _stm32_rccGetResetFlags(void);
+
+
 extern int _stm32_gpioConfig(unsigned int d, u8 pin, u8 mode, u8 af, u8 otype, u8 ospeed, u8 pupd);
 
 

--- a/hal/armv8m/nrf/hal.c
+++ b/hal/armv8m/nrf/hal.c
@@ -201,3 +201,10 @@ int hal_cpuJump(void)
 	/* clang-format on */
 	__builtin_unreachable();
 }
+
+
+int hal_cpuReasonOfReset(u32 *val)
+{
+	/* TODO: Implement reading of the source of reset register */
+	return -1;
+}

--- a/hal/hal.h
+++ b/hal/hal.h
@@ -52,6 +52,10 @@ extern void hal_cpuReboot(void) __attribute__((noreturn));
 extern int hal_cpuJump(void);
 
 
+/* Get flags indicating the reason of the CPU reset */
+extern int hal_cpuReasonOfReset(u32 *val);
+
+
 /* Function translates virtual address into physical */
 extern addr_t hal_kernelGetAddress(addr_t addr);
 

--- a/hal/ia32/cpu.c
+++ b/hal/ia32/cpu.c
@@ -100,3 +100,9 @@ const char *hal_cpuInfo(void)
 {
 	return "IA-32 Generic";
 }
+
+
+int hal_cpuReasonOfReset(u32 *val)
+{
+	return -1;
+}

--- a/plo.c
+++ b/plo.c
@@ -5,9 +5,9 @@
  *
  * Initial loader's routines
  *
- * Copyright 2012, 2017, 2020-2021 Phoenix Systems
+ * Copyright 2012, 2017, 2020-2023 Phoenix Systems
  * Copyright 2001, 2005 Pawel Pisarczyk
- * Authors: Pawel Pisarczyk, Lukasz Kosinski, Hubert Buczynski
+ * Authors: Pawel Pisarczyk, Lukasz Kosinski, Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -29,12 +29,17 @@ void hal_customDone(void) __attribute__((weak, alias("nop")));
 
 int main(void)
 {
+	u32 flags;
+
 	hal_init();
 	hal_customInit();
 	syspage_init();
 
 	lib_printf(CONSOLE_BOLD "Phoenix-RTOS loader v. " VERSION CONSOLE_NORMAL);
 	lib_printf(CONSOLE_CURSOR_HIDE CONSOLE_MAGENTA "\nhal: %s", hal_cpuInfo());
+	if (hal_cpuReasonOfReset(&flags) >= 0) {
+		lib_printf(" (crf=0x%08x)", flags);
+	}
 	devs_init();
 	cmd_run();
 


### PR DESCRIPTION
## Work in progress - do not merge.

The change adds support for `crf` (CPU reset reason flags) to the i.MX RT 10xx, 117x, i.MX 6ULL and STM32L4 targets. During hal's early boot, the `crf` flags are saved internally to be later displayed in the logs at plo startup later. The functionallity of `crf` logging is to help troubleshoot "suspicious" system reboots.

For i.MX 6ULL and RT series the `src_srsr`is cleared after it is read and content stored internally - software has
to take care to clear this register by writing one after every reset that occurs so that the register will contain the information of recently occurred reset.

Future work (not in this PR): adding a method to pass the content of `crf` (resetFlag) via syspage to the kernel to be able to correctly indicate the reset reason to the end user (via platformctl, pctl_reboot reason).

Flags are printed after cpu info:
```
Phoenix-RTOS loader v. 1.21 rev: 123456
hal: Cortex-M i.MX RT117x (crf=0x08000002)
...
```

JIRA: RTOS-455

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt1176-nil, imxrt1064-bes, stm32l4a6-nucleo

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
