### PR TITLE
zynq7000-flash: initialize configuration registers

### DIFF
--- a/devices/flash-zynq7000/flashcfg.c
+++ b/devices/flash-zynq7000/flashcfg.c
@@ -15,6 +15,7 @@
 
 
 #include "flashcfg.h"
+#include "qspi.h"
 #include <lib/errno.h>
 
 
@@ -47,125 +48,42 @@
 #define FLASH_CMD_BE         0x60 /* Chip erase */
 
 
-static void flashcfg_defaultCmds(flash_info_t *info)
-{
-	info->cmds[flash_cmd_rdid].opCode = FLASH_CMD_RDID;
-	info->cmds[flash_cmd_rdid].size = 1;
-	info->cmds[flash_cmd_rdid].dummyCyc = 24;
-
-	info->cmds[flash_cmd_rdsr1].opCode = FLASH_CMD_RDSR1;
-	info->cmds[flash_cmd_rdsr1].size = 1;
-	info->cmds[flash_cmd_rdsr1].dummyCyc = 8;
-
-	info->cmds[flash_cmd_wrdi].opCode = FLASH_CMD_WRDI;
-	info->cmds[flash_cmd_wrdi].size = 1;
-	info->cmds[flash_cmd_wrdi].dummyCyc = 0;
-
-	info->cmds[flash_cmd_wren].opCode = FLASH_CMD_WREN;
-	info->cmds[flash_cmd_wren].size = 1;
-	info->cmds[flash_cmd_wren].dummyCyc = 0;
-
-	info->cmds[flash_cmd_read].opCode = FLASH_CMD_READ;
-	info->cmds[flash_cmd_read].size = 4;
-	info->cmds[flash_cmd_read].dummyCyc = 0;
-
-	info->cmds[flash_cmd_4read].opCode = FLASH_CMD_4READ;
-	info->cmds[flash_cmd_4read].size = 5;
-	info->cmds[flash_cmd_4read].dummyCyc = 0;
-
-	info->cmds[flash_cmd_fast_read].opCode = FLASH_CMD_FAST_READ;
-	info->cmds[flash_cmd_fast_read].size = 4;
-	info->cmds[flash_cmd_fast_read].dummyCyc = 8;
-
-	info->cmds[flash_cmd_4fast_read].opCode = FLASH_CMD_4FAST_READ;
-	info->cmds[flash_cmd_4fast_read].size = 5;
-	info->cmds[flash_cmd_4fast_read].dummyCyc = 8;
-
-	info->cmds[flash_cmd_dor].opCode = FLASH_CMD_DOR;
-	info->cmds[flash_cmd_dor].size = 4;
-	info->cmds[flash_cmd_dor].dummyCyc = 8;
-
-	info->cmds[flash_cmd_4dor].opCode = FLASH_CMD_4DOR;
-	info->cmds[flash_cmd_4dor].size = 5;
-	info->cmds[flash_cmd_4dor].dummyCyc = 16;
-
-	info->cmds[flash_cmd_qor].opCode = FLASH_CMD_QOR;
-	info->cmds[flash_cmd_qor].size = 4;
-	info->cmds[flash_cmd_qor].dummyCyc = 8;
-
-	info->cmds[flash_cmd_4qor].opCode = FLASH_CMD_4QOR;
-	info->cmds[flash_cmd_4qor].size = 5;
-	info->cmds[flash_cmd_4qor].dummyCyc = 8;
-
-	info->cmds[flash_cmd_dior].opCode = FLASH_CMD_DIOR;
-	info->cmds[flash_cmd_dior].size = 4;
-	info->cmds[flash_cmd_dior].dummyCyc = 8;
-
-	info->cmds[flash_cmd_4dior].opCode = FLASH_CMD_4DIOR;
-	info->cmds[flash_cmd_4dior].size = 5;
-	info->cmds[flash_cmd_4dior].dummyCyc = 8;
-
-	info->cmds[flash_cmd_qior].opCode = FLASH_CMD_QIOR;
-	info->cmds[flash_cmd_qior].size = 4;
-	info->cmds[flash_cmd_qior].dummyCyc = 24;
-
-	info->cmds[flash_cmd_4qior].opCode = FLASH_CMD_4QIOR;
-	info->cmds[flash_cmd_4qior].size = 5;
-	info->cmds[flash_cmd_4qior].dummyCyc = 24;
-
-	info->cmds[flash_cmd_pp].opCode = FLASH_CMD_PP;
-	info->cmds[flash_cmd_pp].size = 4;
-	info->cmds[flash_cmd_pp].dummyCyc = 0;
-
-	info->cmds[flash_cmd_4pp].opCode = FLASH_CMD_4PP;
-	info->cmds[flash_cmd_4pp].size = 5;
-	info->cmds[flash_cmd_4pp].dummyCyc = 0;
-
-	info->cmds[flash_cmd_qpp].opCode = FLASH_CMD_QPP;
-	info->cmds[flash_cmd_qpp].size = 4;
-	info->cmds[flash_cmd_qpp].dummyCyc = 0;
-
-	info->cmds[flash_cmd_4qpp].opCode = FLASH_CMD_4QPP;
-	info->cmds[flash_cmd_4qpp].size = 5;
-	info->cmds[flash_cmd_4qpp].dummyCyc = 0;
-
-	info->cmds[flash_cmd_p4e].opCode = FLASH_CMD_P4E;
-	info->cmds[flash_cmd_p4e].size = 4;
-	info->cmds[flash_cmd_p4e].dummyCyc = 0;
-
-	info->cmds[flash_cmd_4p4e].opCode = FLASH_CMD_4P4E;
-	info->cmds[flash_cmd_4p4e].size = 5;
-	info->cmds[flash_cmd_4p4e].dummyCyc = 0;
-
-	info->cmds[flash_cmd_p64e].opCode = FLASH_CMD_SE;
-	info->cmds[flash_cmd_p64e].size = 4;
-	info->cmds[flash_cmd_p64e].dummyCyc = 0;
-
-	info->cmds[flash_cmd_4p64e].opCode = FLASH_CMD_4SE;
-	info->cmds[flash_cmd_4p64e].size = 5;
-	info->cmds[flash_cmd_4p64e].dummyCyc = 0;
-
-	info->cmds[flash_cmd_be].opCode = FLASH_CMD_BE;
-	info->cmds[flash_cmd_be].size = 1;
-	info->cmds[flash_cmd_be].dummyCyc = 0;
-}
-
-
-void flashcfg_jedecIDGet(flash_cmd_t *cmd)
-{
-	cmd->opCode = FLASH_CMD_RDID;
-	cmd->size = 1;
-	cmd->dummyCyc = 24;
-}
+static const flash_cmd_t flash_defCmds[flash_cmd_end] = {
+	{ FLASH_CMD_RDID, 1, 24, 1 },
+	{ FLASH_CMD_RDSR1, 1, 8, 1 },
+	{ FLASH_CMD_WRDI, 1, 0, 1 },
+	{ FLASH_CMD_WREN, 1, 0, 1 },
+	{ FLASH_CMD_READ, 4, 0, 1 },
+	{ FLASH_CMD_4READ, 5, 0, 1 },
+	{ FLASH_CMD_FAST_READ, 4, 8, 1 },
+	{ FLASH_CMD_4FAST_READ, 5, 8, 1 },
+	{ FLASH_CMD_DOR, 4, 4, 2 },
+	{ FLASH_CMD_4DOR, 5, 8, 2 },
+	{ FLASH_CMD_QOR, 4, 2, 4 },
+	{ FLASH_CMD_4QOR, 5, 2, 4 },
+	{ FLASH_CMD_DIOR, 4, 4, 2 },
+	{ FLASH_CMD_4DIOR, 5, 4, 2 },
+	{ FLASH_CMD_QIOR, 4, 6, 4 },
+	{ FLASH_CMD_4QIOR, 5, 6, 4 },
+	{ FLASH_CMD_PP, 4, 0, 1 },
+	{ FLASH_CMD_4PP, 5, 0, 1 },
+	{ FLASH_CMD_QPP, 4, 0, 4 },
+	{ FLASH_CMD_4QPP, 5, 0, 4 },
+	{ FLASH_CMD_P4E, 4, 0, 1 },
+	{ FLASH_CMD_4P4E, 5, 0, 1 },
+	{ FLASH_CMD_SE, 4, 0, 1 },
+	{ FLASH_CMD_4SE, 5, 0, 1 },
+	{ FLASH_CMD_BE, 1, 0, 1 }
+};
 
 
 static void flashcfg_spansion(flash_info_t *info)
 {
 	info->name = "Spansion s25fl256s1";
-	flashcfg_defaultCmds(info);
+	hal_memcpy(info->cmds, flash_defCmds, sizeof(flash_defCmds));
 
 	/* FIXME: s25fl256s1 should be able to operate in quad and dual mode for 4byte transactions.
-	          In the current implementation errors occur for the dual and the quad mode. */
+			  In the current implementation errors occur for the dual and the quad mode. */
 	info->readCmd = flash_cmd_4fast_read;
 	info->ppCmd = flash_cmd_4pp;
 }
