### PR TITLE
Adjust TARGET selection to global CPU defines

### DIFF
--- a/devices/flash-flexspi/Makefile
+++ b/devices/flash-flexspi/Makefile
@@ -9,13 +9,10 @@
 FLEXSPI_OBJS := fspi/fspi.o
 
 ifneq (, $(findstring imxrt117x, $(TARGET_SUBFAMILY)))
-	CFLAGS += -DIMXRT117X
 	FLEXSPI_OBJS += flashdrv.o nor/nor.o nor/nor_mx.o
 else ifneq (, $(findstring imxrt106x, $(TARGET_SUBFAMILY)))
-	CFLAGS += -DIMXRT106X
 	FLEXSPI_OBJS += flashdrv.o nor/nor.o nor/nor_mx.o
 else ifneq (, $(findstring imxrt105x, $(TARGET_SUBFAMILY)))
-	CFLAGS += -DIMXRT105X
 	FLEXSPI_OBJS += flashdrv.o nor/nor.o hyperbus/hyper.o
 endif
 

--- a/devices/flash-flexspi/flashdrv.c
+++ b/devices/flash-flexspi/flashdrv.c
@@ -36,7 +36,7 @@ static inline int minorToInstance(unsigned int minor)
 		case 0:
 			return flexspi_instance1;
 
-#if defined(IMXRT106X) || defined(IMXRT117X)
+#if defined(__CPU_IMXRT106X) || defined(__CPU_IMXRT117X)
 		case 1:
 			return flexspi_instance2;
 #endif
@@ -53,12 +53,12 @@ static inline int minorToPortMask(unsigned int minor)
 		case 0:
 			return flexspi_slBusA1;
 
-#if defined(IMXRT106X)
+#if defined(__CPU_IMXRT106X)
 		case 1:
 			return flexspi_slBusA1;
 #endif
 
-#if defined(IMXRT117X)
+#if defined(__CPU_IMXRT117X)
 		case 1:
 			return flexspi_slBusA1 | flexspi_slBusA2;
 #endif

--- a/devices/flash-flexspi/fspi/fspi.c
+++ b/devices/flash-flexspi/fspi/fspi.c
@@ -21,11 +21,11 @@
 
 
 /* Include platform dependent pin config */
-#if defined(IMXRT117X)
+#if defined(__CPU_IMXRT117X)
 #include "fspi_rt117x.h"
-#elif defined(IMXRT106X)
+#elif defined(__CPU_IMXRT106X)
 #include "fspi_rt106x.h"
-#elif defined(IMXRT105X)
+#elif defined(__CPU_IMXRT105X)
 #include "fspi_rt105x.h"
 #else
 #error "FlexSPI is not supported on this target"

--- a/hal/armv7m/exceptions.c
+++ b/hal/armv7m/exceptions.c
@@ -18,7 +18,7 @@
 
 #define SIZE_FPUCTX (16 * sizeof(u32))
 
-#ifdef CPU_IMXRT
+#if defined(__CPU_IMXRT106X) || defined(__CPU_IMXRT105X) || defined(__CPU_IMXRT117X)
 #define EXCRET_PSP 0xffffffed
 #else
 #define EXCRET_PSP 0xfffffffd


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

The reason for this is a recent change to phoenix-rtos-build which provides __TARGET and __CPU globally. So local definition of IMXRT* became redundant.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt1176, imxrt1064.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/plo/pull/270
- [ ] I will merge this PR by myself when appropriate.
