### PR TITLE
imxrt117x: implement clock root tree

### DIFF
--- a/hal/armv7m/imxrt/117x/imxrt.c
+++ b/hal/armv7m/imxrt/117x/imxrt.c
@@ -243,7 +243,7 @@ int _imxrt_gpioConfig(unsigned int d, u8 pin, u8 dir)
 		return -1;
 	}
 
-	clr = *(reg + gpio_gdir) & ~(1u << pin);
+	clr = *(reg + gpio_gdir) & ~(1uL << pin);
 	dir = (dir != 0u) ? 1u : 0u;
 	*(reg + gpio_gdir) = clr | (dir << pin);
 
@@ -260,7 +260,7 @@ int _imxrt_gpioSet(unsigned int d, u8 pin, u8 val)
 		return -1;
 	}
 
-	clr = *(reg + gpio_dr) & ~(1u << pin);
+	clr = *(reg + gpio_dr) & ~(1uL << pin);
 	val = (val != 0u) ? 1u : 0u;
 	*(reg + gpio_dr) = clr | (val << pin);
 
@@ -290,7 +290,7 @@ int _imxrt_gpioGet(unsigned int d, u8 pin, u8 *val)
 		return -1;
 	}
 
-	*val = ((*(reg + gpio_psr) & (1u << pin)) != 0u) ? 1u : 0u;
+	*val = ((*(reg + gpio_psr) & (1uL << pin)) != 0u) ? 1u : 0u;
 
 	return 0;
 }
@@ -405,11 +405,11 @@ int _imxrt_setVtorCM4(int dwpLock, int dwp, addr_t vtor)
 	tmp |= *(imxrt_common.iomuxc_lpsr_gpr + 1u);
 
 	/* is DWP locked or CM7 forbidden ? */
