### PR TITLE
Leon3: Remove `-mflat` flag filter from makefile

### DIFF
--- a/hal/sparcv8leon3/Makefile
+++ b/hal/sparcv8leon3/Makefile
@@ -8,7 +8,6 @@
 
 include hal/sparcv8leon3/$(TARGET_SUBFAMILY)/Makefile
 
-CFLAGS := $(filter-out -mflat,$(CFLAGS)) # TODO: remove when kernel supports register windows
 CFLAGS += -Ihal/sparcv8leon3/$(TARGET_SUBFAMILY)
 
 OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/, cpu.o string.o interrupts.o exceptions.o _init.o _interrupts.o _traps.o)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Kernel has support for register windows, `-mflat` flag no longer used.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
JIRA: RTOS-406
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `sparcv8leon3-gr716-mini`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