@@ -191,15 +109,15 @@ static void flashcfg_micron(flash_info_t *info)
 	info->cfi.regs[0].count = 0xff;
 	info->cfi.regs[0].size = 0x100;
 
-	flashcfg_defaultCmds(info);
+	hal_memcpy(info->cmds, flash_defCmds, sizeof(flash_defCmds));
 
 	/* Specific configuration */
-	info->cmds[flash_cmd_dior].dummyCyc = 16;
-	info->cmds[flash_cmd_qior].dummyCyc = 32;
+	info->cmds[flash_cmd_dior].dummyCyc = 6;
+	info->cmds[flash_cmd_qior].dummyCyc = 10;
 
 	/* Default read and page program commands */
 	info->readCmd = flash_cmd_qior;
-	info->ppCmd = flash_cmd_pp;
+	info->ppCmd = flash_cmd_qpp;
 }
 
 
@@ -223,10 +141,18 @@ static void flashcfg_winbond(flash_info_t *info)
 	info->cfi.regs[0].count = 0xff;
 	info->cfi.regs[0].size = 0x100;
 
-	flashcfg_defaultCmds(info);
+	hal_memcpy(info->cmds, flash_defCmds, sizeof(flash_defCmds));
+
+	info->cmds[flash_cmd_qior].dummyCyc = 4;
 
 	info->readCmd = flash_cmd_qior;
-	info->ppCmd = flash_cmd_pp;
+	info->ppCmd = flash_cmd_qpp;
+}
+
+
+void flashcfg_jedecIDGet(flash_cmd_t *cmd)
+{
+	hal_memcpy(cmd, &flash_defCmds[flash_cmd_rdid], sizeof(*cmd));
 }
 
 
@@ -235,15 +161,15 @@ int flashcfg_infoResolve(flash_info_t *info)
 	int res = EOK;
 
 	/* Spansion s25fl256s1 */
