### PR TITLE
nand-imx6ull: add missing define in Makefile

### DIFF
--- a/hal/armv7a/imx6ull/Makefile
+++ b/hal/armv7a/imx6ull/Makefile
@@ -29,6 +29,9 @@ endif
 ifeq ($(PLO_NOR), y)
 	include devices/flash-imx6ull/Makefile
 endif
+ifeq ($(PLO_NOR_BOOT), y)
+	CFLAGS += -DPLO_NOR_BOOT
+endif
 include devices/uart-imx6ull/Makefile
 include devices/usbc-cdc/Makefile
 


### PR DESCRIPTION
JIRA: DTR-322

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imx6ull

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
