### PR TITLE
cmds/bootcm4: Fix address overwrite before check

### DIFF
--- a/cmds/bootcm4.c
+++ b/cmds/bootcm4.c
@@ -94,6 +94,7 @@ static int cmd_bootcm4(int argc, char *argv[])
 	int opt;
 	int optLoad = 0;
 	int optBoot = 0;
+	addr_t tmp;
 
 	lib_printf("\n");
 
@@ -118,11 +119,12 @@ static int cmd_bootcm4(int argc, char *argv[])
 				break;
 
 			case 'o':
-				common.cm4VtorOffset = (addr_t)lib_strtoul(optarg, &endptr, 0);
-				if ((*endptr != '\0') || (common.cm4VtorOffset >= CM4_BOOT_MEMSIZE)) {
+				tmp = (addr_t)lib_strtoul(optarg, &endptr, 0);
+				if ((*endptr != '\0') || (tmp >= CM4_BOOT_MEMSIZE)) {
 					log_error("%s: Invalid arguments", argv[0]);
 					return CMD_EXIT_FAILURE;
 				}
+				common.cm4VtorOffset = tmp;
 
 				break;
 


### PR DESCRIPTION
Fix for overwriting locally stored vector table address before checking if it is out of bounds.

JIRA: RTOS-457

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt1176-nil.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