-	if ((tmp & (0xdu << 28)) != 0u) {
+	if ((tmp & (0xduL << 28u)) != 0u) {
 		return -1;
 	}
 
-	tmp = ((((u32)dwpLock & 3u) << 30) | (((u32)dwp & 3u) << 28));
+	tmp = ((((u32)dwpLock & 3u) << 30u) | (((u32)dwp & 3u) << 28u));
 
 	*(imxrt_common.iomuxc_lpsr_gpr + 0u) = (tmp | (vtor & 0xfff8u));
 	*(imxrt_common.iomuxc_lpsr_gpr + 1u) = (tmp | ((vtor >> 16) & 0xffffu));
@@ -425,7 +425,7 @@ int _imxrt_setVtorCM4(int dwpLock, int dwp, addr_t vtor)
 void _imxrt_runCM4(void)
 {
 	/* CM7 is allowed to reset system, CM4 is disallowed */
-	*(imxrt_common.src + src_srmr) |= ((3u << 10) | (3u << 6));
+	*(imxrt_common.src + src_srmr) |= ((3uL << 10u) | (3uL << 6u));
 	hal_cpuDataMemoryBarrier();
 
 	/* Release CM4 reset */

--- a/hal/armv7m/imxrt/117x/imxrt.h
+++ b/hal/armv7m/imxrt/117x/imxrt.h
@@ -28,7 +28,7 @@ enum { gpio1 = 0, gpio2, gpio3, gpio4, gpio5, gpio6, gpio7, gpio8, gpio9, gpio10
 
 
 /* CCM - Root Clocks */
-enum { pctl_clk_cm7 = 0, pctl_clk_cm4, pctl_clk_bus, pctl_clk_bus_lpsr, pctl_clk_semc, pctl_clk_cssys,
+enum { pctl_clk_m7 = 0, pctl_clk_m4, pctl_clk_bus, pctl_clk_bus_lpsr, pctl_clk_semc, pctl_clk_cssys,
 	pctl_clk_cstrace, pctl_clk_m4_systick, pctl_clk_m7_systick, pctl_clk_adc1, pctl_clk_adc2, pctl_clk_acmp,
 	pctl_clk_flexio1, pctl_clk_flexio2, pctl_clk_gpt1, pctl_clk_gpt2, pctl_clk_gpt3, pctl_clk_gpt4, pctl_clk_gpt5,
 	pctl_clk_gpt6, pctl_clk_flexspi1, pctl_clk_flexspi2, pctl_clk_can1, pctl_clk_can2, pctl_clk_can3, pctl_clk_lpuart1,
@@ -36,11 +36,11 @@ enum { pctl_clk_cm7 = 0, pctl_clk_cm4, pctl_clk_bus, pctl_clk_bus_lpsr, pctl_clk
 	pctl_clk_lpuart8, pctl_clk_lpuart9, pctl_clk_lpuart10, pctl_clk_lpuart11, pctl_clk_lpuart12, pctl_clk_lpi2c1,
 	pctl_clk_lpi2c2, pctl_clk_lpi2c3, pctl_clk_lpi2c4, pctl_clk_lpi2c5, pctl_clk_lpi2c6, pctl_clk_lpspi1, pctl_clk_lpspi2,
 	pctl_clk_lpspi3, pctl_clk_lpspi4, pctl_clk_lpspi5, pctl_clk_lpspi6, pctl_clk_emv1, pctl_clk_emv2, pctl_clk_enet1,
-	pctl_clk_enet2, pctl_clk_enet_qos, pctl_clk_enet_25m, pctl_clk_enet_time1, pctl_clk_enet_time2, pctl_clk_enet_time3,
-	pctl_clk_usdhc1, pctl_clk_usdhc2, pctl_clk_asrc, pctl_clk_mqs, pctl_clk_pdm, pctl_clk_spdif, pctl_clk_sai1,
-	pctl_clk_sai2, pctl_clk_sai3, pctl_clk_sai4, pctl_clk_gpu2d, pctl_clk_elcdif, pctl_clk_lcdifv2, pctl_clk_mipi_ref,
-	pctl_clk_mipi_esc, pctl_clk_csi2, pctl_clk_csi2_esc, pctl_clk_csi2_ui, pctl_clk_csi, pctl_clk_ccm_clko1,
-	pctl_clk_ccm_clko2 };
+	pctl_clk_enet2, pctl_clk_enet_qos, pctl_clk_enet_25m, pctl_clk_enet_timer1, pctl_clk_enet_timer2, pctl_clk_enet_timer3,
+	pctl_clk_usdhc1, pctl_clk_usdhc2, pctl_clk_asrc, pctl_clk_mqs, pctl_clk_mic, pctl_clk_spdif, pctl_clk_sai1,
+	pctl_clk_sai2, pctl_clk_sai3, pctl_clk_sai4, pctl_clk_gpu2d, pctl_clk_lcdif, pctl_clk_lcdifv2, pctl_clk_mipi_ref,
+	pctl_clk_mipi_esc, pctl_clk_csi2, pctl_clk_csi2_esc, pctl_clk_csi2_ui, pctl_clk_csi, pctl_clk_clko1,
+	pctl_clk_clko2 };
 
 
 /* CCM - Low Power Clock Gates */
@@ -320,6 +320,328 @@ enum { cti0_err_irq = 17 + 16, cti1_err_irq, core_irq, lpuart1_irq, lpuart2_irq,
 	xecc_flexspi1_fatal_irq, xecc_flexspi2_irq, xecc_flexspi2_fatal_irq, xecc_semc_irq, xecc_semc_fatal_irq, enet_qos_irq,
 	enet_pmt_irq };
 
+
+/* Mux selector: M7 */
+enum { mux_clkroot_m7_oscrc48mdiv2 = 0, mux_clkroot_m7_osc24mout, mux_clkroot_m7_oscrc400m, mux_clkroot_m7_oscrc16m,
+	mux_clkroot_m7_armpllout, mux_clkroot_m7_syspll1out, mux_clkroot_m7_syspll3out, mux_clkroot_m7_videopllout };
+
+/* Mux selector: M4 */
+enum { mux_clkroot_m4_oscrc48mdiv2 = 0, mux_clkroot_m4_osc24mout, mux_clkroot_m4_oscrc400m, mux_clkroot_m4_oscrc16m,
+	mux_clkroot_m4_syspll3pfd3, mux_clkroot_m4_syspll3out, mux_clkroot_m4_syspll2out, mux_clkroot_m4_syspll1div5 };
+
+/* Mux selector: BUS */
+enum { mux_clkroot_bus_oscrc48mdiv2 = 0, mux_clkroot_bus_osc24mout, mux_clkroot_bus_oscrc400m, mux_clkroot_bus_oscrc16m,
+	mux_clkroot_bus_syspll3out, mux_clkroot_bus_syspll1div5, mux_clkroot_bus_syspll2out, mux_clkroot_bus_syspll2pfd3 };
+
+/* Mux selector: BUS_LPSR */
+enum { mux_clkroot_bus_lpsr_oscrc48mdiv2 = 0, mux_clkroot_bus_lpsr_osc24mout, mux_clkroot_bus_lpsr_oscrc400m, mux_clkroot_bus_lpsr_oscrc16m,
+	mux_clkroot_bus_lpsr_syspll3pfd3, mux_clkroot_bus_lpsr_syspll3out, mux_clkroot_bus_lpsr_syspll2out, mux_clkroot_bus_lpsr_syspll1div5 };
+
+/* Mux selector: SEMC */
+enum { mux_clkroot_semc_oscrc48mdiv2 = 0, mux_clkroot_semc_osc24mout, mux_clkroot_semc_oscrc400m, mux_clkroot_semc_oscrc16m,
+	mux_clkroot_semc_syspll1div5, mux_clkroot_semc_syspll2out, mux_clkroot_semc_syspll2pfd1, mux_clkroot_semc_syspll3pfd0 };
+
+/* Mux selector: CSSYS */
+enum { mux_clkroot_cssys_oscrc48mdiv2 = 0, mux_clkroot_cssys_osc24mout, mux_clkroot_cssys_oscrc400m, mux_clkroot_cssys_oscrc16m,
+	mux_clkroot_cssys_syspll3div2, mux_clkroot_cssys_syspll1div5, mux_clkroot_cssys_syspll2out, mux_clkroot_cssys_syspll2pfd3 };
+
+/* Mux selector: CSTRACE */
+enum { mux_clkroot_cstrace_oscrc48mdiv2 = 0, mux_clkroot_cstrace_osc24mout, mux_clkroot_cstrace_oscrc400m, mux_clkroot_cstrace_oscrc16m,
+	mux_clkroot_cstrace_syspll3div2, mux_clkroot_cstrace_syspll1div5, mux_clkroot_cstrace_syspll2pfd1, mux_clkroot_cstrace_syspll2out };
+
+/* Mux selector: M4_SYSTICK */
+enum { mux_clkroot_m4_systick_oscrc48mdiv2 = 0, mux_clkroot_m4_systick_osc24mout, mux_clkroot_m4_systick_oscrc400m, mux_clkroot_m4_systick_oscrc16m,
+	mux_clkroot_m4_systick_syspll3pfd3, mux_clkroot_m4_systick_syspll3out, mux_clkroot_m4_systick_syspll2pfd0, mux_clkroot_m4_systick_syspll1div5 };
+
+/* Mux selector: M7_SYSTICK */
+enum { mux_clkroot_m7_systick_oscrc48mdiv2 = 0, mux_clkroot_m7_systick_osc24mout, mux_clkroot_m7_systick_oscrc400m, mux_clkroot_m7_systick_oscrc16m,
+	mux_clkroot_m7_systick_syspll2out, mux_clkroot_m7_systick_syspll3div2, mux_clkroot_m7_systick_syspll1div5, mux_clkroot_m7_systick_syspll2pfd0 };
+
+/* Mux selector: ADC1 */
+enum { mux_clkroot_adc1_oscrc48mdiv2 = 0, mux_clkroot_adc1_osc24mout, mux_clkroot_adc1_oscrc400m, mux_clkroot_adc1_oscrc16m,
+	mux_clkroot_adc1_syspll3div2, mux_clkroot_adc1_syspll1div5, mux_clkroot_adc1_syspll2out, mux_clkroot_adc1_syspll2pfd3 };
+
+/* Mux selector: ADC2 */
+enum { mux_clkroot_adc2_oscrc48mdiv2 = 0, mux_clkroot_adc2_osc24mout, mux_clkroot_adc2_oscrc400m, mux_clkroot_adc2_oscrc16m,
+	mux_clkroot_adc2_syspll3div2, mux_clkroot_adc2_syspll1div5, mux_clkroot_adc2_syspll2out, mux_clkroot_adc2_syspll2pfd3 };
+
+/* Mux selector: ACMP */
+enum { mux_clkroot_acmp_oscrc48mdiv2 = 0, mux_clkroot_acmp_osc24mout, mux_clkroot_acmp_oscrc400m, mux_clkroot_acmp_oscrc16m,
+	mux_clkroot_acmp_syspll3out, mux_clkroot_acmp_syspll1div5, mux_clkroot_acmp_audiopllout, mux_clkroot_acmp_syspll2pfd3 };
+
+/* Mux selector: FLEXIO1 */
+enum { mux_clkroot_flexio1_oscrc48mdiv2 = 0, mux_clkroot_flexio1_osc24mout, mux_clkroot_flexio1_oscrc400m, mux_clkroot_flexio1_oscrc16m,
+	mux_clkroot_flexio1_syspll3div2, mux_clkroot_flexio1_syspll1div5, mux_clkroot_flexio1_syspll2out, mux_clkroot_flexio1_syspll2pfd3 };
+
+/* Mux selector: FLEXIO2 */
+enum { mux_clkroot_flexio2_oscrc48mdiv2 = 0, mux_clkroot_flexio2_osc24mout, mux_clkroot_flexio2_oscrc400m, mux_clkroot_flexio2_oscrc16m,
+	mux_clkroot_flexio2_syspll3div2, mux_clkroot_flexio2_syspll1div5, mux_clkroot_flexio2_syspll2out, mux_clkroot_flexio2_syspll2pfd3 };
+
+/* Mux selector: GPT1 */
+enum { mux_clkroot_gpt1_oscrc48mdiv2 = 0, mux_clkroot_gpt1_osc24mout, mux_clkroot_gpt1_oscrc400m, mux_clkroot_gpt1_oscrc16m,
+	mux_clkroot_gpt1_syspll3div2, mux_clkroot_gpt1_syspll1div5, mux_clkroot_gpt1_syspll3pfd2, mux_clkroot_gpt1_syspll3pfd3 };
+
+/* Mux selector: GPT2 */
+enum { mux_clkroot_gpt2_oscrc48mdiv2 = 0, mux_clkroot_gpt2_osc24mout, mux_clkroot_gpt2_oscrc400m, mux_clkroot_gpt2_oscrc16m,
+	mux_clkroot_gpt2_syspll3div2, mux_clkroot_gpt2_syspll1div5, mux_clkroot_gpt2_audiopllout, mux_clkroot_gpt2_videopllout };
+
+/* Mux selector: GPT3 */
+enum { mux_clkroot_gpt3_oscrc48mdiv2 = 0, mux_clkroot_gpt3_osc24mout, mux_clkroot_gpt3_oscrc400m, mux_clkroot_gpt3_oscrc16m,
+	mux_clkroot_gpt3_syspll3div2, mux_clkroot_gpt3_syspll1div5, mux_clkroot_gpt3_audiopllout, mux_clkroot_gpt3_videopllout };
+
+/* Mux selector: GPT4 */
+enum { mux_clkroot_gpt4_oscrc48mdiv2 = 0, mux_clkroot_gpt4_osc24mout, mux_clkroot_gpt4_oscrc400m, mux_clkroot_gpt4_oscrc16m,
+	mux_clkroot_gpt4_syspll3div2, mux_clkroot_gpt4_syspll1div5, mux_clkroot_gpt4_syspll3pfd2, mux_clkroot_gpt4_syspll3pfd3 };
+
+/* Mux selector: GPT5 */
+enum { mux_clkroot_gpt5_oscrc48mdiv2 = 0, mux_clkroot_gpt5_osc24mout, mux_clkroot_gpt5_oscrc400m, mux_clkroot_gpt5_oscrc16m,
+	mux_clkroot_gpt5_syspll3div2, mux_clkroot_gpt5_syspll1div5, mux_clkroot_gpt5_syspll3pfd2, mux_clkroot_gpt5_syspll3pfd3 };
+
+/* Mux selector: GPT6 */
+enum { mux_clkroot_gpt6_oscrc48mdiv2 = 0, mux_clkroot_gpt6_osc24mout, mux_clkroot_gpt6_oscrc400m, mux_clkroot_gpt6_oscrc16m,
+	mux_clkroot_gpt6_syspll3div2, mux_clkroot_gpt6_syspll1div5, mux_clkroot_gpt6_syspll3pfd2, mux_clkroot_gpt6_syspll3pfd3 };
+
+/* Mux selector: FLEXSPI1 */
+enum { mux_clkroot_flexspi1_oscrc48mdiv2 = 0, mux_clkroot_flexspi1_osc24mout, mux_clkroot_flexspi1_oscrc400m, mux_clkroot_flexspi1_oscrc16m,
+	mux_clkroot_flexspi1_syspll3pfd0, mux_clkroot_flexspi1_syspll2out, mux_clkroot_flexspi1_syspll2pfd2, mux_clkroot_flexspi1_syspll3out };
+
+/* Mux selector: FLEXSPI2 */
+enum { mux_clkroot_flexspi2_oscrc48mdiv2 = 0, mux_clkroot_flexspi2_osc24mout, mux_clkroot_flexspi2_oscrc400m, mux_clkroot_flexspi2_oscrc16m,
+	mux_clkroot_flexspi2_syspll3pfd0, mux_clkroot_flexspi2_syspll2out, mux_clkroot_flexspi2_syspll2pfd2, mux_clkroot_flexspi2_syspll3out };
+
+/* Mux selector: CAN1 */
+enum { mux_clkroot_can1_oscrc48mdiv2 = 0, mux_clkroot_can1_osc24mout, mux_clkroot_can1_oscrc400m, mux_clkroot_can1_oscrc16m,
+	mux_clkroot_can1_syspll3div2, mux_clkroot_can1_syspll1div5, mux_clkroot_can1_syspll2out, mux_clkroot_can1_syspll2pfd3 };
+
+/* Mux selector: CAN2 */
+enum { mux_clkroot_can2_oscrc48mdiv2 = 0, mux_clkroot_can2_osc24mout, mux_clkroot_can2_oscrc400m, mux_clkroot_can2_oscrc16m,
+	mux_clkroot_can2_syspll3div2, mux_clkroot_can2_syspll1div5, mux_clkroot_can2_syspll2out, mux_clkroot_can2_syspll2pfd3 };
+
+/* Mux selector: CAN3 */
+enum { mux_clkroot_can3_oscrc48mdiv2 = 0, mux_clkroot_can3_osc24mout, mux_clkroot_can3_oscrc400m, mux_clkroot_can3_oscrc16m,
+	mux_clkroot_can3_syspll3pfd3, mux_clkroot_can3_syspll3out, mux_clkroot_can3_syspll2pfd3, mux_clkroot_can3_syspll1div5 };
+
+/* Mux selector: LPUART1 */
+enum { mux_clkroot_lpuart1_oscrc48mdiv2 = 0, mux_clkroot_lpuart1_osc24mout, mux_clkroot_lpuart1_oscrc400m, mux_clkroot_lpuart1_oscrc16m,
+	mux_clkroot_lpuart1_syspll3div2, mux_clkroot_lpuart1_syspll1div5, mux_clkroot_lpuart1_syspll2out, mux_clkroot_lpuart1_syspll2pfd3 };
+
+/* Mux selector: LPUART2 */
+enum { mux_clkroot_lpuart2_oscrc48mdiv2 = 0, mux_clkroot_lpuart2_osc24mout, mux_clkroot_lpuart2_oscrc400m, mux_clkroot_lpuart2_oscrc16m,
+	mux_clkroot_lpuart2_syspll3div2, mux_clkroot_lpuart2_syspll1div5, mux_clkroot_lpuart2_syspll2out, mux_clkroot_lpuart2_syspll2pfd3 };
+
+/* Mux selector: LPUART3 */
+enum { mux_clkroot_lpuart3_oscrc48mdiv2 = 0, mux_clkroot_lpuart3_osc24mout, mux_clkroot_lpuart3_oscrc400m, mux_clkroot_lpuart3_oscrc16m,
+	mux_clkroot_lpuart3_syspll3div2, mux_clkroot_lpuart3_syspll1div5, mux_clkroot_lpuart3_syspll2out, mux_clkroot_lpuart3_syspll2pfd3 };
+
+/* Mux selector: LPUART4 */
+enum { mux_clkroot_lpuart4_oscrc48mdiv2 = 0, mux_clkroot_lpuart4_osc24mout, mux_clkroot_lpuart4_oscrc400m, mux_clkroot_lpuart4_oscrc16m,
+	mux_clkroot_lpuart4_syspll3div2, mux_clkroot_lpuart4_syspll1div5, mux_clkroot_lpuart4_syspll2out, mux_clkroot_lpuart4_syspll2pfd3 };
+
+/* Mux selector: LPUART5 */
+enum { mux_clkroot_lpuart5_oscrc48mdiv2 = 0, mux_clkroot_lpuart5_osc24mout, mux_clkroot_lpuart5_oscrc400m, mux_clkroot_lpuart5_oscrc16m,
+	mux_clkroot_lpuart5_syspll3div2, mux_clkroot_lpuart5_syspll1div5, mux_clkroot_lpuart5_syspll2out, mux_clkroot_lpuart5_syspll2pfd3 };
+
+/* Mux selector: LPUART6 */
+enum { mux_clkroot_lpuart6_oscrc48mdiv2 = 0, mux_clkroot_lpuart6_osc24mout, mux_clkroot_lpuart6_oscrc400m, mux_clkroot_lpuart6_oscrc16m,
+	mux_clkroot_lpuart6_syspll3div2, mux_clkroot_lpuart6_syspll1div5, mux_clkroot_lpuart6_syspll2out, mux_clkroot_lpuart6_syspll2pfd3 };
+
+/* Mux selector: LPUART7 */
+enum { mux_clkroot_lpuart7_oscrc48mdiv2 = 0, mux_clkroot_lpuart7_osc24mout, mux_clkroot_lpuart7_oscrc400m, mux_clkroot_lpuart7_oscrc16m,
+	mux_clkroot_lpuart7_syspll3div2, mux_clkroot_lpuart7_syspll1div5, mux_clkroot_lpuart7_syspll2out, mux_clkroot_lpuart7_syspll2pfd3 };
+
+/* Mux selector: LPUART8 */
+enum { mux_clkroot_lpuart8_oscrc48mdiv2 = 0, mux_clkroot_lpuart8_osc24mout, mux_clkroot_lpuart8_oscrc400m, mux_clkroot_lpuart8_oscrc16m,
+	mux_clkroot_lpuart8_syspll3div2, mux_clkroot_lpuart8_syspll1div5, mux_clkroot_lpuart8_syspll2out, mux_clkroot_lpuart8_syspll2pfd3 };
+
+/* Mux selector: LPUART9 */
+enum { mux_clkroot_lpuart9_oscrc48mdiv2 = 0, mux_clkroot_lpuart9_osc24mout, mux_clkroot_lpuart9_oscrc400m, mux_clkroot_lpuart9_oscrc16m,
+	mux_clkroot_lpuart9_syspll3div2, mux_clkroot_lpuart9_syspll1div5, mux_clkroot_lpuart9_syspll2out, mux_clkroot_lpuart9_syspll2pfd3 };
+
+/* Mux selector: LPUART10 */
+enum { mux_clkroot_lpuart10_oscrc48mdiv2 = 0, mux_clkroot_lpuart10_osc24mout, mux_clkroot_lpuart10_oscrc400m, mux_clkroot_lpuart10_oscrc16m,
+	mux_clkroot_lpuart10_syspll3div2, mux_clkroot_lpuart10_syspll1div5, mux_clkroot_lpuart10_syspll2out, mux_clkroot_lpuart10_syspll2pfd3 };
+
+/* Mux selector: LPUART11 */
+enum { mux_clkroot_lpuart11_oscrc48mdiv2 = 0, mux_clkroot_lpuart11_osc24mout, mux_clkroot_lpuart11_oscrc400m, mux_clkroot_lpuart11_oscrc16m,
+	mux_clkroot_lpuart11_syspll3pfd3, mux_clkroot_lpuart11_syspll3out, mux_clkroot_lpuart11_syspll2pfd3, mux_clkroot_lpuart11_syspll1div5 };
+
+/* Mux selector: LPUART12 */
+enum { mux_clkroot_lpuart12_oscrc48mdiv2 = 0, mux_clkroot_lpuart12_osc24mout, mux_clkroot_lpuart12_oscrc400m, mux_clkroot_lpuart12_oscrc16m,
+	mux_clkroot_lpuart12_syspll3pfd3, mux_clkroot_lpuart12_syspll3out, mux_clkroot_lpuart12_syspll2pfd3, mux_clkroot_lpuart12_syspll1div5 };
+
+/* Mux selector: LPI2C1 */
+enum { mux_clkroot_lpi2c1_oscrc48mdiv2 = 0, mux_clkroot_lpi2c1_osc24mout, mux_clkroot_lpi2c1_oscrc400m, mux_clkroot_lpi2c1_oscrc16m,
+	mux_clkroot_lpi2c1_syspll3div2, mux_clkroot_lpi2c1_syspll1div5, mux_clkroot_lpi2c1_syspll2out, mux_clkroot_lpi2c1_syspll2pfd3 };
+
+/* Mux selector: LPI2C2 */
+enum { mux_clkroot_lpi2c2_oscrc48mdiv2 = 0, mux_clkroot_lpi2c2_osc24mout, mux_clkroot_lpi2c2_oscrc400m, mux_clkroot_lpi2c2_oscrc16m,
+	mux_clkroot_lpi2c2_syspll3div2, mux_clkroot_lpi2c2_syspll1div5, mux_clkroot_lpi2c2_syspll2out, mux_clkroot_lpi2c2_syspll2pfd3 };
+
+/* Mux selector: LPI2C3 */
+enum { mux_clkroot_lpi2c3_oscrc48mdiv2 = 0, mux_clkroot_lpi2c3_osc24mout, mux_clkroot_lpi2c3_oscrc400m, mux_clkroot_lpi2c3_oscrc16m,
+	mux_clkroot_lpi2c3_syspll3div2, mux_clkroot_lpi2c3_syspll1div5, mux_clkroot_lpi2c3_syspll2out, mux_clkroot_lpi2c3_syspll2pfd3 };
+
+/* Mux selector: LPI2C4 */
+enum { mux_clkroot_lpi2c4_oscrc48mdiv2 = 0, mux_clkroot_lpi2c4_osc24mout, mux_clkroot_lpi2c4_oscrc400m, mux_clkroot_lpi2c4_oscrc16m,
+	mux_clkroot_lpi2c4_syspll3div2, mux_clkroot_lpi2c4_syspll1div5, mux_clkroot_lpi2c4_syspll2out, mux_clkroot_lpi2c4_syspll2pfd3 };
+
+/* Mux selector: LPI2C5 */
+enum { mux_clkroot_lpi2c5_oscrc48mdiv2 = 0, mux_clkroot_lpi2c5_osc24mout, mux_clkroot_lpi2c5_oscrc400m, mux_clkroot_lpi2c5_oscrc16m,
+	mux_clkroot_lpi2c5_syspll3pfd3, mux_clkroot_lpi2c5_syspll3out, mux_clkroot_lpi2c5_syspll2pfd3, mux_clkroot_lpi2c5_syspll1div5 };
+
+/* Mux selector: LPI2C6 */
+enum { mux_clkroot_lpi2c6_oscrc48mdiv2 = 0, mux_clkroot_lpi2c6_osc24mout, mux_clkroot_lpi2c6_oscrc400m, mux_clkroot_lpi2c6_oscrc16m,
+	mux_clkroot_lpi2c6_syspll3pfd3, mux_clkroot_lpi2c6_syspll3out, mux_clkroot_lpi2c6_syspll2pfd3, mux_clkroot_lpi2c6_syspll1div5 };
+
+/* Mux selector: LPSPI1 */
+enum { mux_clkroot_lpspi1_oscrc48mdiv2 = 0, mux_clkroot_lpspi1_osc24mout, mux_clkroot_lpspi1_oscrc400m, mux_clkroot_lpspi1_oscrc16m,
+	mux_clkroot_lpspi1_syspll3pfd2, mux_clkroot_lpspi1_syspll1div5, mux_clkroot_lpspi1_syspll2out, mux_clkroot_lpspi1_syspll2pfd3 };
+
+/* Mux selector: LPSPI2 */
+enum { mux_clkroot_lpspi2_oscrc48mdiv2 = 0, mux_clkroot_lpspi2_osc24mout, mux_clkroot_lpspi2_oscrc400m, mux_clkroot_lpspi2_oscrc16m,
+	mux_clkroot_lpspi2_syspll3pfd2, mux_clkroot_lpspi2_syspll1div5, mux_clkroot_lpspi2_syspll2out, mux_clkroot_lpspi2_syspll2pfd3 };
+
+/* Mux selector: LPSPI3 */
+enum { mux_clkroot_lpspi3_oscrc48mdiv2 = 0, mux_clkroot_lpspi3_osc24mout, mux_clkroot_lpspi3_oscrc400m, mux_clkroot_lpspi3_oscrc16m,
+	mux_clkroot_lpspi3_syspll3pfd2, mux_clkroot_lpspi3_syspll1div5, mux_clkroot_lpspi3_syspll2out, mux_clkroot_lpspi3_syspll2pfd3 };
+
+/* Mux selector: LPSPI4 */
+enum { mux_clkroot_lpspi4_oscrc48mdiv2 = 0, mux_clkroot_lpspi4_osc24mout, mux_clkroot_lpspi4_oscrc400m, mux_clkroot_lpspi4_oscrc16m,
+	mux_clkroot_lpspi4_syspll3pfd2, mux_clkroot_lpspi4_syspll1div5, mux_clkroot_lpspi4_syspll2out, mux_clkroot_lpspi4_syspll2pfd3 };
+
+/* Mux selector: LPSPI5 */
+enum { mux_clkroot_lpspi5_oscrc48mdiv2 = 0, mux_clkroot_lpspi5_osc24mout, mux_clkroot_lpspi5_oscrc400m, mux_clkroot_lpspi5_oscrc16m,
+	mux_clkroot_lpspi5_syspll3pfd3, mux_clkroot_lpspi5_syspll3out, mux_clkroot_lpspi5_syspll3pfd2, mux_clkroot_lpspi5_syspll1div5 };
+
+/* Mux selector: LPSPI6 */
+enum { mux_clkroot_lpspi6_oscrc48mdiv2 = 0, mux_clkroot_lpspi6_osc24mout, mux_clkroot_lpspi6_oscrc400m, mux_clkroot_lpspi6_oscrc16m,
+	mux_clkroot_lpspi6_syspll3pfd3, mux_clkroot_lpspi6_syspll3out, mux_clkroot_lpspi6_syspll3pfd2, mux_clkroot_lpspi6_syspll1div5 };
+
+/* Mux selector: EMV1 */
+enum { mux_clkroot_emv1_oscrc48mdiv2 = 0, mux_clkroot_emv1_osc24mout, mux_clkroot_emv1_oscrc400m, mux_clkroot_emv1_oscrc16m,
+	mux_clkroot_emv1_syspll3div2, mux_clkroot_emv1_syspll1div5, mux_clkroot_emv1_syspll2out, mux_clkroot_emv1_syspll2pfd3 };
+
+/* Mux selector: EMV2 */
+enum { mux_clkroot_emv2_oscrc48mdiv2 = 0, mux_clkroot_emv2_osc24mout, mux_clkroot_emv2_oscrc400m, mux_clkroot_emv2_oscrc16m,
+	mux_clkroot_emv2_syspll3div2, mux_clkroot_emv2_syspll1div5, mux_clkroot_emv2_syspll2out, mux_clkroot_emv2_syspll2pfd3 };
+
+/* Mux selector: ENET1 */
+enum { mux_clkroot_enet1_oscrc48mdiv2 = 0, mux_clkroot_enet1_osc24mout, mux_clkroot_enet1_oscrc400m, mux_clkroot_enet1_oscrc16m,
+	mux_clkroot_enet1_syspll1div2, mux_clkroot_enet1_audiopllout, mux_clkroot_enet1_syspll1div5, mux_clkroot_enet1_syspll2pfd1 };
+
+/* Mux selector: ENET2 */
+enum { mux_clkroot_enet2_oscrc48mdiv2 = 0, mux_clkroot_enet2_osc24mout, mux_clkroot_enet2_oscrc400m, mux_clkroot_enet2_oscrc16m,
+	mux_clkroot_enet2_syspll1div2, mux_clkroot_enet2_audiopllout, mux_clkroot_enet2_syspll1div5, mux_clkroot_enet2_syspll2pfd1 };
+
+/* Mux selector: ENET_QOS */
+enum { mux_clkroot_enet_qos_oscrc48mdiv2 = 0, mux_clkroot_enet_qos_osc24mout, mux_clkroot_enet_qos_oscrc400m, mux_clkroot_enet_qos_oscrc16m,
+	mux_clkroot_enet_qos_syspll1div2, mux_clkroot_enet_qos_audiopllout, mux_clkroot_enet_qos_syspll1div5, mux_clkroot_enet_qos_syspll2pfd1 };
+
+/* Mux selector: ENET_25M */
+enum { mux_clkroot_enet_25m_oscrc48mdiv2 = 0, mux_clkroot_enet_25m_osc24mout, mux_clkroot_enet_25m_oscrc400m, mux_clkroot_enet_25m_oscrc16m,
+	mux_clkroot_enet_25m_syspll1div2, mux_clkroot_enet_25m_audiopllout, mux_clkroot_enet_25m_syspll1div5, mux_clkroot_enet_25m_syspll2pfd1 };
+
+/* Mux selector: ENET_TIMER1 */
+enum { mux_clkroot_enet_timer1_oscrc48mdiv2 = 0, mux_clkroot_enet_timer1_osc24mout, mux_clkroot_enet_timer1_oscrc400m, mux_clkroot_enet_timer1_oscrc16m,
+	mux_clkroot_enet_timer1_syspll1div2, mux_clkroot_enet_timer1_audiopllout, mux_clkroot_enet_timer1_syspll1div5, mux_clkroot_enet_timer1_syspll2pfd1 };
+
+/* Mux selector: ENET_TIMER2 */
+enum { mux_clkroot_enet_timer2_oscrc48mdiv2 = 0, mux_clkroot_enet_timer2_osc24mout, mux_clkroot_enet_timer2_oscrc400m, mux_clkroot_enet_timer2_oscrc16m,
+	mux_clkroot_enet_timer2_syspll1div2, mux_clkroot_enet_timer2_audiopllout, mux_clkroot_enet_timer2_syspll1div5, mux_clkroot_enet_timer2_syspll2pfd1 };
+
+/* Mux selector: ENET_TIMER3 */
+enum { mux_clkroot_enet_timer3_oscrc48mdiv2 = 0, mux_clkroot_enet_timer3_osc24mout, mux_clkroot_enet_timer3_oscrc400m, mux_clkroot_enet_timer3_oscrc16m,
+	mux_clkroot_enet_timer3_syspll1div2, mux_clkroot_enet_timer3_audiopllout, mux_clkroot_enet_timer3_syspll1div5, mux_clkroot_enet_timer3_syspll2pfd1 };
+
+/* Mux selector: USDHC1 */
+enum { mux_clkroot_usdhc1_oscrc48mdiv2 = 0, mux_clkroot_usdhc1_osc24mout, mux_clkroot_usdhc1_oscrc400m, mux_clkroot_usdhc1_oscrc16m,
+	mux_clkroot_usdhc1_syspll2pfd2, mux_clkroot_usdhc1_syspll2pfd0, mux_clkroot_usdhc1_syspll1div5, mux_clkroot_usdhc1_armpllout };
+
+/* Mux selector: USDHC2 */
+enum { mux_clkroot_usdhc2_oscrc48mdiv2 = 0, mux_clkroot_usdhc2_osc24mout, mux_clkroot_usdhc2_oscrc400m, mux_clkroot_usdhc2_oscrc16m,
+	mux_clkroot_usdhc2_syspll2pfd2, mux_clkroot_usdhc2_syspll2pfd0, mux_clkroot_usdhc2_syspll1div5, mux_clkroot_usdhc2_armpllout };
+
+/* Mux selector: ASRC */
+enum { mux_clkroot_asrc_oscrc48mdiv2 = 0, mux_clkroot_asrc_osc24mout, mux_clkroot_asrc_oscrc400m, mux_clkroot_asrc_oscrc16m,
+	mux_clkroot_asrc_syspll1div5, mux_clkroot_asrc_syspll3div2, mux_clkroot_asrc_audiopllout, mux_clkroot_asrc_syspll2pfd3 };
+
+/* Mux selector: MQS */
+enum { mux_clkroot_mqs_oscrc48mdiv2 = 0, mux_clkroot_mqs_osc24mout, mux_clkroot_mqs_oscrc400m, mux_clkroot_mqs_oscrc16m,
+	mux_clkroot_mqs_syspll1div5, mux_clkroot_mqs_syspll3div2, mux_clkroot_mqs_audiopllout, mux_clkroot_mqs_syspll2pfd3 };
+
+/* Mux selector: MIC */
+enum { mux_clkroot_mic_oscrc48mdiv2 = 0, mux_clkroot_mic_osc24mout, mux_clkroot_mic_oscrc400m, mux_clkroot_mic_oscrc16m,
+	mux_clkroot_mic_syspll3pfd3, mux_clkroot_mic_syspll3out, mux_clkroot_mic_audiopllout, mux_clkroot_mic_syspll1div5 };
+
+/* Mux selector: SPDIF */
+enum { mux_clkroot_spdif_oscrc48mdiv2 = 0, mux_clkroot_spdif_osc24mout, mux_clkroot_spdif_oscrc400m, mux_clkroot_spdif_oscrc16m,
+	mux_clkroot_spdif_audiopllout, mux_clkroot_spdif_syspll3out, mux_clkroot_spdif_syspll3pfd2, mux_clkroot_spdif_syspll2pfd3 };
+
+/* Mux selector: SAI1 */
+enum { mux_clkroot_sai1_oscrc48mdiv2 = 0, mux_clkroot_sai1_osc24mout, mux_clkroot_sai1_oscrc400m, mux_clkroot_sai1_oscrc16m,
+	mux_clkroot_sai1_audiopllout, mux_clkroot_sai1_syspll3pfd2, mux_clkroot_sai1_syspll1div5, mux_clkroot_sai1_syspll2pfd3 };
+
+/* Mux selector: SAI2 */
+enum { mux_clkroot_sai2_oscrc48mdiv2 = 0, mux_clkroot_sai2_osc24mout, mux_clkroot_sai2_oscrc400m, mux_clkroot_sai2_oscrc16m,
+	mux_clkroot_sai2_audiopllout, mux_clkroot_sai2_syspll3pfd2, mux_clkroot_sai2_syspll1div5, mux_clkroot_sai2_syspll2pfd3 };
+
+/* Mux selector: SAI3 */
+enum { mux_clkroot_sai3_oscrc48mdiv2 = 0, mux_clkroot_sai3_osc24mout, mux_clkroot_sai3_oscrc400m, mux_clkroot_sai3_oscrc16m,
+	mux_clkroot_sai3_audiopllout, mux_clkroot_sai3_syspll3pfd2, mux_clkroot_sai3_syspll1div5, mux_clkroot_sai3_syspll2pfd3 };
+
+/* Mux selector: SAI4 */
+enum { mux_clkroot_sai4_oscrc48mdiv2 = 0, mux_clkroot_sai4_osc24mout, mux_clkroot_sai4_oscrc400m, mux_clkroot_sai4_oscrc16m,
+	mux_clkroot_sai4_syspll3pfd3, mux_clkroot_sai4_syspll3out, mux_clkroot_sai4_audiopllout, mux_clkroot_sai4_syspll1div5 };
+
+/* Mux selector: GPU2D */
+enum { mux_clkroot_gpu2d_oscrc48mdiv2 = 0, mux_clkroot_gpu2d_osc24mout, mux_clkroot_gpu2d_oscrc400m, mux_clkroot_gpu2d_oscrc16m,
+	mux_clkroot_gpu2d_syspll2out, mux_clkroot_gpu2d_syspll2pfd1, mux_clkroot_gpu2d_syspll3out, mux_clkroot_gpu2d_videopllout };
+
+/* Mux selector: LCDIF */
+enum { mux_clkroot_lcdif_oscrc48mdiv2 = 0, mux_clkroot_lcdif_osc24mout, mux_clkroot_lcdif_oscrc400m, mux_clkroot_lcdif_oscrc16m,
+	mux_clkroot_lcdif_syspll2out, mux_clkroot_lcdif_syspll2pfd2, mux_clkroot_lcdif_syspll3pfd0, mux_clkroot_lcdif_videopllout };
+
+/* Mux selector: LCDIFV2 */
+enum { mux_clkroot_lcdifv2_oscrc48mdiv2 = 0, mux_clkroot_lcdifv2_osc24mout, mux_clkroot_lcdifv2_oscrc400m, mux_clkroot_lcdifv2_oscrc16m,
+	mux_clkroot_lcdifv2_syspll2out, mux_clkroot_lcdifv2_syspll2pfd2, mux_clkroot_lcdifv2_syspll3pfd0, mux_clkroot_lcdifv2_videopllout };
+
+/* Mux selector: MIPI_REF */
+enum { mux_clkroot_mipi_ref_oscrc48mdiv2 = 0, mux_clkroot_mipi_ref_osc24mout, mux_clkroot_mipi_ref_oscrc400m, mux_clkroot_mipi_ref_oscrc16m,
+	mux_clkroot_mipi_ref_syspll2out, mux_clkroot_mipi_ref_syspll2pfd0, mux_clkroot_mipi_ref_syspll3pfd0, mux_clkroot_mipi_ref_videopllout };
+
+/* Mux selector: MIPI_ESC */
+enum { mux_clkroot_mipi_esc_oscrc48mdiv2 = 0, mux_clkroot_mipi_esc_osc24mout, mux_clkroot_mipi_esc_oscrc400m, mux_clkroot_mipi_esc_oscrc16m,
+	mux_clkroot_mipi_esc_syspll2out, mux_clkroot_mipi_esc_syspll2pfd0, mux_clkroot_mipi_esc_syspll3pfd0, mux_clkroot_mipi_esc_videopllout };
+
+/* Mux selector: CSI2 */
+enum { mux_clkroot_csi2_oscrc48mdiv2 = 0, mux_clkroot_csi2_osc24mout, mux_clkroot_csi2_oscrc400m, mux_clkroot_csi2_oscrc16m,
+	mux_clkroot_csi2_syspll2pfd2, mux_clkroot_csi2_syspll3out, mux_clkroot_csi2_syspll2pfd0, mux_clkroot_csi2_videopllout };
+
+/* Mux selector: CSI2_ESC */
+enum { mux_clkroot_csi2_esc_oscrc48mdiv2 = 0, mux_clkroot_csi2_esc_osc24mout, mux_clkroot_csi2_esc_oscrc400m, mux_clkroot_csi2_esc_oscrc16m,
+	mux_clkroot_csi2_esc_syspll2pfd2, mux_clkroot_csi2_esc_syspll3out, mux_clkroot_csi2_esc_syspll2pfd0, mux_clkroot_csi2_esc_videopllout };
+
+/* Mux selector: CSI2_UI */
+enum { mux_clkroot_csi2_ui_oscrc48mdiv2 = 0, mux_clkroot_csi2_ui_osc24mout, mux_clkroot_csi2_ui_oscrc400m, mux_clkroot_csi2_ui_oscrc16m,
+	mux_clkroot_csi2_ui_syspll2pfd2, mux_clkroot_csi2_ui_syspll3out, mux_clkroot_csi2_ui_syspll2pfd0, mux_clkroot_csi2_ui_videopllout };
+
+/* Mux selector: CSI */
+enum { mux_clkroot_csi_oscrc48mdiv2 = 0, mux_clkroot_csi_osc24mout, mux_clkroot_csi_oscrc400m, mux_clkroot_csi_oscrc16m,
+	mux_clkroot_csi_syspll2pfd2, mux_clkroot_csi_syspll3out, mux_clkroot_csi_syspll3pfd1, mux_clkroot_csi_videopllout };
+
+/* Mux selector: CKO1 */
+enum { mux_clkroot_cko1_oscrc48mdiv2 = 0, mux_clkroot_cko1_osc24mout, mux_clkroot_cko1_oscrc400m, mux_clkroot_cko1_oscrc16m,
+	mux_clkroot_cko1_syspll2pfd2, mux_clkroot_cko1_syspll2out, mux_clkroot_cko1_syspll3pfd1, mux_clkroot_cko1_syspll1div5 };
+
+/* Mux selector: CKO2 */
+enum { mux_clkroot_cko2_oscrc48mdiv2 = 0, mux_clkroot_cko2_osc24mout, mux_clkroot_cko2_oscrc400m, mux_clkroot_cko2_oscrc16m,
+	mux_clkroot_cko2_syspll2pfd3, mux_clkroot_cko2_oscrc48m, mux_clkroot_cko2_syspll3pfd1, mux_clkroot_cko2_audiopllout };
+
+
+/* PLL clock source */
+enum { clk_pllarm = 0, clk_pllsys1, clk_pllsys2, clk_pllsys3, clk_pllaudio, clk_pllvideo };
+
+
 /* clang-format on */
 
 
@@ -351,6 +673,9 @@ extern int _imxrt_getDevClock(int clock, int *div, int *mux, int *mfd, int *mfn,
 
 
 extern int _imxrt_setDevClock(int clock, int div, int mux, int mfd, int mfn, int state);
+
+
+extern int _imxrt_setPfdPllFracClock(u8 pfd, u8 clk_pll, u8 frac);
 
 
 extern void _imxrt_init(void);

--- a/hal/armv7m/imxrt/117x/timer.c
+++ b/hal/armv7m/imxrt/117x/timer.c
@@ -72,10 +72,9 @@ void timer_init(void)
 
 	/* FIXME */
 	//freq = _imxrt_ccmGetFreq(clk_ipg) / 2;
-	freq = 400 * 1000 * 1000;
+	freq = 24 * 1000 * 1000;
 	ticksPerMs = freq / 1000;
-
-	_imxrt_setDevClock(GPT1_CLK, 0, 2, 0, 0, 1);
+	/* NOTE: clock initialized during clock root setup in hal */
 
 	*(timer_common.base + gpt_cr) |= 1 << 15;
 


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

This pull-request implements i.MX RT117x root clock tree configuration.

By default ARM PLL is set to `800MHz` (automotive and industrial targets). For consumer electronics market ARM PLL of M7 CPU is configured to `1GHz`. 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

JIRA: RTOS-608

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-evk`, `imxrt-1176-nil`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
