### PR TITLE
imx6ull: slow down qspi clocks

### DIFF
--- a/devices/flash-imx6ull/qspi/qspi.c
+++ b/devices/flash-imx6ull/qspi/qspi.c
@@ -176,8 +176,8 @@ __attribute__((section(".noxip"))) static void qspi_setClk(void)
 	imx6ull_setDevClock(clk_qspi, 0x03);
 
 	qspi_enable(0);
-	/* Set clock source to PLL2 440M Hz with divider 4 = 100 MHz. */
-	imx6ull_setQSPIClockSource(CLK_SEL_QSPI1_PLL2, 4);
+	/* Set clock source to PLL3 480M Hz with divider 6 = 80 MHz. */
+	imx6ull_setQSPIClockSource(CLK_SEL_QSPI1_PLL3, 6);
 	qspi_enable(1);
 	qspi_swReset();
 }

--- a/hal/armv7a/imx6ull/_init.S
+++ b/hal/armv7a/imx6ull/_init.S
@@ -58,7 +58,7 @@ qspi_config:
 	.word 0          /* Serial flash A2 size */
 	.word 0          /* Serial flash B1 size */
 	.word 0          /* Serial flash B2 size */
-	.word 6          /* Serial clock freq (99 MHz, SDR only) */
+	.word 0          /* Serial clock freq (18 MHz) */
 	.word 0          /* busy_bit_offset */
 	.word 1          /* Mode of operation of serial flash (Single pad) */
 	.word 0          /* Serial Flash Port B Selection */
@@ -71,7 +71,7 @@ qspi_config:
 	.word 0          /* Full Speed Delay Selection */
 	.word 0          /* DDR Sampling Point */
 	/* LUT program sequance */
-	.word 0x08180403, 0x24001C00, 0x00000000, 0x00000000 /* Read command */
+	.word 0x08180403, 0x24001C00, 0x00000000, 0x00000000 /* Standard READ 0x3 command. */
 	.word 0x00000000, 0x00000000, 0x00000000, 0x00000000
 	.word 0x00000000, 0x00000000, 0x00000000, 0x00000000
 	.word 0x00000000, 0x00000000, 0x00000000, 0x00000000


### PR DESCRIPTION
JIRA: RTOS-496

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
The clocks were too fast and on same examples this resulted in data corruption while loading the image by bootrom.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imx6ull

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
