### PR TITLE
imxrt: add mux selector in early console

### DIFF
--- a/hal/armv7m/imxrt/10xx/console.c
+++ b/hal/armv7m/imxrt/10xx/console.c
@@ -5,7 +5,7 @@
  *
  * Console
  *
- * Copyright 2021 Phoenix Systems
+ * Copyright 2021-2023 Phoenix Systems
  * Authors: Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
@@ -39,8 +39,34 @@ struct {
 } halconsole_common;
 
 
+/* clang-format off */
+
 enum { uart_verid = 0, uart_param, uart_global, uart_pincfg, uart_baud, uart_stat, uart_ctrl,
-	   uart_data, uart_match, uart_modir, uart_fifo, uart_water };
+	uart_data, uart_match, uart_modir, uart_fifo, uart_water };
+
+/* clang-format on */
+
+
+static int console_muxVal(int mux)
+{
+	switch (mux) {
+		case pctl_mux_gpio_b1_12:
+		case pctl_mux_gpio_b1_13:
+			return 1;
+
+		case pctl_mux_gpio_b0_08:
+		case pctl_mux_gpio_b0_09:
+			return 3;
+
+		case pctl_mux_gpio_sd_b1_00:
+		case pctl_mux_gpio_sd_b1_01:
+			return 4;
+
+		default: break;
+	}
+
+	return 2;
+}
 
 
 void hal_consolePrint(const char *s)
@@ -62,11 +88,13 @@ void console_init(void)
 	_imxrt_ccmControlGate(CONSOLE_CLK(UART_CONSOLE_PLO), clk_state_run_wait);
 
 	/* tx */
-	_imxrt_setIOmux(CONSOLE_MUX(UART_CONSOLE_PLO, TX_PIN), 0, 2);
+	_imxrt_setIOmux(CONSOLE_MUX(UART_CONSOLE_PLO, TX_PIN), 0,
+		console_muxVal(CONSOLE_MUX(UART_CONSOLE_PLO, TX_PIN)));
 	_imxrt_setIOpad(CONSOLE_PAD(UART_CONSOLE_PLO, TX_PIN), 0, 0, 0, 1, 0, 2, 6, 0);
 
 	/* rx */
-	_imxrt_setIOmux(CONSOLE_MUX(UART_CONSOLE_PLO, RX_PIN), 0, 2);
+	_imxrt_setIOmux(CONSOLE_MUX(UART_CONSOLE_PLO, RX_PIN), 0,
+		console_muxVal(CONSOLE_MUX(UART_CONSOLE_PLO, RX_PIN)));
 	_imxrt_setIOpad(CONSOLE_PAD(UART_CONSOLE_PLO, RX_PIN), 0, 0, 0, 1, 0, 2, 6, 0);
 
 #if (UART_CONSOLE_PLO >= 2) && (UART_CONSOLE_PLO <= 8)

--- a/hal/armv7m/imxrt/117x/console.c
+++ b/hal/armv7m/imxrt/117x/console.c
@@ -5,7 +5,7 @@
  *
  * Console
  *
- * Copyright 2021 Phoenix Systems
+ * Copyright 2021-2023 Phoenix Systems
  * Authors: Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
@@ -39,8 +39,98 @@ struct {
 } halconsole_common;
 
 