-	if (info->cfi.vendorData[0] == 0x1 && info->cfi.vendorData[2] == 0x19) {
+	if ((info->cfi.vendorData[0] == 0x1) && (info->cfi.vendorData[2] == 0x19)) {
 		flashcfg_spansion(info);
 	}
 	/* Micron n25q128 */
-	else if (info->cfi.vendorData[0] == 0x20 && info->cfi.vendorData[1] == 0xbb && info->cfi.vendorData[2] == 0x18) {
+	else if ((info->cfi.vendorData[0] == 0x20) && (info->cfi.vendorData[1] == 0xbb) && (info->cfi.vendorData[2] == 0x18)) {
 		flashcfg_micron(info);
 	}
 	/* Winbond W25Q128JV - IM/JM */
-	else if (info->cfi.vendorData[0] == 0xef && info->cfi.vendorData[1] == 0x40 && info->cfi.vendorData[2] == 0x18) {
+	else if ((info->cfi.vendorData[0] == 0xef) && (info->cfi.vendorData[1] == 0x40) && (info->cfi.vendorData[2] == 0x18)) {
 		flashcfg_winbond(info);
 	}
 	else {
@@ -251,7 +177,7 @@ int flashcfg_infoResolve(flash_info_t *info)
 		res = -EINVAL;
 	}
 
-	info->addrMode = (info->cfi.chipSize > 24) ? flash_4byteAddr : flash_3byteAddr;
+	info->addrMode = (info->cfi.chipSize > 0x18) ? flash_4byteAddr : flash_3byteAddr;
 
 	return res;
 }

--- a/devices/flash-zynq7000/flashcfg.c
+++ b/devices/flash-zynq7000/flashcfg.c
@@ -47,6 +47,9 @@
 #define FLASH_CMD_4SE        0xdc /* 4-byte 64KB sector erase*/
 #define FLASH_CMD_BE         0x60 /* Chip erase */
 
+#define FLASH_TIMEOUT_CMD_MS 1000
+#define FLASH_TIMEOUT_WIP_MS 1000
+
 
 static const flash_cmd_t flash_defCmds[flash_cmd_end] = {
 	{ FLASH_CMD_RDID, 1, 24, 1 },
@@ -55,16 +58,16 @@ static const flash_cmd_t flash_defCmds[flash_cmd_end] = {
 	{ FLASH_CMD_WREN, 1, 0, 1 },
 	{ FLASH_CMD_READ, 4, 0, 1 },
 	{ FLASH_CMD_4READ, 5, 0, 1 },
-	{ FLASH_CMD_FAST_READ, 4, 8, 1 },
-	{ FLASH_CMD_4FAST_READ, 5, 8, 1 },
-	{ FLASH_CMD_DOR, 4, 4, 2 },
-	{ FLASH_CMD_4DOR, 5, 8, 2 },
-	{ FLASH_CMD_QOR, 4, 2, 4 },
-	{ FLASH_CMD_4QOR, 5, 2, 4 },
-	{ FLASH_CMD_DIOR, 4, 4, 2 },
-	{ FLASH_CMD_4DIOR, 5, 4, 2 },
-	{ FLASH_CMD_QIOR, 4, 6, 4 },
-	{ FLASH_CMD_4QIOR, 5, 6, 4 },
+	{ FLASH_CMD_FAST_READ, 4, CFI_DUMMY_CYCLES_NOT_SET, 1 },
+	{ FLASH_CMD_4FAST_READ, 5, CFI_DUMMY_CYCLES_NOT_SET, 1 },
+	{ FLASH_CMD_DOR, 4, CFI_DUMMY_CYCLES_NOT_SET, 2 },
+	{ FLASH_CMD_4DOR, 5, CFI_DUMMY_CYCLES_NOT_SET, 2 },
+	{ FLASH_CMD_QOR, 4, CFI_DUMMY_CYCLES_NOT_SET, 4 },
+	{ FLASH_CMD_4QOR, 5, CFI_DUMMY_CYCLES_NOT_SET, 4 },
+	{ FLASH_CMD_DIOR, 4, CFI_DUMMY_CYCLES_NOT_SET, 2 },
+	{ FLASH_CMD_4DIOR, 5, CFI_DUMMY_CYCLES_NOT_SET, 2 },
+	{ FLASH_CMD_QIOR, 4, CFI_DUMMY_CYCLES_NOT_SET, 4 },
+	{ FLASH_CMD_4QIOR, 5, CFI_DUMMY_CYCLES_NOT_SET, 4 },
 	{ FLASH_CMD_PP, 4, 0, 1 },
 	{ FLASH_CMD_4PP, 5, 0, 1 },
 	{ FLASH_CMD_QPP, 4, 0, 4 },
@@ -77,15 +80,214 @@ static const flash_cmd_t flash_defCmds[flash_cmd_end] = {
 };
 
 
+static int flashcfg_wren(const flash_info_t *info)
+{
+	int res;
+	u8 cmdOpCode = info->cmds[flash_cmd_wren].opCode;
+
+	qspi_start();
+	res = qspi_polledTransfer(&cmdOpCode, NULL, 1, FLASH_TIMEOUT_CMD_MS);
+	qspi_stop();
+
+	return res;
+}
+
+
+static int flashcfg_statusRegGet(const flash_info_t *info, u8 *val)
+{
+	int res;
+	u8 rx[2] = { 0, 0 };
+	u8 tx[2] = { 0, 0 };
+
+	tx[0] = info->cmds[flash_cmd_rdsr1].opCode;
+
+	qspi_start();
+	res = qspi_polledTransfer(tx, rx, 2, FLASH_TIMEOUT_CMD_MS);
+	qspi_stop();
+
+	*val = rx[1];
+
+	return res;
+}
+
+
+static int flashcfg_wipCheck(const flash_info_t *info, time_t timeout)
+{
+	int res;
+	u8 st;
+	const time_t stop = hal_timerGet() + timeout;
+
+	do {
+		res = flashcfg_statusRegGet(info, &st);
+		if (res < 0) {
+			return res;
+		}
+
+		if (hal_timerGet() >= stop) {
+			return -ETIME;
+		}
+	} while ((st & 0x1) != 0);
+
+	return EOK;
+}
+
+
+static int flashcfg_spansionInit(const flash_info_t *info)
+{
+	int res;
+	u8 tx[3];
+
+	res = flashcfg_wren(info);
+	if (res < 0) {
+		return res;
+	}
+
+	/* Write registers */
+
+	/* Write registers cmd code */
+	tx[0] = 0x1;
+
+	/* SR */
+	/* Leave SR in default state */
+	tx[1] = 0;
+
+	/* CR */
+	/* Set latency code to 10b to support 100 MHz */
+	/* Other values are set as in default config (0) */
+	tx[2] = (2 << 6);
+	/* Enable quad mode if needed. */
+	if ((info->cmds[info->readCmd].dataLines == 4) || (info->cmds[info->ppCmd].dataLines == 4)) {
+		tx[2] = (1 << 1);
+	}
+
+	qspi_start();
+	res = qspi_polledTransfer(tx, NULL, 3, FLASH_TIMEOUT_CMD_MS);
+	qspi_stop();
+
+	if (res < 0) {
+		return res;
+	}
+
+	return flashcfg_wipCheck(info, FLASH_TIMEOUT_WIP_MS);
+}
+
+
 static void flashcfg_spansion(flash_info_t *info)
 {
 	info->name = "Spansion s25fl256s1";
 	hal_memcpy(info->cmds, flash_defCmds, sizeof(flash_defCmds));
 
-	/* FIXME: s25fl256s1 should be able to operate in quad and dual mode for 4byte transactions.
-			  In the current implementation errors occur for the dual and the quad mode. */
+	/* Specific configuration */
+	/* Dummy cycles chosen for 100MHz clock speed. Latency Code 10b. */
+	/* Dummy cycles * data lines must be divisible by 8. */
+
+	/* Single line */
+	info->cmds[flash_cmd_fast_read].dummyCyc = 8;
+	info->cmds[flash_cmd_4fast_read].dummyCyc = 8;
+	/* Two lines */
+	info->cmds[flash_cmd_dor].dummyCyc = 8;
+	info->cmds[flash_cmd_4dor].dummyCyc = 8;
+	info->cmds[flash_cmd_dior].dummyCyc = 6;
+	info->cmds[flash_cmd_4dior].dummyCyc = 6;
+	/* Four lines */
+	info->cmds[flash_cmd_qor].dummyCyc = 8;
+	info->cmds[flash_cmd_4qor].dummyCyc = 8;
+	info->cmds[flash_cmd_qior].dummyCyc = 7;
+	info->cmds[flash_cmd_4qior].dummyCyc = 7;
+
+	/* FIXME:  s25fl256s1 should be able to operate in quad and dual mode for 4byte transactions.
+			   In the current implementation errors occur for the dual and the quad mode.
+			   Zedboard's QSPI controller doesn't officially support 4byte addressing.
+			   Due to this fact quad / dual mode with 4 byte addressing maybe impossible. */
 	info->readCmd = flash_cmd_4fast_read;
 	info->ppCmd = flash_cmd_4pp;
+
+	info->init = flashcfg_spansionInit;
+}
+
+
+static int flashcfg_micronVolatileCRWREN(const flash_info_t *info, int enable)
+{
+	int res;
+	u8 tx[3];
+
+	res = flashcfg_wren(info);
+	if (res < 0) {
+		return res;
+	}
+
+	/* Enable non-volatile CR write */
+	/* non-volatile CR write cmd code */
+	tx[0] = 0xb1;
+
+	/* Output driver strength 30 Ohms, TODO optimize */
+	/* Enable hold, disable Quad I/O and Dual I/O protocols */
+	/* Enable write on non-volatile register */
+	tx[1] = 0xfe;
+	if (enable == 0) {
+		tx[1] |= 1;
+	}
+
+	/* Set default value for number of dummy clock cycles */
+	/* Disable XIP */
+	tx[2] = 0xff;
+
+	qspi_start();
+	res = qspi_polledTransfer(tx, NULL, 3, FLASH_TIMEOUT_CMD_MS);
+	qspi_stop();
+
+	if (res < 0) {
+		return res;
+	}
+
+	return flashcfg_wipCheck(info, FLASH_TIMEOUT_WIP_MS);
+}
+
+
+static int flashcfg_micronInit(const flash_info_t *info)
+{
+	int res;
+	u8 tx[2];
+
+	/* Ensure number of dummy cycles is supported by this flash. */
+	if ((info->cmds[info->readCmd].dummyCyc - 1) > 0xf) {
+		return -EINVAL;
+	}
+
+	res = flashcfg_micronVolatileCRWREN(info, 1);
+	if (res < 0) {
+		return res;
+	}
+
+	/* Write volatile CR */
+
+	/* Volatile CR write cmd code */
+	tx[0] = 0x81;
+
+	/* Set number of dummy cycles */
+	tx[1] = ((info->cmds[info->readCmd].dummyCyc - 1) << 4);
+	/* Disable XIP, continuous read */
+	tx[1] |= 0xb;
+
+	qspi_start();
+	res = qspi_polledTransfer(tx, NULL, 2, FLASH_TIMEOUT_CMD_MS);
+	qspi_stop();
+
+	if (res < 0) {
+		return res;
+	}
+
+	res = flashcfg_wipCheck(info, FLASH_TIMEOUT_WIP_MS);
+	if (res < 0) {
+		return res;
+	}
+
+	res = flashcfg_micronVolatileCRWREN(info, 0);
+	if (res < 0) {
+		return res;
+	}
+
+	return 0;
 }
 
 
@@ -112,12 +314,74 @@ static void flashcfg_micron(flash_info_t *info)
 	hal_memcpy(info->cmds, flash_defCmds, sizeof(flash_defCmds));
 
 	/* Specific configuration */
-	info->cmds[flash_cmd_dior].dummyCyc = 6;
+	/* Dummy cycles chosen for 100MHz clock speed. */
+	/* Dummy cycles * data lines must be divisible by 8. */
+
+	/* Single line */
+	info->cmds[flash_cmd_fast_read].dummyCyc = 8;
+	info->cmds[flash_cmd_4fast_read].dummyCyc = 8;
+	/* Two lines */
+	info->cmds[flash_cmd_dor].dummyCyc = 4;
+	info->cmds[flash_cmd_4dor].dummyCyc = 4;
+	info->cmds[flash_cmd_dior].dummyCyc = 8;
+	info->cmds[flash_cmd_4dior].dummyCyc = 8;
+	/* Four lines */
+	info->cmds[flash_cmd_qor].dummyCyc = 6;
+	info->cmds[flash_cmd_4qor].dummyCyc = 6;
 	info->cmds[flash_cmd_qior].dummyCyc = 10;
+	info->cmds[flash_cmd_4qior].dummyCyc = 10;
 
 	/* Default read and page program commands */
 	info->readCmd = flash_cmd_qior;
 	info->ppCmd = flash_cmd_qpp;
+
+	info->init = flashcfg_micronInit;
+}
+
+
+static int flashcfg_winbondInit(const flash_info_t *info)
+{
+	int res;
+	u8 tx[4];
+
+	/* Write enable SR and set the write mode to volatile. */
+	tx[0] = 0x50;
+
+	qspi_start();
+	res = qspi_polledTransfer(tx, NULL, 2, FLASH_TIMEOUT_CMD_MS);
+	qspi_stop();
+
+	if (res < 0) {
+		return res;
+	}
+
+	/* Write volatile status registers */
+
+	/* Write status registers cmd code */
+	tx[0] = 0x1;
+
+	/* SR */
+	/* Ensure SR is protected by software */
+	/* Do not enable any protection. */
+	tx[1] = 0;
+	tx[2] = 0;
+	/* Enable quad mode if needed. */
+	if ((info->cmds[info->readCmd].dataLines == 4) || (info->cmds[info->ppCmd].dataLines == 4)) {
+		tx[2] = (1 << 1);
+	}
+	/* Set output the driver strength to 25% (default value in the docs). */
+	/* TODO: optimize */
+	tx[3] = (3 << 5);
+
+	qspi_start();
+	res = qspi_polledTransfer(tx, NULL, 4, FLASH_TIMEOUT_CMD_MS);
+	qspi_stop();
+
+	if (res < 0) {
+		return res;
+	}
+
+	return flashcfg_wipCheck(info, FLASH_TIMEOUT_WIP_MS);
 }
 
 
@@ -143,10 +407,21 @@ static void flashcfg_winbond(flash_info_t *info)
 
 	hal_memcpy(info->cmds, flash_defCmds, sizeof(flash_defCmds));
 
-	info->cmds[flash_cmd_qior].dummyCyc = 4;
+	/* 4 byte address commands are not supported. */
+
+	/* Single line */
+	info->cmds[flash_cmd_fast_read].dummyCyc = 8;
+	/* Two lines */
+	info->cmds[flash_cmd_dor].dummyCyc = 8;
+	info->cmds[flash_cmd_dior].dummyCyc = 4; /* One mode byte */
+	/* Four lines */
+	info->cmds[flash_cmd_qor].dummyCyc = 8;
+	info->cmds[flash_cmd_qior].dummyCyc = 6; /* One mode byte + 4 dummy cycles */
 
 	info->readCmd = flash_cmd_qior;
 	info->ppCmd = flash_cmd_qpp;
+
+	info->init = flashcfg_winbondInit;
 }
 
 

--- a/devices/flash-zynq7000/flashcfg.h
+++ b/devices/flash-zynq7000/flashcfg.h
@@ -28,6 +28,7 @@
 #define CFI_SIZE_PAGE(val)                 (1u << val)
 #define CFI_SIZE_REGION(regSize, regCount) (CFI_SIZE_SECTION(regSize) * (size_t)(regCount + 1u))
 
+#define CFI_DUMMY_CYCLES_NOT_SET 0xff
 
 /* Order in command's table */
 enum {
@@ -112,6 +113,8 @@ typedef struct flash_info {
 	int readCmd; /* Default read command define for specific flash memory */
 	int ppCmd;   /* Default page program command define for specific flash memory */
 	const char *name;
+
+	int (*init)(const struct flash_info *info);
 } flash_info_t;
 
 

--- a/devices/flash-zynq7000/flashcfg.h
+++ b/devices/flash-zynq7000/flashcfg.h
@@ -98,17 +98,19 @@ typedef struct {
 	u8 opCode;
 	u8 size;
 	u8 dummyCyc;
+	u8 dataLines;
 } flash_cmd_t;
 
 
-typedef struct {
+typedef struct flash_info {
 	flash_cfi_t cfi;
 	flash_cmd_t cmds[flash_cmd_end];
 
-	enum { flash_3byteAddr,
-		flash_4byteAddr } addrMode; /* Address mode based on chip size */
-	int readCmd;                    /* Default read command define for specific flash memory */
-	int ppCmd;                      /* Default page program command define for specific flash memory */
+	/* clang-format off */
+	enum { flash_3byteAddr, flash_4byteAddr } addrMode; /* Address mode based on chip size */
+	/* clang-format on */
+	int readCmd; /* Default read command define for specific flash memory */
+	int ppCmd;   /* Default page program command define for specific flash memory */
 	const char *name;
 } flash_info_t;
 

--- a/devices/flash-zynq7000/flashdrv.c
+++ b/devices/flash-zynq7000/flashdrv.c
@@ -45,8 +45,9 @@ static size_t flashdrv_regStart(int id)
 	size_t regStart = 0;
 	const flash_cfi_t *cfi = &fdrv_common.info.cfi;
 
-	for (i = 0; i < id; ++i)
+	for (i = 0; i < id; ++i) {
 		regStart += CFI_SIZE_REGION(cfi->regs[i].size, cfi->regs[i].count);
+	}
 
 	return regStart;
 }
@@ -73,10 +74,10 @@ static int flashdrv_regionFind(addr_t offs, u32 *id)
 }
 
 
-static inline void flashdrv_serializeTxCmd(u8 *buff, const flash_cmd_t *cmd, addr_t offs)
+static inline void flashdrv_serializeTxCmd(u8 *buff, flash_cmd_t cmd, addr_t offs)
 {
-	hal_memset(buff, 0, cmd->size);
-	buff[0] = cmd->opCode;
+	hal_memset(buff, 0, cmd.size);
+	buff[0] = cmd.opCode;
 
 	if (fdrv_common.info.addrMode == flash_4byteAddr) {
 		buff[1] = (offs >> 24) & 0xff;
@@ -103,7 +104,7 @@ static int flashdrv_cfiRead(flash_cfi_t *cfi)
 	flashcfg_jedecIDGet(&cmd);
 
 	/* Cmd size is rounded to 4 bytes, it includes dummy cycles [b]. */
-	cmdSz = (cmd.size + cmd.dummyCyc / 8 + 0x3) & ~0x3;
+	cmdSz = (cmd.size + (cmd.dummyCyc * cmd.dataLines) / 8 + 0x3) & ~0x3;
 	/* Size of the data which is received during cmd transfer */
 	dataSz = cmdSz - cmd.size;
 
@@ -130,16 +131,15 @@ static int flashdrv_statusRegGet(unsigned int *val)
 {
 	ssize_t res;
 	size_t cmdSz;
-	const flash_cmd_t *cmd = &fdrv_common.info.cmds[flash_cmd_rdsr1];
+	const flash_cmd_t cmd = fdrv_common.info.cmds[flash_cmd_rdsr1];
 
 	*val = 0;
 
-	cmdSz = cmd->size + cmd->dummyCyc / 8;
+	cmdSz = cmd.size + (cmd.dummyCyc * cmd.dataLines) / 8;
 	hal_memset(fdrv_common.cmdTx, 0, cmdSz);
 
-	fdrv_common.cmdTx[0] = cmd->opCode;
-
 	qspi_start();
+	fdrv_common.cmdTx[0] = cmd.opCode;
 	res = qspi_polledTransfer(fdrv_common.cmdTx, (u8 *)val, cmdSz, TIMEOUT_CMD_MS);
 	qspi_stop();
 
@@ -155,11 +155,13 @@ static int flashdrv_wipCheck(time_t timeout)
 
 	do {
 		res = flashdrv_statusRegGet(&st);
-		if (res < 0)
+		if (res < 0) {
 			return res;
+		}
 
-		if (hal_timerGet() >= stop)
+		if (hal_timerGet() >= stop) {
 			return -ETIME;
+		}
 	} while ((st >> 8) & 0x1);
 
 	return EOK;
@@ -169,18 +171,19 @@ static int flashdrv_wipCheck(time_t timeout)
 static int flashdrv_welSet(unsigned int cmdID)
 {
 	ssize_t res;
-	const flash_cmd_t *cmd;
+	flash_cmd_t cmd;
 
-	if (cmdID != flash_cmd_wrdi && cmdID != flash_cmd_wren)
+	if ((cmdID != flash_cmd_wrdi) && (cmdID != flash_cmd_wren)) {
 		return -EINVAL;
+	}
 
-	cmd = &fdrv_common.info.cmds[cmdID];
+	cmd = fdrv_common.info.cmds[cmdID];
 
-	hal_memset(fdrv_common.cmdTx, 0, cmd->size);
-	fdrv_common.cmdTx[0] = cmd->opCode;
+	hal_memset(fdrv_common.cmdTx, 0, cmd.size);
+	fdrv_common.cmdTx[0] = cmd.opCode;
 
 	qspi_start();
-	res = qspi_polledTransfer(fdrv_common.cmdTx, fdrv_common.cmdRx, cmd->size, TIMEOUT_CMD_MS);
+	res = qspi_polledTransfer(fdrv_common.cmdTx, fdrv_common.cmdRx, cmd.size, TIMEOUT_CMD_MS);
 	qspi_stop();
 
 	return res;
@@ -193,18 +196,18 @@ static int flashdrv_chipErase(void)
 	time_t timeout;
 
 	const flash_cfi_t *cfi = &fdrv_common.info.cfi;
-	const flash_cmd_t *cmd = &fdrv_common.info.cmds[flash_cmd_be];
+	flash_cmd_t cmd = fdrv_common.info.cmds[flash_cmd_be];
 
 	res = flashdrv_welSet(flash_cmd_wren);
 	if (res < 0) {
 		return res;
 	}
 
-	hal_memset(fdrv_common.cmdTx, 0, cmd->size);
-	fdrv_common.cmdTx[0] = cmd->opCode;
+	hal_memset(fdrv_common.cmdTx, 0, cmd.size);
+	fdrv_common.cmdTx[0] = cmd.opCode;
 
 	qspi_start();
-	res = (int)qspi_polledTransfer(fdrv_common.cmdTx, NULL, cmd->size, TIMEOUT_CMD_MS);
+	res = (int)qspi_polledTransfer(fdrv_common.cmdTx, NULL, cmd.size, TIMEOUT_CMD_MS);
 	qspi_stop();
 
 	if (res < 0) {
@@ -221,7 +224,7 @@ static int flashdrv_sectorErase(addr_t offs, size_t sectSz)
 {
 	int res;
 	time_t timeout;
-	const flash_cmd_t *cmd;
+	flash_cmd_t cmd;
 	const flash_cfi_t *cfi = &fdrv_common.info.cfi;
 
 	if (offs > CFI_SIZE_FLASH(cfi->chipSize)) {
@@ -230,23 +233,24 @@ static int flashdrv_sectorErase(addr_t offs, size_t sectSz)
 
 	switch (sectSz) {
 		case 0x1000:
-			cmd = (fdrv_common.info.addrMode == flash_4byteAddr) ? &fdrv_common.info.cmds[flash_cmd_4p4e] : &fdrv_common.info.cmds[flash_cmd_p4e];
+			cmd = (fdrv_common.info.addrMode == flash_4byteAddr) ? fdrv_common.info.cmds[flash_cmd_4p4e] : fdrv_common.info.cmds[flash_cmd_p4e];
 			break;
 		case 0x10000:
-			cmd = (fdrv_common.info.addrMode == flash_4byteAddr) ? &fdrv_common.info.cmds[flash_cmd_4p64e] : &fdrv_common.info.cmds[flash_cmd_p64e];
+			cmd = (fdrv_common.info.addrMode == flash_4byteAddr) ? fdrv_common.info.cmds[flash_cmd_4p64e] : fdrv_common.info.cmds[flash_cmd_p64e];
 			break;
 		default:
 			return -EINVAL;
 	}
 
 	res = flashdrv_welSet(flash_cmd_wren);
-	if (res < 0)
+	if (res < 0) {
 		return res;
+	}
 
 	flashdrv_serializeTxCmd(fdrv_common.cmdTx, cmd, offs);
 
 	qspi_start();
-	res = (int)qspi_polledTransfer(fdrv_common.cmdTx, fdrv_common.cmdRx, cmd->size, TIMEOUT_CMD_MS);
+	res = (int)qspi_polledTransfer(fdrv_common.cmdTx, fdrv_common.cmdRx, cmd.size, TIMEOUT_CMD_MS);
 	if (res < 0) {
 		qspi_stop();
 		return res;
@@ -264,22 +268,25 @@ static ssize_t flashdrv_pageProgram(addr_t offs, const void *buff, size_t len)
 	ssize_t res;
 	time_t timeout;
 	const flash_cfi_t *cfi = &fdrv_common.info.cfi;
-	const flash_cmd_t *cmd = &fdrv_common.info.cmds[fdrv_common.info.ppCmd];
+	flash_cmd_t cmd = fdrv_common.info.cmds[fdrv_common.info.ppCmd];
 
-	if (len == 0)
+	if (len == 0) {
 		return 0;
+	}
 
-	if (buff == NULL || len % CFI_SIZE_PAGE(cfi->pageSize))
+	if ((buff == NULL) || ((len % CFI_SIZE_PAGE(cfi->pageSize)) != 0)) {
 		return -EINVAL;
+	}
 
 	res = flashdrv_welSet(flash_cmd_wren);
-	if (res < 0)
+	if (res < 0) {
 		return res;
+	}
 
 	flashdrv_serializeTxCmd(fdrv_common.cmdTx, cmd, offs);
 
 	qspi_start();
-	res = qspi_polledTransfer(fdrv_common.cmdTx, fdrv_common.cmdRx, cmd->size, TIMEOUT_CMD_MS);
+	res = qspi_polledTransfer(fdrv_common.cmdTx, fdrv_common.cmdRx, cmd.size, TIMEOUT_CMD_MS);
 	if (res < 0) {
 		qspi_stop();
 		return res;
@@ -297,8 +304,9 @@ static ssize_t flashdrv_pageProgram(addr_t offs, const void *buff, size_t len)
 
 	timeout = CFI_TIMEOUT_MAX_PROGRAM(cfi->timeoutTypical.pageWrite, cfi->timeoutMax.pageWrite) + TIMEOUT_CMD_MS;
 	res = flashdrv_wipCheck(timeout);
-	if (res < 0)
+	if (res < 0) {
 		return res;
+	}
 
 	return len;
 }
@@ -309,32 +317,35 @@ static ssize_t flashdrv_pageProgram(addr_t offs, const void *buff, size_t len)
 static ssize_t flashdrv_read(unsigned int minor, addr_t offs, void *buff, size_t len, time_t timeout)
 {
 	ssize_t res;
-	size_t cmdSz, dataSz, transferSz;
-	const flash_cmd_t *cmd = &fdrv_common.info.cmds[fdrv_common.info.readCmd];
+	size_t cmdSz, dataSz, transferSz, paddedCmdSz;
+	const flash_cmd_t cmd = fdrv_common.info.cmds[fdrv_common.info.readCmd];
 
-	if (len == 0)
+	if (len == 0) {
 		return 0;
+	}
 
-	if (buff == NULL)
+	if (buff == NULL) {
 		return -EINVAL;
+	}
 
 	flashdrv_serializeTxCmd(fdrv_common.cmdTx, cmd, offs);
 
+	cmdSz = cmd.size + (cmd.dummyCyc * cmd.dataLines) / 8;
 	/* Cmd size is rounded to 4 bytes, it includes dummy cycles [b]. */
-	cmdSz = (cmd->size + cmd->dummyCyc / 8 + 0x3) & ~0x3;
+	paddedCmdSz = (cmdSz + 0x3) & ~0x3;
 
 	/* Size of the data which is received during cmd transfer */
-	transferSz = cmdSz - cmd->size - cmd->dummyCyc / 8;
+	transferSz = paddedCmdSz - cmdSz;
 	dataSz = (transferSz > len) ? len : transferSz;
 
 	qspi_start();
-	res = qspi_polledTransfer(fdrv_common.cmdTx, fdrv_common.cmdRx, cmdSz, TIMEOUT_CMD_MS);
+	res = qspi_polledTransfer(fdrv_common.cmdTx, fdrv_common.cmdRx, paddedCmdSz, TIMEOUT_CMD_MS);
 	if (res < 0) {
 		qspi_stop();
 		return res;
 	}
 	/* Copy data received after dummy bytes */
-	hal_memcpy(buff, (fdrv_common.cmdRx + cmd->size + cmd->dummyCyc / 8), dataSz);
+	hal_memcpy(buff, (fdrv_common.cmdRx + cmdSz), dataSz);
 
 	res = qspi_polledTransfer(NULL, (u8 *)buff + dataSz, len - dataSz, timeout);
 	qspi_stop();
@@ -353,8 +364,9 @@ static int flashdrv_sync(unsigned int minor)
 	size_t pageSz, sectSz, regStart = 0;
 	const flash_cfi_t *cfi = &fdrv_common.info.cfi;
 
-	if (fdrv_common.buffPos == 0)
+	if (fdrv_common.buffPos == 0) {
 		return EOK;
+	}
 
 	regStart = flashdrv_regStart(fdrv_common.regID);
 	sectSz = CFI_SIZE_SECTION(cfi->regs[fdrv_common.regID].size);
@@ -366,8 +378,9 @@ static int flashdrv_sync(unsigned int minor)
 		src = fdrv_common.buff + i * pageSz;
 
 		res = flashdrv_pageProgram(dst, src, pageSz);
-		if (res < 0)
+		if (res < 0) {
 			return res;
+		}
 	}
 
 	fdrv_common.regID = (u32)-1;
@@ -390,18 +403,21 @@ static ssize_t flashdrv_write(unsigned int minor, addr_t offs, const void *buff,
 
 	const flash_cfi_t *cfi = &fdrv_common.info.cfi;
 
-	if (len == 0)
+	if (len == 0) {
 		return 0;
+	}
 
-	if (buff == NULL || (offs + len) > CFI_SIZE_FLASH(cfi->chipSize))
+	if ((buff == NULL) || ((offs + len) > CFI_SIZE_FLASH(cfi->chipSize))) {
 		return -EINVAL;
+	}
 
 	while (saveSz < len) {
 		offs += chunkSz;
 
 		res = flashdrv_regionFind(offs, &regID);
-		if (res < 0)
+		if (res < 0) {
 			return res;
+		}
 
 		regStart = flashdrv_regStart(regID);
 		sectSz = CFI_SIZE_SECTION(cfi->regs[regID].size);
@@ -409,18 +425,21 @@ static ssize_t flashdrv_write(unsigned int minor, addr_t offs, const void *buff,
 
 		if (regID != fdrv_common.regID || sectID != fdrv_common.sectID) {
 			res = flashdrv_sync(minor);
-			if (res < 0)
+			if (res < 0) {
 				return res;
+			}
 
 			/* Read operation timeout depends on sector size. Factor value selected empirically. */
 			timeout = (sectSz * TIMEOUT_CMD_MS) / timeoutFactor;
 			res = flashdrv_read(minor, regStart + (sectSz * sectID), fdrv_common.buff, sectSz, timeout);
-			if (res < 0)
+			if (res < 0) {
 				return res;
+			}
 
 			res = flashdrv_sectorErase(regStart + (sectSz * sectID), sectSz);
-			if (res < 0)
+			if (res < 0) {
 				return res;
+			}
 
 			fdrv_common.regID = regID;
 			fdrv_common.sectID = sectID;
@@ -434,12 +453,14 @@ static ssize_t flashdrv_write(unsigned int minor, addr_t offs, const void *buff,
 		saveSz += chunkSz;
 		fdrv_common.buffPos += chunkSz;
 
-		if (fdrv_common.buffPos < sectSz)
+		if (fdrv_common.buffPos < sectSz) {
 			continue;
+		}
 
 		res = flashdrv_sync(minor);
-		if (res < 0)
+		if (res < 0) {
 			return res;
+		}
 	}
 
 	return saveSz;
@@ -540,8 +561,9 @@ static int flashdrv_done(unsigned int minor)
 	}
 
 	res = qspi_deinit();
-	if (res < 0)
+	if (res < 0) {
 		return res;
+	}
 
 	return EOK;
 }
@@ -551,8 +573,9 @@ static int flashdrv_done(unsigned int minor)
 static int flashdrv_map(unsigned int minor, addr_t addr, size_t sz, int mode, addr_t memaddr, size_t memsz, int memmode, addr_t *a)
 {
 	/* Device mode cannot be higher than map mode to copy data */
-	if ((mode & memmode) != mode)
+	if ((mode & memmode) != mode) {
 		return -EINVAL;
+	}
 
 	/* flash is not mappable to any region in I/O mode */
 	return dev_isNotMappable;
@@ -572,20 +595,30 @@ static int flashdrv_init(unsigned int minor)
 	fdrv_common.buff = (void *)ADDR_OCRAM_HIGH;
 
 	res = qspi_init();
-	if (res < 0)
+	if (res < 0) {
 		return res;
+	}
 
 	res = flashdrv_cfiRead(&info->cfi);
-	if (res < 0)
+	if (res < 0) {
 		return res;
+	}
 
 	res = flashcfg_infoResolve(info);
-	if (res < 0)
+	if (res < 0) {
 		return res;
+	}
 
 	for (i = 0; i < info->cfi.regsCount; ++i) {
-		if (CFI_SIZE_SECTION(info->cfi.regs[i].size) > SIZE_OCRAM_HIGH)
+		if (CFI_SIZE_SECTION(info->cfi.regs[i].size) > SIZE_OCRAM_HIGH) {
 			return -EINVAL;
+		}
+	}
+
+	/* Require data RXed due to dummy cycles to be byte aligned. */
+	/* This requirement is in place to simplify implementation of read. */
+	if (((info->cmds[info->readCmd].dummyCyc * info->cmds[info->readCmd].dataLines) % 8) != 0) {
+		return -EINVAL;
 	}
 
 	lib_printf("\ndev/flash: Configured %s %dMB nor flash(%d.%d)", info->name,

--- a/devices/flash-zynq7000/qspi.c
+++ b/devices/flash-zynq7000/qspi.c
@@ -5,8 +5,8 @@
  *
  * Quad-SPI Controller driver
  *
- * Copyright 2021-2022 Phoenix Systems
- * Author: Hubert Buczynski
+ * Copyright 2021-2023 Phoenix Systems
+ * Author: Hubert Buczynski, Hubert Badocha
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -14,13 +14,16 @@
  */
 
 #include "qspi.h"
-#include <lib/errno.h>
 
+#include <lib/lib.h>
 #include <board_config.h>
 
+
+/* clang-format off */
 enum { cr = 0, sr, ier, idr, imr, er, dr, txd00, rxd, sicr, txth, rxth, gpio,
 	   lpbk = 0xe, txd01 = 0x20, txd10, txd11,
 	   lqspi_cr = 0x28, lqspi_sr, modid = 0x3f };
+/* clang-format on */
 
 
 struct {
@@ -31,8 +34,9 @@ struct {
 void qspi_stop(void)
 {
 	/* Clean up RX Fifo */
-	while ((*(qspi_common.base + sr) & (1 << 4)))
+	while ((*(qspi_common.base + sr) & (1 << 4)) != 0) {
 		*(qspi_common.base + rxd);
+	}
 
 	*(qspi_common.base + cr) |= (1 << 10);
 	hal_cpuDataMemoryBarrier();
@@ -87,7 +91,7 @@ static unsigned int qspi_rxData(u8 *rxBuff, size_t size)
 		}
 	}
 
-	return (size < 4) ? size : 4;
+	return min(size, 4);
 }
 
 
@@ -127,25 +131,28 @@ ssize_t qspi_polledTransfer(const u8 *txBuff, u8 *rxBuff, size_t size, time_t ti
 
 	start = hal_timerGet();
 
-	while (txSz || rxSz) {
+	while ((txSz != 0) || (rxSz != 0)) {
 		/* Transmit data */
-		while (txSz) {
+		while (txSz != 0) {
 			/* Incomplete word has to be send and receive as a last transfer
 			 * otherwise there is an undefined behaviour.                   */
-			if ((txSz < sizeof(u32)) && (rxSz >= sizeof(u32)))
+			if ((txSz < sizeof(u32)) && (rxSz >= sizeof(u32))) {
 				break;
+			}
 
 			/* TX Fifo is full */
-			if ((*(qspi_common.base + sr) & (1 << 3)))
+			if ((*(qspi_common.base + sr) & (1 << 3)) != 0) {
 				break;
+			}
 
 			tempSz = qspi_txData(txBuff, txSz);
 
 			txSz -= tempSz;
 			rxSz += tempSz;
 
-			if (txBuff != NULL)
+			if (txBuff != NULL) {
 				txBuff += tempSz;
+			}
 		}
 
 		/* Start data transmission */
@@ -153,21 +160,24 @@ ssize_t qspi_polledTransfer(const u8 *txBuff, u8 *rxBuff, size_t size, time_t ti
 
 		/* Wait until TX Fifo is empty */
 		while ((*(qspi_common.base + sr) & (1 << 2)) == 0) {
-			if ((hal_timerGet() - start) >= timeout)
+			if ((hal_timerGet() - start) >= timeout) {
 				return -ETIME;
+			}
 		}
 
 		/* Receive data */
-		while (rxSz) {
+		while (rxSz != 0) {
 			/* RX Fifo is empty */
-			if ((*(qspi_common.base + sr) & (1 << 4)) == 0)
+			if ((*(qspi_common.base + sr) & (1 << 4)) == 0) {
 				break;
+			}
 
 			tempSz = qspi_rxData(rxBuff, rxSz);
 			rxSz -= tempSz;
 
-			if (rxBuff != NULL)
+			if (rxBuff != NULL) {
 				rxBuff += tempSz;
+			}
 		}
 	}
 
@@ -184,9 +194,15 @@ static int qspi_setPin(u32 pin)
 		return EOK;
 	}
 
+	if ((pin < mio_pin_01) && (pin > mio_pin_08)) {
+		return -EINVAL;
+	}
+
 	ctl.pin = pin;
 	ctl.l0 = 0x1;
-	ctl.l1 = ctl.l2 = ctl.l3 = 0;
+	ctl.l1 = 0;
+	ctl.l2 = 0;
+	ctl.l3 = 0;
 	ctl.pullup = 0;
 	ctl.speed = 0x1;
 	ctl.ioType = 0x1;
@@ -196,9 +212,6 @@ static int qspi_setPin(u32 pin)
 	if (pin == mio_pin_01) {
 		ctl.pullup = 1;
 		ctl.speed = 0x0;
-	}
-	else if (pin < mio_pin_01 && pin > mio_pin_08) {
-		return -EINVAL;
 	}
 
 	return _zynq_setMIO(&ctl);
@@ -276,7 +289,7 @@ static void qspi_IOMode(void)
 	/* Configure controller */
 
 	/* Set master mode, not Legacy mode */
-	*(qspi_common.base + cr) = 0x1 | (1 << 31);
+	*(qspi_common.base + cr) = 0x1 | (1u << 31);
 
 	/* Set baud rate to 100 MHz: 200 MHz / 2 */
 	*(qspi_common.base + cr) &= ~(0x7 << 3);
@@ -298,7 +311,7 @@ static void qspi_IOMode(void)
 
 	/* Loopback clock is used for high-speed read data capturing (>40MHz) */
 	if (QSPI_FCLK >= 0) {
-		*(qspi_common.base + lpbk) = *(qspi_common.base + lpbk) & ~0x3f;
+		*(qspi_common.base + lpbk) = (*(qspi_common.base + lpbk)) & ~0x3f;
 		*(qspi_common.base + lpbk) = (1 << 5);
 	}
 
@@ -323,12 +336,14 @@ int qspi_init(void)
 	qspi_common.base = (void *)0xe000d000;
 
 	res = _zynq_setAmbaClk(amba_lqspi_clk, clk_enable);
-	if (res < 0)
+	if (res < 0) {
 		return res;
+	}
 
 	res = qspi_initCtrlClk();
-	if (res < 0)
+	if (res < 0) {
 		return res;
+	}
 
 	qspi_setPin(QSPI_CS);
 	qspi_setPin(QSPI_IO0);

--- a/hal/armv7a/zynq7000/Makefile
+++ b/hal/armv7a/zynq7000/Makefile
@@ -17,7 +17,7 @@ CFLAGS += -DVADDR_KERNEL_INIT=$(VADDR_KERNEL_INIT)
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
 PLO_COMMANDS = alias app bitstream call console copy dump echo erase go help jffs2 kernel map mem \
-  phfs reboot script test-ddr wait
+  phfs reboot script test-ddr test-dev wait
 
 include devices/gpio-zynq7000/Makefile
 include devices/usbc-cdc/Makefile


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Initialize configuration registers on flash memories so that we send proper amount of dummy cycles for the frequency we operate at.
Add workaournd to bug in zynq hardware.
Rewrite qspi_polledTransfer to improve readability.
Switch to faster command for page program and read.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/406
- [ ] I will merge this PR by myself when appropriate.
