### PR TITLE
quick-fix: add support for tab character in ia32 tty-bios

### DIFF
--- a/cmds/cmd.c
+++ b/cmds/cmd.c
@@ -223,6 +223,10 @@ void cmd_prompt(void)
 				lib_printf("\n%s", PROMPT);
 				continue;
 			}
+			else if (c == '\t') {
+				/* skip */
+				continue;
+			}
 			else {
 				newline = 0;
 			}

--- a/devices/tty-bios/tty-bios.c
+++ b/devices/tty-bios/tty-bios.c
@@ -19,6 +19,11 @@
 #include <lib/errno.h>
 
 
+#ifndef TTYBIOS_TAB_WIDTH
+#define TTYBIOS_TAB_WIDTH 8u
+#endif
+
+
 /* ANSI escape sequence states */
 enum {
 	esc_init, /* normal */
@@ -246,6 +251,9 @@ static ssize_t ttybios_write(unsigned int minor, addr_t offs, const void *buff, 
 					}
 					break;
 
+				case '\t':
+					col += TTYBIOS_TAB_WIDTH - (col % TTYBIOS_TAB_WIDTH);
+					break;
 				case '\n':
 					row++;
 				case '\r':


### PR DESCRIPTION
The tty-bios (a.k.a. vga-console) was missing `\t` support.

Before:
![2023-08-23-140733_1346x461_scrot](https://github.com/phoenix-rtos/plo/assets/141153/0baa3869-5403-4eac-8a50-35f88778149c)

After (fixed):
![2023-08-23-140621_1405x460_scrot](https://github.com/phoenix-rtos/plo/assets/141153/791924d1-4406-43e9-ad7b-435c26628199)


JIRA: RTOS-568

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic (VGA).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
