### PR TITLE
hal/ia32: Add basic ACPI support

### DIFF
--- a/hal/ia32/Makefile
+++ b/hal/ia32/Makefile
@@ -15,7 +15,7 @@ include devices/disk-bios/Makefile
 include devices/tty-bios/Makefile
 include devices/uart-16550/Makefile
 
-OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/, _exceptions.o _init.o _interrupts.o cpu.o exceptions.o hal.o interrupts.o memory.o pci.o string.o timer.o)
+OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/, _exceptions.o _init.o _interrupts.o cpu.o exceptions.o hal.o interrupts.o memory.o pci.o string.o timer.o acpi.o)
 
 ifeq ($(CONSOLE), serial)
   OBJS += $(PREFIX_O)hal/$(TARGET_SUFF)/console-serial.o

--- a/hal/ia32/acpi.c
+++ b/hal/ia32/acpi.c
@@ -1,0 +1,180 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system loader
+ *
+ * ACPI detection and configuration
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Andrzej Stalke
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+#include "acpi.h"
+
+#define MAX_CPU_COUNT 64
+
+typedef struct {
+	char magic[4];
+	u32 length;
+	u8 revision;
+	u8 checksum;
+	char oem[6];
+	char oemID[8];
+	u32 oemRevision;
+	u32 creatorId;
+	u32 creatorRevision;
+} __attribute__((packed)) sdt_header_t;
+
+
+typedef struct {
+	char magic[8];
+	u8 checksum;
+	char oemID[6];
+	u8 revision;
+	struct {
+		sdt_header_t header;
+		sdt_header_t *sdt[];
+	} __attribute__((packed)) * rsdt;
+} __attribute__((packed)) rsdp_t;
+
+
+typedef struct {
+	rsdp_t rsdp;
+
+	u32 length;
+	u64 xsdtAddr;
+	u8 extChecksum;
+	u8 _reserved[3];
+} __attribute__((packed)) xsdp_t;
+
+
+static inline int _hal_checksumVerify(const void *data, const size_t size)
+{
+	const u8 *ptr;
+	u8 sum = 0;
+	for (ptr = (const u8 *)data; ptr < (const u8 *)data + size; ++ptr) {
+		sum += *ptr;
+	}
+	return (sum == 0) ? 1 : 0;
+}
+
+
+static void _hal_acpiMadtHandler(hal_syspage_t *hs, sdt_header_t *header)
+{
+	if (_hal_checksumVerify(header, header->length) != 0) {
+		hs->madt = (unsigned int)header;
+		hs->madtLength = header->length;
+	}
+}
+
+
+static void _hal_acpiFadtHandler(hal_syspage_t *hs, sdt_header_t *header)
+{
+	if (_hal_checksumVerify(header, header->length) != 0) {
+		hs->fadt = (unsigned int)header;
+		hs->fadtLength = header->length;
+	}
+}
+
+static const struct {
+	const char magic[4];
+	void (*handler)(hal_syspage_t *hs, sdt_header_t *);
+} acpi_knownTables[] = {
+	{ .magic = "APIC", .handler = _hal_acpiMadtHandler },
+	{ .magic = "FACP", .handler = _hal_acpiFadtHandler }
+};
+
+
+static rsdp_t *_hal_acpiLookForRsdp(hal_syspage_t *hs, void *start, void *end)
+{
+	static const char rsdpMagic[] = "RSD PTR ";
+	void *ptr;
+	rsdp_t *entry;
+	for (ptr = start; ptr < end; ptr += 16) {
+		if (hal_strncmp(rsdpMagic, ptr, 8) == 0) {
+			if (_hal_checksumVerify(ptr, sizeof(rsdp_t)) != 0) {
+				entry = ptr;
+				if ((entry->revision == 2) && (_hal_checksumVerify(entry, sizeof(xsdp_t)) != 0)) {
+					hs->acpi_version = ACPI_XSDP;
+				}
+				else {
+					hs->acpi_version = ACPI_RSDP;
+				}
+				return entry;
+			}
+		}
+	}
+	return NULL;
+}
+
+
+static rsdp_t *_hal_acpiFindRsdp(hal_syspage_t *hs)
+{
+	/* Search EBDA */
+	unsigned int ebda = ((*(u16 *)0x40eu) << 4) & ~(SIZE_PAGE - 1);
+	rsdp_t *result;
+	if ((ebda < 0x00080000u) || (ebda > 0x0009ffffu)) {
+		ebda = 0x00080000u;
+	}
+	hs->ebda = ebda;
+
+	result = _hal_acpiLookForRsdp(hs, (void *)ebda, (void *)(ebda + 1024));
+	if (result == NULL) {
+		result = _hal_acpiLookForRsdp(hs, (void *)0x000e0000u, (void *)0x000fffffu);
+	}
+	return result;
+}
+
+
+static void _hal_acpiHandleRsdt(hal_syspage_t *hs, rsdp_t *rsdp)
+{
+	size_t i, j;
+	if (_hal_checksumVerify(rsdp->rsdt, rsdp->rsdt->header.length) != 0) {
+		for (i = 0; i < (rsdp->rsdt->header.length - sizeof(sdt_header_t)) / 4; ++i) {
+			for (j = 0; j < sizeof(acpi_knownTables) / sizeof(*acpi_knownTables); ++j) {
+				if (hal_strncmp(rsdp->rsdt->sdt[i]->magic, acpi_knownTables[j].magic, 4) == 0) {
+					acpi_knownTables[j].handler(hs, rsdp->rsdt->sdt[i]);
+					break;
+				}
+			}
+		}
+	}
+	else {
+		/* Invalid RSDT table */
+		hs->acpi_version = ACPI_NONE;
+	}
+}
+
+
+void hal_acpiInit(hal_syspage_t *hs)
+{
+	hs->ebda = 0;
+	hs->acpi_version = ACPI_NONE;
+	hs->localApicAddr = 0;
+	hs->madt = 0;
+	hs->madtLength = 0;
+	hs->fadt = 0;
+	hs->fadtLength = 0;
+
+	rsdp_t *rsdp = _hal_acpiFindRsdp(hs);
+	if (rsdp != NULL) {
+		switch (hs->acpi_version) {
+			case ACPI_XSDP:
+				/* TODO: Don't fallback to RSDP */
+				hs->acpi_version = ACPI_RSDP;
+				/* fall-through */
+			case ACPI_RSDP:
+				_hal_acpiHandleRsdt(hs, rsdp);
+				break;
+			default:
+				/* RSDP not found */
+				break;
+		}
+	}
+	else {
+		hs->acpi_version = ACPI_NONE;
+	}
+}

