### PR TITLE
uart-grlib: remove explicit array size declaration

### DIFF
--- a/devices/uart-grlib/uart.c
+++ b/devices/uart-grlib/uart.c
@@ -68,7 +68,7 @@ static const struct {
 	unsigned int txPin;
 	unsigned int rxPin;
 	unsigned int active;
-} info[UART_MAX_CNT] = {
+} info[] = {
 	{ UART0_BASE, UART0_IRQ, UART0_TX, UART0_RX, UART0_ACTIVE },
 	{ UART1_BASE, UART1_IRQ, UART1_TX, UART1_RX, UART1_ACTIVE },
 	{ UART2_BASE, UART2_IRQ, UART2_TX, UART2_RX, UART2_ACTIVE },


### PR DESCRIPTION
JIRA: RTOS-704

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
allow specifying different `UART_MAX_CNT`
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
