### PR TITLE
flash-zynq7000: fix erase on last block

### DIFF
--- a/devices/flash-zynq7000/flashcfg.h
+++ b/devices/flash-zynq7000/flashcfg.h
@@ -19,14 +19,14 @@
 #include <hal/hal.h>
 
 /* Return timeouts in ms */
-#define CFI_TIMEOUT_MAX_PROGRAM(typical, max) (((1 << typical) * (1 << max)) / 1000)
-#define CFI_TIMEOUT_MAX_ERASE(typical, max)   ((1 << typical) * (1 << max))
+#define CFI_TIMEOUT_MAX_PROGRAM(typical, max) (((1u << typical) * (1u << max)) / 1000u)
+#define CFI_TIMEOUT_MAX_ERASE(typical, max)   ((1u << typical) * (1u << max))
 
 /* Return size in bytes */
-#define CFI_SIZE_FLASH(val)                (1 << val)
-#define CFI_SIZE_SECTION(val)              (val * 0x100)
-#define CFI_SIZE_PAGE(val)                 (1 << val)
-#define CFI_SIZE_REGION(regSize, regCount) (CFI_SIZE_SECTION(regSize) * (regCount + 1))
+#define CFI_SIZE_FLASH(val)                (1u << val)
+#define CFI_SIZE_SECTION(val)              ((size_t)val * 0x100u)
+#define CFI_SIZE_PAGE(val)                 (1u << val)
+#define CFI_SIZE_REGION(regSize, regCount) (CFI_SIZE_SECTION(regSize) * (size_t)(regCount + 1u))
 
 
 /* Order in command's table */
@@ -105,9 +105,10 @@ typedef struct {
 	flash_cfi_t cfi;
 	flash_cmd_t cmds[flash_cmd_end];
 
-	enum { flash_3byteAddr, flash_4byteAddr } addrMode; /* Address mode based on chip size */
-	int readCmd;                              /* Default read command define for specific flash memory */
-	int ppCmd;                                /* Default page program command define for specific flash memory */
+	enum { flash_3byteAddr,
+		flash_4byteAddr } addrMode; /* Address mode based on chip size */
+	int readCmd;                    /* Default read command define for specific flash memory */
+	int ppCmd;                      /* Default page program command define for specific flash memory */
 	const char *name;
 } flash_info_t;
 

--- a/devices/flash-zynq7000/flashdrv.c
+++ b/devices/flash-zynq7000/flashdrv.c
@@ -485,7 +485,7 @@ static ssize_t flashdrv_erase(unsigned int minor, addr_t addr, size_t len, unsig
 
 	/* Calculate sector size of the last address */
 	end = addr + len;
-	res = flashdrv_regionFind(end, &id);
+	res = flashdrv_regionFind(end - 1, &id);
 	if (res < 0) {
 		return res;
 	}
@@ -510,19 +510,19 @@ static ssize_t flashdrv_erase(unsigned int minor, addr_t addr, size_t len, unsig
 
 	len = 0;
 	while (addr < end) {
-		res = flashdrv_sectorErase(addr, sectSz);
-		if (res < 0) {
-			return res;
-		}
-		addr += sectSz;
-		len += sectSz;
-
 		res = flashdrv_regionFind(addr, &id);
 		if (res < 0) {
 			return res;
 		}
 
 		sectSz = CFI_SIZE_SECTION(cfi->regs[id].size);
+
+		res = flashdrv_sectorErase(addr, sectSz);
+		if (res < 0) {
+			return res;
+		}
+		addr += sectSz;
+		len += sectSz;
 	}
 
 	return len;

--- a/devices/flash-zynq7000/flashdrv.c
+++ b/devices/flash-zynq7000/flashdrv.c
@@ -588,7 +588,8 @@ static int flashdrv_init(unsigned int minor)
 			return -EINVAL;
 	}
 
-	lib_printf("\ndev/flash: Initializing flash(%d.%d)", DEV_STORAGE, minor);
+	lib_printf("\ndev/flash: Configured %s %dMB nor flash(%d.%d)", info->name,
+		CFI_SIZE_FLASH(info->cfi.chipSize) >> 20u, DEV_STORAGE, minor);
 
 	return EOK;
 }


### PR DESCRIPTION
JIRA: RTOS-482

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
When trying to erase to the end of the device driver was doing wrong region checks.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: zynq7000

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
