### PR TITLE
GR712RC: flashdrv and init fixes

### DIFF
--- a/devices/flash-gr712rc/flashdrv.c
+++ b/devices/flash-gr712rc/flashdrv.c
@@ -281,7 +281,20 @@ static int flashdrv_map(unsigned int minor, addr_t addr, size_t sz, int mode, ad
 
 static int flashdrv_done(unsigned int minor)
 {
-	return flashdrv_sync(minor);
+	flash_device_t *dev;
+
+	if (minor >= FLASH_NO) {
+		return -ENXIO;
+	}
+
+	dev = &fdrv_common.dev[minor];
+
+	(void)flashdrv_sync(minor);
+	ftmctrl_WrEn();
+	flash_read(dev, 0, NULL, 0);
+	ftmctrl_WrDis();
+
+	return EOK;
 }
 
 

--- a/hal/sparcv8leon3/gaisler/gr712rc/Makefile
+++ b/hal/sparcv8leon3/gaisler/gr712rc/Makefile
@@ -8,10 +8,9 @@
 
 CFLAGS += -DVADDR_KERNEL_INIT=$(VADDR_KERNEL_INIT)
 
-PLO_COMMANDS := alias app call console copy dump echo go help kernel map mem phfs reboot script wait test-dev
+PLO_COMMANDS := alias app call console copy dump echo go help jffs2 kernel map mem phfs reboot script wait test-dev
 
 include devices/uart-grlib/Makefile
-include devices/ram-storage/Makefile
 include devices/flash-gr712rc/Makefile
 
 OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/gaisler/$(TARGET_SUBFAMILY)/, _init.o hal.o gr712rc.o)

--- a/hal/sparcv8leon3/gaisler/gr712rc/_init.S
+++ b/hal/sparcv8leon3/gaisler/gr712rc/_init.S
@@ -19,11 +19,21 @@
 #include "../../cpu.h"
 
 
+.extern syspage_common
+
+
 .section ".init", "ax"
 .align 4
 .global _init
 .type _init, #function
 _init:
+	/* Get current PC
+	 * Note: call is PC-relative - no need to worry about relocation
+	 */
+	call . + 8
+	nop
+	mov %o7, %g5
+
 	wr %g0, %wim
 	nop
 	nop
@@ -31,6 +41,41 @@ _init:
 
 	wr %g0, PSR_S, %psr
 
+	/* Get CPU ID */
+	rd %asr17, %g1
+	srl %g1, 28, %g1
+	cmp %g1, %g0
+	bnz jmp_core
+	nop
+
+	set _plo_load_addr, %g3
+	cmp %g5, %g3
+	bge stage1
+	nop
+
+	/* We're executing in FLASH, copy PLO to RAM */
+	set _plo_size, %g1
+	/* src = %g5 - 0x1000 */
+	set 0x1000, %g2
+	sub %g5, %g2, %g2 /* src */
+	/* dst = _plo_load_addr (%g3) */
+	add %g3, %g1, %g4 /* end */
+
+copy:
+	ld [%g2], %g5
+	add %g2, 4, %g2
+	st %g5, [%g3]
+	add %g3, 4, %g3
+	cmp %g3, %g4
+	bl copy
+	nop
+
+	/* Jump to RAM */
+	sethi %hi(stage1), %g1
+	jmp %g1 + %lo(stage1)
+	nop
+
+stage1:
 	/* Set up trap table */
 	sethi %hi(_trap_table), %g1
 	wr %g1, %tbr
@@ -59,4 +104,13 @@ _init:
 	sethi %hi(_startc), %g1
 	jmpl %g1 + %lo(_startc), %g0
 	clr %g1
+
+jmp_core:
+	set syspage_common, %g1
+	ld [%g1], %g1 /* syspage_common->syspage */
+	ld [%g1 + 8], %g1 /* syspage->pkernel */
+
+	/* Jump to kernel */
+	jmp %g1
+	nop
 .size _init, . - _init


### PR DESCRIPTION
JIRA: RTOS-616

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

This PR:
 - updates the flash mode to read in the flashdrv_done function - this ensures that other cores can safely start from flash.
 - adapts the initialization process to support multicore systems and copies the PLO to RAM if needed


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `sparcv8leon3-gr712rc-board`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
