### PR TITLE
hal/zynq7000, hal/imx6ull: Fix accesses to GIC EOIR register

### DIFF
--- a/hal/armv7a/imx6ull/interrupts.c
+++ b/hal/armv7a/imx6ull/interrupts.c
@@ -89,7 +89,7 @@ void interrupts_dispatch(void)
 		interrupts_common.handlers[n].f(n, interrupts_common.handlers[n].data);
 
 	/* Update End of Interrupt register with original value from iar */
-	*(interrupts_common.gic + gicv_eoir) = (*(interrupts_common.gic + gicv_eoir) & 0x03ff) | iar;
+	*(interrupts_common.gic + gicv_eoir) = iar;
 
 	return;
 }

--- a/hal/armv7a/zynq7000/interrupts.c
+++ b/hal/armv7a/zynq7000/interrupts.c
@@ -130,7 +130,7 @@ void interrupts_dispatch(void)
 	if (interrupts_common.handlers[n].f != NULL)
 		interrupts_common.handlers[n].f(n, interrupts_common.handlers[n].data);
 
-	*(interrupts_common.mpcore + ceoir) = (*(interrupts_common.mpcore + ceoir) & ~0x3ff) | n;
+	*(interrupts_common.mpcore + ceoir) = n;
 
 	return;
 }


### PR DESCRIPTION
Fixes code trying to read from a write-only register.

## Description
On both of these platforms interrupt handling code tried to read from EOIR. According to documentation ([link](https://developer.arm.com/documentation/ihi0048/latest/), Table 4-2) EOIR is write-only, reads from it are undefined. The code worked because reads from it probably returned 0.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a9-zynq7000-zturn, armv7a9-zynq7000-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