+/* clang-format off */
+
 enum { uart_verid = 0, uart_param, uart_global, uart_pincfg, uart_baud, uart_stat, uart_ctrl,
-	   uart_data, uart_match, uart_modir, uart_fifo, uart_water };
+	uart_data, uart_match, uart_modir, uart_fifo, uart_water };
+
+/* clang-format on */
+
+
+static int console_muxVal(int uart, int mux)
+{
+	switch (mux) {
+		case pctl_mux_gpio_ad_24:
+		case pctl_mux_gpio_ad_25:
+		case pctl_mux_gpio_ad_26:
+		case pctl_mux_gpio_ad_27:
+		case pctl_mux_gpio_lpsr_08:
+		case pctl_mux_gpio_lpsr_09:
+			return 0;
+
+		case pctl_mux_gpio_ad_02:
+		case pctl_mux_gpio_ad_03:
+			return (uart == 6) ? 1 : 6;
+
+		case pctl_mux_gpio_ad_04:
+		case pctl_mux_gpio_ad_05:
+		case pctl_mux_gpio_ad_15:
+		case pctl_mux_gpio_ad_16:
+		case pctl_mux_gpio_ad_28:
+		case pctl_mux_gpio_ad_29:
+			return 1;
+
+		case pctl_mux_gpio_disp_b1_04:
+		case pctl_mux_gpio_disp_b1_05:
+		case pctl_mux_gpio_disp_b1_06:
+		case pctl_mux_gpio_disp_b1_07:
+		case pctl_mux_gpio_disp_b2_06:
+		case pctl_mux_gpio_disp_b2_07:
+		case pctl_mux_gpio_disp_b2_10:
+		case pctl_mux_gpio_disp_b2_11:
+			return 2;
+
+		case pctl_mux_gpio_disp_b2_08:
+		case pctl_mux_gpio_disp_b2_09:
+			return (uart == 0) ? 9 : 2;
+
+		case pctl_mux_gpio_disp_b2_12:
+		case pctl_mux_gpio_disp_b2_13:
+		case pctl_mux_gpio_sd_b2_00:
+		case pctl_mux_gpio_sd_b2_01:
+		case pctl_mux_gpio_sd_b2_02:
+		case pctl_mux_gpio_sd_b2_03:
+		case pctl_mux_gpio_sd_b2_07:
+		case pctl_mux_gpio_sd_b2_08:
+		case pctl_mux_gpio_sd_b2_09:
+		case pctl_mux_gpio_sd_b2_10:
+		case pctl_mux_gpio_emc_b1_40:
+		case pctl_mux_gpio_emc_b1_41:
+		case pctl_mux_gpio_emc_b2_00:
+		case pctl_mux_gpio_emc_b2_01:
+		case pctl_mux_gpio_lpsr_06:
+		case pctl_mux_gpio_lpsr_07:
+			return 3;
+
+		case pctl_mux_gpio_ad_30:
+		case pctl_mux_gpio_ad_31:
+			return 4;
+
+		case pctl_mux_gpio_ad_00:
+		case pctl_mux_gpio_ad_01:
+		case pctl_mux_gpio_lpsr_00:
+		case pctl_mux_gpio_lpsr_01:
+		case pctl_mux_gpio_lpsr_04:
+		case pctl_mux_gpio_lpsr_05:
+			return 6;
+
+		case pctl_mux_gpio_ad_32:
+		case pctl_mux_gpio_ad_33:
+		case pctl_mux_gpio_ad_34:
+		case pctl_mux_gpio_ad_35:
+		case pctl_mux_gpio_lpsr_10:
+		case pctl_mux_gpio_lpsr_11:
+			return 8;
+
+		case pctl_mux_gpio_disp_b1_02:
+		case pctl_mux_gpio_disp_b1_03:
+			return 9;
+
+		default: break;
+	}
+
+	return 2;
+}
 
 
 void hal_consolePrint(const char *s)
@@ -62,11 +152,13 @@ void console_init(void)
 	_imxrt_setDevClock(CONSOLE_CLK(UART_CONSOLE_PLO), 0, 0, 0, 0, 1);
 
 	/* tx */
-	_imxrt_setIOmux(CONSOLE_MUX(UART_CONSOLE_PLO, TX_PIN), 0, 0);
+	_imxrt_setIOmux(CONSOLE_MUX(UART_CONSOLE_PLO, TX_PIN), 0,
+		console_muxVal((UART_CONSOLE_PLO) - 1, CONSOLE_MUX(UART_CONSOLE_PLO, TX_PIN)));
 	_imxrt_setIOpad(CONSOLE_PAD(UART_CONSOLE_PLO, TX_PIN), 0, 0, 0, 0, 0, 0);
 
 	/* rx */
-	_imxrt_setIOmux(CONSOLE_MUX(UART_CONSOLE_PLO, RX_PIN), 0, 0);
+	_imxrt_setIOmux(CONSOLE_MUX(UART_CONSOLE_PLO, RX_PIN), 0,
+		console_muxVal((UART_CONSOLE_PLO) - 1, CONSOLE_MUX(UART_CONSOLE_PLO, RX_PIN)));
 	_imxrt_setIOpad(CONSOLE_PAD(UART_CONSOLE_PLO, RX_PIN), 0, 0, 1, 1, 0, 0);
 
 #if (UART_CONSOLE_PLO == 1) || (UART_CONSOLE_PLO == 12)


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

This change adds an ALTMODE selector depending on the TX_PIN & RX_PIN mux provided in the board config.

JIRA: NIL-459

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-nil`, `imxrt1064-evk`, `imxrt1052-evk(a)`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
