### PR TITLE
imxrt117x: add functions to control gpio

### DIFF
--- a/hal/armv7m/imxrt/117x/imxrt.h
+++ b/hal/armv7m/imxrt/117x/imxrt.h
@@ -22,6 +22,11 @@
 #include "../types.h"
 
 
+/* clang-format off */
+
+enum { gpio1 = 0, gpio2, gpio3, gpio4, gpio5, gpio6, gpio7, gpio8, gpio9, gpio10, gpio11, gpio12, gpio13 };
+
+
 /* CCM - Root Clocks */
 enum { pctl_clk_cm7 = 0, pctl_clk_cm4, pctl_clk_bus, pctl_clk_bus_lpsr, pctl_clk_semc, pctl_clk_cssys,
 	pctl_clk_cstrace, pctl_clk_m4_systick, pctl_clk_m7_systick, pctl_clk_adc1, pctl_clk_adc2, pctl_clk_acmp,
@@ -315,6 +320,8 @@ enum { cti0_err_irq = 17 + 16, cti1_err_irq, core_irq, lpuart1_irq, lpuart2_irq,
 	xecc_flexspi1_fatal_irq, xecc_flexspi2_irq, xecc_flexspi2_fatal_irq, xecc_semc_irq, xecc_semc_fatal_irq, enet_qos_irq,
 	enet_pmt_irq };
 
+/* clang-format on */
+
 
 extern int _imxrt_setIOmux(int mux, char sion, char mode);
 
@@ -323,6 +330,21 @@ extern int _imxrt_setIOpad(int pad, char sre, char dse, char pue, char pus, char
 
 
 extern int _imxrt_setIOisel(int isel, char daisy);
+
+
+extern int _imxrt_gpioConfig(unsigned int d, u8 pin, u8 dir);
+
+
+extern int _imxrt_gpioSet(unsigned int d, u8 pin, u8 val);
+
+
+extern int _imxrt_gpioSetPort(unsigned int d, u32 val);
+
+
+extern int _imxrt_gpioGet(unsigned int d, u8 pin, u8 *val);
+
+
+extern int _imxrt_gpioGetPort(unsigned int d, u32 *val);
 
 
 extern int _imxrt_getDevClock(int clock, int *div, int *mux, int *mfd, int *mfn, int *state);


### PR DESCRIPTION
Adds functions, similar to imxrt10xx API, which allow to configure, gpio direction and control gpio: get, set, clear gpio value, either single bit or whole register.

The goal is abbility to provide project `plo_custom.c`, e.g:

```C
#include "imxrt.h"

void hal_customInit(void)
{
    /* deassert /RESET of other device */
    _imxrt_setIOmux(pctl_mux_gpio_sd_b1_00, 0, 10);
    _imxrt_setIOpad(pctl_pad_gpio_sd_b1_00, 0, 0, 0, 0, 0, 0);
    _imxrt_gpioConfig(gpio10, 3, 1);
    _imxrt_gpioSet(gpio10, 3, 0);
}
```

JIRA: NIL-460

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-nil`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
