### PR TITLE
hal/string: correct `hal_memcpy` return value

### DIFF
--- a/hal/armv7a/string.c
+++ b/hal/armv7a/string.c
@@ -19,6 +19,8 @@
 
 void *hal_memcpy(void *dst, const void *src, size_t l)
 {
+	void *ret = dst;
+
 	__asm__ volatile
 	(" \
 		orr r3, %0, %1; \
@@ -41,7 +43,7 @@ void *hal_memcpy(void *dst, const void *src, size_t l)
 	: "+r" (dst), "+r" (src), "+r" (l)
 	:
 	: "r3", "memory", "cc");
-	return dst;
+	return ret;
 }
 
 

--- a/hal/armv7m/string.c
+++ b/hal/armv7m/string.c
@@ -19,6 +19,8 @@
 
 void *hal_memcpy(void *dst, const void *src, size_t l)
 {
+	void *ret = dst;
+
 	__asm__ volatile
 	(" \
 		orr r3, %0, %1; \
@@ -41,7 +43,7 @@ void *hal_memcpy(void *dst, const void *src, size_t l)
 	: "+r" (dst), "+r" (src), "+r" (l)
 	:
 	: "r3", "memory", "cc");
-	return dst;
+	return ret;
 }
 
 

--- a/hal/armv8m/string.c
+++ b/hal/armv8m/string.c
@@ -20,8 +20,10 @@
 
 
 /* clang-format off */
-void hal_memcpy(void *dst, const void *src, size_t l)
+void *hal_memcpy(void *dst, const void *src, size_t l)
 {
+	void *ret = dst;
+
 	__asm__ volatile
 	(" \
 		orr r3, %0, %1; \
@@ -44,6 +46,7 @@ void hal_memcpy(void *dst, const void *src, size_t l)
 	: "+r" (dst), "+r" (src), "+r" (l)
 	:
 	: "r3", "memory", "cc");
+	return ret;
 }
 
 

--- a/hal/ia32/string.c
+++ b/hal/ia32/string.c
@@ -19,6 +19,8 @@
 
 void *hal_memcpy(void *dst, const void *src, size_t n)
 {
+	void *ret = dst;
+
 	__asm__ volatile
 	(" \
 		cld; \
@@ -34,7 +36,7 @@ void *hal_memcpy(void *dst, const void *src, size_t n)
 	:
 	: "g" (n), "g" (dst), "g" (src)
 	: "ecx", "edx", "esi", "edi", "cc", "memory");
-	return dst;
+	return ret;
 }
 
 

--- a/hal/sparcv8leon3/string.c
+++ b/hal/sparcv8leon3/string.c
@@ -21,6 +21,8 @@ void *memcpy(void *dst, const void *src, size_t n) __attribute__((weak, alias("h
 
 void *hal_memcpy(void *dst, const void *src, size_t l)
 {
+	void *ret = dst;
+
 	/* clang-format off */
 
 	__asm__ volatile(" \
@@ -57,7 +59,7 @@ void *hal_memcpy(void *dst, const void *src, size_t l)
 
 	/* clang-format on */
 
-	return dst;
+	return ret;
 }
 
 


### PR DESCRIPTION
JIRA: RTOS-475

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Changes return value in hal_memcpy to original destination.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes comment: https://github.com/phoenix-rtos/plo/pull/219#issuecomment-1554090667
JIRA: RTOS-475
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
