### PR TITLE
flash-imxrt: rewrite opRead and opWrite

### DIFF
--- a/devices/flash-imxrt/fspi/fspi.c
+++ b/devices/flash-imxrt/fspi/fspi.c
@@ -307,118 +307,78 @@ __attribute__((section(".noxip"))) static int flexspi_checkFlags(flexspi_t *fspi
 __attribute__((section(".noxip"))) static ssize_t flexspi_opRead(flexspi_t *fspi, time_t start, struct xferOp *xfer)
 {
 	int res;
-	size_t ofs, len = xfer->data.read.sz, size = xfer->data.read.sz & ~7;
-	u8 *buf = xfer->data.read.ptr;
+	u8 *ptr = xfer->data.read.ptr;
+	u8 *end = ptr + xfer->data.read.sz;
 
-	/* note: FlexSPI FIFO watermark level is 64bit aligned */
-	for (ofs = 0; ofs < size; ofs += 8, buf += 8, len -= 8) {
+	while (ptr != end) {
+		volatile u8 *rfdr = (volatile u8 *)(fspi->base + rfdr32); /* 2x */
+
 		/* Wait for rx FIFO available */
-		while ((*(fspi->base + intr) & (1 << 5)) == 0) {
+		while ((*(fspi->base + intr) & (1u << 5u)) == 0u) {
 			res = flexspi_checkFlags(fspi);
 			if (res != EOK) {
 				return res;
 			}
-			else if (xfer->timeout > 0 && (hal_timerGet() - start) >= xfer->timeout) {
+			else if ((xfer->timeout > 0uLL) && ((hal_timerGet() - start) >= xfer->timeout)) {
 				return -ETIME;
 			}
 		}
 
-		((u32 *)buf)[0] = (fspi->base + rfdr32)[0];
-		((u32 *)buf)[1] = (fspi->base + rfdr32)[1];
-
-		/* Move FIFO pointer to watermark level */
-		*(fspi->base + intr) |= 1 << 5;
-	}
-
-	if (ofs < xfer->data.read.sz) {
-		/* Wait for rx FIFO available */
-		while ((*(fspi->base + intr) & (1 << 5)) == 0) {
-			res = flexspi_checkFlags(fspi);
-			if (res != EOK) {
-				return res;
-			}
-			else if (xfer->timeout > 0 && (hal_timerGet() - start) >= xfer->timeout) {
-				return -ETIME;
-			}
+		/* FlexSPI FIFO watermark level is 64bit aligned */
+		for (size_t n = sizeof(u64); (n != 0u) && (ptr != end); --n) {
+			*(ptr++) = *(rfdr++);
 		}
 
-		for (ofs = rfdr32; len > 0; ++ofs) {
-			u32 tmp = *(fspi->base + ofs); /* is volatile! */
-			size = len < sizeof(tmp) ? len : sizeof(tmp);
-			hal_memcpy(buf, &tmp, size);
-			len -= size;
-			buf += size;
-		}
 		/* Move FIFO pointer to watermark level */
-		*(fspi->base + intr) |= 1 << 5;
+		*(fspi->base + intr) |= 1u << 5u;
 	}
 
-	/* FIXME: delay of ~27us */
-	for (u32 i = 0x10000; i > 0; --i) {
-		asm volatile("nop");
+	while ((*(fspi->base + sts0) & 3u) != 3u) {
+		if (xfer->timeout > 0uLL && (hal_timerGet() - start) >= xfer->timeout) {
+			return -ETIME;
+		}
 	}
 
-	/* Reset rx FIFO */
-	*(fspi->base + iprxfcr) |= 1;
-
-	return buf - (u8 *)xfer->data.read.ptr;
+	return xfer->data.read.sz;
 }
 
 
 __attribute__((section(".noxip"))) static ssize_t flexspi_opWrite(flexspi_t *fspi, time_t start, struct xferOp *xfer)
 {
 	int res;
-	size_t ofs, len = xfer->data.write.sz, size = xfer->data.write.sz & ~7;
-	const u8 *buf = xfer->data.write.ptr;
+	const u8 *ptr = xfer->data.write.ptr;
+	const u8 *end = ptr + xfer->data.write.sz;
 
-	/* note: FlexSPI FIFO watermark level is 64bit aligned */
-	for (ofs = 0; ofs < size; ofs += 8, buf += 8, len -= 8) {
+	while (ptr != end) {
+		volatile u8 *tfdr = (volatile u8 *)(fspi->base + tfdr32); /* 2x */
+
 		/* Wait for tx FIFO available */
-		while ((*(fspi->base + intr) & (1 << 6)) == 0) {
+		while ((*(fspi->base + intr) & (1u << 6u)) == 0u) {
 			res = flexspi_checkFlags(fspi);
 			if (res != EOK) {
 				return res;
 			}
-			else if (xfer->timeout > 0 && (hal_timerGet() - start) >= xfer->timeout) {
+			else if ((xfer->timeout > 0uLL) && ((hal_timerGet() - start) >= xfer->timeout)) {
 				return -ETIME;
 			}
 		}
 
-		(fspi->base + tfdr32)[0] = ((u32 *)buf)[0];
-		(fspi->base + tfdr32)[1] = ((u32 *)buf)[1];
+		/* FlexSPI FIFO watermark level is 64bit aligned */
+		for (size_t n = sizeof(u64); (n != 0u) && (ptr != end); --n) {
+			*(tfdr++) = *(ptr++);
+		}
 
 		/* Move tx FIFO pointer to watermark level */
-		*(fspi->base + intr) |= 1 << 6;
+		*(fspi->base + intr) |= 1u << 6u;
 	}
 
-	if (ofs < xfer->data.write.sz) {
-		/* Wait for tx FIFO available */
-		while ((*(fspi->base + intr) & (1 << 6)) == 0) {
-			res = flexspi_checkFlags(fspi);
-			if (res != EOK) {
-				return res;
-			}
-			else if (xfer->timeout > 0 && (hal_timerGet() - start) >= xfer->timeout) {
-				return -ETIME;
-			}
+	while ((*(fspi->base + sts0) & 3u) != 3u) {
+		if (xfer->timeout > 0uLL && (hal_timerGet() - start) >= xfer->timeout) {
+			return -ETIME;
 		}
-
-		for (ofs = tfdr32; len > 0; ++ofs) {
-			u32 tmp;
-			size = len < sizeof(tmp) ? len : sizeof(tmp);
-			hal_memcpy(&tmp, buf, size);
-			*(fspi->base + ofs) = tmp;
-			len -= size;
-			buf += size;
-		}
-		/* Move FIFO pointer to watermark level */
-		*(fspi->base + intr) |= 1 << 6;
 	}
 
-	/* Reset tx FIFO */
-	*(fspi->base + iptxfcr) |= 1;
-
-	return buf - (u8 *)xfer->data.write.ptr;
+	return xfer->data.write.sz;
 }
 
 
@@ -456,8 +416,8 @@ __attribute__((section(".noxip"))) ssize_t flexspi_xferExec(flexspi_t *fspi, str
 	}
 
 	/* Wait for either AHB & IP bus ready or sequence controller to be idle */
-	while (((*(fspi->base + sts0) & 3) ^ 3) != 0) {
-		if (xfer->timeout > 0 && (hal_timerGet() - start) >= xfer->timeout) {
+	while ((*(fspi->base + sts0) & 3u) != 3u) {
+		if (xfer->timeout > 0uLL && (hal_timerGet() - start) >= xfer->timeout) {
 			return -ETIME;
 		}
 	}
@@ -471,9 +431,9 @@ __attribute__((section(".noxip"))) ssize_t flexspi_xferExec(flexspi_t *fspi, str
 	/* Set device's start address of transfer */
 	*(fspi->base + ipcr0) = dataAddr;
 
-	/* Reset tx/rx FIFOs, no DMA */
-	*(fspi->base + iptxfcr) = (*(fspi->base + iptxfcr) & ~3) | 1;
-	*(fspi->base + iprxfcr) = (*(fspi->base + iprxfcr) & ~3) | 1;
+	/* Clear tx/rx FIFOs */
+	*(fspi->base + iptxfcr) |= 1u;
+	*(fspi->base + iprxfcr) |= 1u;
 
 	/* Configure sequence index[number] and set xfer data size using "individual" mode */
 	*(fspi->base + ipcr1) = dataSize | ((xfer->seqIdx & 0xf) << 16) | ((xfer->seqNum & 0x7) << 24);


### PR DESCRIPTION
The purpose of this PR:
* reduce the size of functions relocated to the itcm memory
* eliminate the problem of byte by byte reading (when a plo is reading its scripts) and the destination address is not necessarily aligned to 32 bits (tfdr and rfdr size). Reading and writing from/to memory is performed in 64bit chunks, which results from the alignment of watermark indicator.

JIRA: RTOS-605

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Trying to fix https://github.com/phoenix-rtos/phoenix-rtos-project/issues/773

Since the problem appears once every few hundred launches, it is necessary to run a dedicated testing campaign on rt1064 to check whether the bug has been fixed by this PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-nil`, `imxrt1064-evk`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
