### PR TITLE
flash-imxrt: fix addressing mode for W25Q256 chip

### DIFF
--- a/devices/flash-imxrt/nor/nor.c
+++ b/devices/flash-imxrt/nor/nor.c
@@ -38,18 +38,18 @@ static const char *nor_vendors[] = {
 
 static const struct nor_info flashInfo[] = {
 	/* Winbond */
-	{ FLASH_ID(0xef, 0x4015), "W25Q16", 2 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric, NULL },
-	{ FLASH_ID(0xef, 0x4016), "W25Q32", 4 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric, NULL },
-	{ FLASH_ID(0xef, 0x4017), "W25Q64", 8 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric, NULL },
-	{ FLASH_ID(0xef, 0x4018), "W25Q128", 16 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric, NULL },
-	{ FLASH_ID(0xef, 0x4019), "W25Q256JVEIQ", 32 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric, NULL },
-	{ FLASH_ID(0xef, 0x6019), "W25Q256JW-Q", 32 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric, NULL },
-	{ FLASH_ID(0xef, 0x8019), "W25Q256JW-M", 32 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric, NULL },
+	{ FLASH_ID(0xef, 0x4015), "W25Q16", 2 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric3Byte, NULL },
+	{ FLASH_ID(0xef, 0x4016), "W25Q32", 4 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric3Byte, NULL },
+	{ FLASH_ID(0xef, 0x4017), "W25Q64", 8 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric3Byte, NULL },
+	{ FLASH_ID(0xef, 0x4018), "W25Q128", 16 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric3Byte, NULL },
+	{ FLASH_ID(0xef, 0x4019), "W25Q256JVEIQ", 32 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric4Byte, NULL },
+	{ FLASH_ID(0xef, 0x6019), "W25Q256JW-Q", 32 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric4Byte, NULL },
+	{ FLASH_ID(0xef, 0x8019), "W25Q256JW-M", 32 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric4Byte, NULL },
 
 	/* ISSI */
-	{ FLASH_ID(0x9d, 0x7016), "IS25WP032", 4 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric, NULL },
-	{ FLASH_ID(0x9d, 0x7017), "IS25WP064", 8 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric, NULL },
-	{ FLASH_ID(0x9d, 0x7018), "IS25WP128", 16 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric, NULL },
+	{ FLASH_ID(0x9d, 0x7016), "IS25WP032", 4 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric3Byte, NULL },
+	{ FLASH_ID(0x9d, 0x7017), "IS25WP064", 8 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric3Byte, NULL },
+	{ FLASH_ID(0x9d, 0x7018), "IS25WP128", 16 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric3Byte, NULL },
 
 	/* Micron */
 	{ FLASH_ID(0x20, 0xba19), "MT25QL256", 32 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC | NOR_CAPS_EN4B, lutMicronMono, NULL },
@@ -58,7 +58,7 @@ static const struct nor_info flashInfo[] = {
 	{ FLASH_ID(0x20, 0xba22), "MT25QL02G", 256 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_DIE4 | NOR_CAPS_EN4B, lutMicronDie, NULL },
 
 	/* Macronix (MXIX) */
-	{ FLASH_ID(0xc2, 0x2016), "MX25L3233", 4 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric, nor_mxQuadEnable },
+	{ FLASH_ID(0xc2, 0x2016), "MX25L3233", 4 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric3Byte, nor_mxQuadEnable },
 };
 
 

--- a/devices/flash-imxrt/nor/nor_lut.h
+++ b/devices/flash-imxrt/nor/nor_lut.h
@@ -30,8 +30,16 @@ static const u32 seq_genericReadID[NOR_LUTSEQSZ] = {
 };
 
 /* Read Fast Quad (3-byte address) */
-static const u32 seq_genericReadData[NOR_LUTSEQSZ] = {
+static const u32 seq_genericReadData3Byte[NOR_LUTSEQSZ] = {
 	LUT_SEQ(lutCmd_SDR, lutPad1, FLASH_CMD_QIOR, lutCmdRADDR_SDR, lutPad4, 0x18),
+	LUT_SEQ(lutCmdMODE8_SDR, lutPad4, 0x00, lutCmdDUMMY_SDR, lutPad4, 0x04),
+	LUT_SEQ(lutCmdREAD_SDR, lutPad4, 0x04, lutCmdSTOP, lutPad1, 0),
+	0
+};
+
+/* Read Fast Quad (4-byte address) */
+static const u32 seq_genericReadData4Byte[NOR_LUTSEQSZ] = {
+	LUT_SEQ(lutCmd_SDR, lutPad1, FLASH_CMD_4QIOR, lutCmdRADDR_SDR, lutPad4, 0x20),
 	LUT_SEQ(lutCmdMODE8_SDR, lutPad4, 0x00, lutCmdDUMMY_SDR, lutPad4, 0x04),
 	LUT_SEQ(lutCmdREAD_SDR, lutPad4, 0x04, lutCmdSTOP, lutPad1, 0),
 	0
@@ -64,15 +72,29 @@ static const u32 seq_genericWriteDisable[NOR_LUTSEQSZ] = {
 };
 
 /* Sector Erase (3-byte address) */
-static const u32 seq_genericEraseSector[NOR_LUTSEQSZ] = {
+static const u32 seq_genericEraseSector3Byte[NOR_LUTSEQSZ] = {
 	LUT_SEQ(lutCmd_SDR, lutPad1, FLASH_CMD_P4E, lutCmdRADDR_SDR, lutPad1, 0x18),
 	LUT_SEQ(lutCmdSTOP, lutPad1, 0, 0, 0, 0),
 	0, 0
 };
 
+/* Sector Erase (4-byte address) */
+static const u32 seq_genericEraseSector4Byte[NOR_LUTSEQSZ] = {
+	LUT_SEQ(lutCmd_SDR, lutPad1, FLASH_CMD_4P4E, lutCmdRADDR_SDR, lutPad1, 0x20),
+	LUT_SEQ(lutCmdSTOP, lutPad1, 0, 0, 0, 0),
+	0, 0
+};
+
 /* Block Erase (3-byte address) */
-static const u32 seq_genericEraseBlock[NOR_LUTSEQSZ] = {
+static const u32 seq_genericEraseBlock3Byte[NOR_LUTSEQSZ] = {
 	LUT_SEQ(lutCmd_SDR, lutPad1, FLASH_CMD_SE, lutCmdRADDR_SDR, lutPad1, 0x18),
+	LUT_SEQ(lutCmdSTOP, lutPad1, 0, 0, 0, 0),
+	0, 0
+};
+
+/* Block Erase (4-byte address) */
+static const u32 seq_genericEraseBlock4Byte[NOR_LUTSEQSZ] = {
+	LUT_SEQ(lutCmd_SDR, lutPad1, FLASH_CMD_4SE, lutCmdRADDR_SDR, lutPad1, 0x20),
 	LUT_SEQ(lutCmdSTOP, lutPad1, 0, 0, 0, 0),
 	0, 0
 };
@@ -84,8 +106,15 @@ static const u32 seq_genericEraseChip[NOR_LUTSEQSZ] = {
 };
 
 /* Quad Input Page Program (3-byte address) */
-static const u32 seq_genericProgramQPP[NOR_LUTSEQSZ] = {
+static const u32 seq_genericProgramQPP3Byte[NOR_LUTSEQSZ] = {
 	LUT_SEQ(lutCmd_SDR, lutPad1, FLASH_CMD_QPP, lutCmdRADDR_SDR, lutPad1, 0x18),
+	LUT_SEQ(lutCmdWRITE_SDR, lutPad4, 0x04, lutCmdSTOP, lutPad1, 0),
+	0, 0
+};
+
+/* Quad Input Page Program (4-byte address) */
+static const u32 seq_genericProgramQPP4Byte[NOR_LUTSEQSZ] = {
+	LUT_SEQ(lutCmd_SDR, lutPad1, FLASH_CMD_4QPP, lutCmdRADDR_SDR, lutPad1, 0x20),
 	LUT_SEQ(lutCmdWRITE_SDR, lutPad4, 0x04, lutCmdSTOP, lutPad1, 0),
 	0, 0
 };
@@ -152,17 +181,31 @@ static const u32 seq_micronExit4Byte[NOR_LUTSEQSZ] = {
 };
 
 
-/* Generic chips: ISSI, Winbond, Macronix */
-static const u32 *lutGeneric[LUT_ENTRIES] = {
-	[fspi_readData] = seq_genericReadData,
+/* Generic chips: ISSI, Winbond, Macronix (3-byte address) */
+static const u32 *lutGeneric3Byte[LUT_ENTRIES] = {
+	[fspi_readData] = seq_genericReadData3Byte,
 	[fspi_readStatus] = seq_genericReadStatus,
 	[fspi_writeStatus] = seq_genericWriteStatus,
 	[fspi_writeEnable] = seq_genericWriteEnable,
 	[fspi_writeDisable] = seq_genericWriteDisable,
-	[fspi_eraseSector] = seq_genericEraseSector,
-	[fspi_eraseBlock] = seq_genericEraseBlock,
+	[fspi_eraseSector] = seq_genericEraseSector3Byte,
+	[fspi_eraseBlock] = seq_genericEraseBlock3Byte,
 	[fspi_eraseChip] = seq_genericEraseChip,
-	[fspi_programQPP] = seq_genericProgramQPP,
+	[fspi_programQPP] = seq_genericProgramQPP3Byte,
+	[fspi_readID] = seq_genericReadID,
+};
+
+/* Generic chips: ISSI, Winbond, Macronix (4-byte address) */
+static const u32 *lutGeneric4Byte[LUT_ENTRIES] = {
+	[fspi_readData] = seq_genericReadData4Byte,
+	[fspi_readStatus] = seq_genericReadStatus,
+	[fspi_writeStatus] = seq_genericWriteStatus,
+	[fspi_writeEnable] = seq_genericWriteEnable,
+	[fspi_writeDisable] = seq_genericWriteDisable,
+	[fspi_eraseSector] = seq_genericEraseSector4Byte,
+	[fspi_eraseBlock] = seq_genericEraseBlock4Byte,
+	[fspi_eraseChip] = seq_genericEraseChip,
+	[fspi_programQPP] = seq_genericProgramQPP4Byte,
 	[fspi_readID] = seq_genericReadID,
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Winbond W25Q256* require 4 byte addressing to access addresses beyond 128MBit.

#### The chip is used in a custom board - setup is not verified by CI, it was manually verified on the target NIL.

JIRA: RTOS-661

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt1176-nil

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