--- a/hal/ia32/acpi.h
+++ b/hal/ia32/acpi.h
@@ -1,0 +1,21 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system loader
+ *
+ * ACPI detection and configuration
+ *
+ * Copyright 2023 Phoenix Systems
+ * Author: Andrzej Stalke
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+#ifndef _ACPI_H_
+#define _ACPI_H_
+#include <hal/hal.h>
+
+void hal_acpiInit(hal_syspage_t *hs);
+
+#endif

--- a/hal/ia32/memory.c
+++ b/hal/ia32/memory.c
@@ -103,11 +103,13 @@ int hal_memoryGetEntry(unsigned int *offs, mapent_t *entry, unsigned int *biosTy
 static void hal_getMinOverlappedRange(addr_t start, addr_t end, mapent_t *entry, mapent_t *minEntry)
 {
 	if ((start < entry->end) && (end > entry->start)) {
-		if (start > entry->start)
+		if (start > entry->start) {
 			entry->start = start;
+		}
 
-		if (end < entry->end)
+		if (end < entry->end) {
 			entry->end = end;
+		}
 
 		if (entry->start < minEntry->start) {
 			minEntry->start = entry->start;
@@ -138,8 +140,9 @@ int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 		{ .start = ADDR_RCACHE, .end = ADDR_RCACHE + SIZE_RCACHE + SIZE_WCACHE, .type = hal_entryTemp },
 	};
 
-	if (start == end)
+	if (start == end) {
 		return -1;
+	}
 
 	hal_memset(&tempEntry, 0, sizeof(tempEntry));
 	hal_memset(&prevEntry, 0, sizeof(prevEntry));
@@ -153,8 +156,9 @@ int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 	hal_getMinOverlappedRange(start, end, &tempEntry, &minEntry);
 
 	for (i = 0; i < sizeof(entries) / sizeof(entries[0]); ++i) {
-		if (entries[i].start >= entries[i].end)
+		if (entries[i].start >= entries[i].end) {
 			continue;
+		}
 		hal_memcpy(&tempEntry, &entries[i], sizeof(mapent_t));
 		hal_getMinOverlappedRange(start, end, &tempEntry, &minEntry);
 	}
@@ -162,12 +166,14 @@ int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 	/* Get BIOS e820 memory map */
 	offs = 0;
 	while (1) {
-		if (hal_memoryGetEntry(&offs, &tempEntry, &biosType) != 0)
+		if (hal_memoryGetEntry(&offs, &tempEntry, &biosType) != 0) {
 			return -1;
+		}
 
 		/* BIOS areas of different type than FREE are added to map's entries list */
-		if (biosType != 0x1)
+		if (biosType != 0x1) {
 			hal_getMinOverlappedRange(start, end, &tempEntry, &minEntry);
+		}
 
 		/* The gap between BIOS entries is assigned as invalid entry */
 		if (prevEntry.end != tempEntry.start) {
@@ -179,8 +185,9 @@ int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 
 		hal_memcpy(&prevEntry, &tempEntry, sizeof(mapent_t));
 
-		if (!offs)
+		if (offs == 0) {
 			break;
+		}
 	}
 
 	if (minEntry.start != (addr_t)-1) {

--- a/hal/ia32/memory.c
+++ b/hal/ia32/memory.c
@@ -15,6 +15,7 @@
  */
 
 #include <hal/hal.h>
+#include "acpi.h"
 
 struct {
 	hal_syspage_t *hs;
@@ -46,6 +47,7 @@ void hal_syspageSet(hal_syspage_t *hs)
 	memory_common.hs->stack = (addr_t)__stack_top;
 
 	memory_common.hs->stacksz = __stack_top - __stack_limit;
+	hal_acpiInit(hs);
 }
 
 
@@ -118,7 +120,6 @@ static void hal_getMinOverlappedRange(addr_t start, addr_t end, mapent_t *entry,
 		}
 	}
 }
-
 
 int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 {
@@ -197,6 +198,7 @@ int hal_memoryGetNextEntry(addr_t start, addr_t end, mapent_t *entry)
 
 		return 0;
 	}
+	/* Get ACPI memory map */
 
 	return -1;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Kernel needs ACPI for more advanced features. This PR gives the kernel access to MADT and FADT tables.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ia32-generic-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work: https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/464
- [ ] I will merge this PR by myself when appropriate.
