### PR TITLE
Fix script processing issues

### DIFF
--- a/cmds/alias.c
+++ b/cmds/alias.c
@@ -120,8 +120,6 @@ static int cmd_alias(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_aliasReg(void)
-{
-	const static cmd_t alias_cmd = { .name = "alias", .run = cmd_alias, .info = cmd_aliasInfo };
-	cmd_reg(&alias_cmd);
-}
+static const cmd_t alias_cmd __attribute__((section("commands"), used)) = {
+	.name = "alias", .run = cmd_alias, .info = cmd_aliasInfo
+};

--- a/cmds/app.c
+++ b/cmds/app.c
@@ -260,9 +260,6 @@ static int cmd_app(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_appReg(void)
-{
-	const static cmd_t app_cmd = { .name = "app", .run = cmd_app, .info = cmd_appInfo };
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t app_cmd __attribute__((section("commands"), used)) = {
+	.name = "app", .run = cmd_app, .info = cmd_appInfo
+};

--- a/cmds/bankswitch.c
+++ b/cmds/bankswitch.c
@@ -27,7 +27,7 @@ static void cmd_bankswitchInfo(void)
 
 static int cmd_bankswitch(int argc, char *argv[])
 {
-	int targetBank, err = EOK;
+	int targetBank, err = CMD_EXIT_SUCCESS;
 
 	if (argc == 1) {
 		targetBank = (_stm32_getFlashBank() == 0) ? 1 : 0;
@@ -37,10 +37,10 @@ static int cmd_bankswitch(int argc, char *argv[])
 	}
 	else {
 		log_error("\n%s: Wrong argument count", argv[0]);
-		err = -EINVAL;
+		err = CMD_EXIT_FAILURE;
 	}
 
-	if (err == EOK) {
+	if (err == CMD_EXIT_SUCCESS) {
 		_stm32_switchFlashBank(targetBank);
 		log_info("\n%s: Bank switch successful (%d -> %d)", argv[0],
 			(targetBank == 0) ? 1 : 0, targetBank);

--- a/cmds/bankswitch.c
+++ b/cmds/bankswitch.c
@@ -50,9 +50,6 @@ static int cmd_bankswitch(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_appreg(void)
-{
-	const static cmd_t app_cmd = { .name = "bankswitch", .run = cmd_bankswitch, .info = cmd_bankswitchInfo };
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t bankswitch_cmd __attribute__((section("commands"), used)) = {
+	.name = "bankswitch", .run = cmd_bankswitch, .info = cmd_bankswitchInfo
+};

--- a/cmds/bitstream.c
+++ b/cmds/bitstream.c
@@ -35,24 +35,27 @@ static int cmd_bitstream(int argc, char *argv[])
 
 	if (argc == 1) {
 		log_error("\n%s: Arguments have to be defined", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 	else if (argc != 3) {
 		log_error("\n%s: Wrong argument count", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 
-	if ((res = phfs_open(argv[1], argv[2], 0, &handler)) < 0) {
-		log_error("\nCan't open %s, on %s", argv[2], argv[1]);
-		return res;
+	res = phfs_open(argv[1], argv[2], 0, &handler);
+	if (res < 0) {
+		log_error("\nCan't open %s, on %s (%d)", argv[2], argv[1], res);
+		return CMD_EXIT_FAILURE;
 	}
 
 	log_info("\nLoading bitstream into DDR, please wait...");
 	do {
-		if ((res = phfs_read(handler, offs, buff, sizeof(buff))) < 0) {
-			log_error("\nCan't read %s from %s", argv[2], argv[1]);
-			return res;
+		res = phfs_read(handler, offs, buff, sizeof(buff));
+		if (res < 0) {
+			log_error("\nCan't read %s from %s (%d)", argv[2], argv[1], res);
+			phfs_close(handler);
+			return CMD_EXIT_FAILURE;
 		}
 
 		hal_memcpy((void *)addr, buff, res);
@@ -60,15 +63,18 @@ static int cmd_bitstream(int argc, char *argv[])
 		offs += res;
 	} while (res != 0);
 
+	phfs_close(handler);
+
 	log_info("\nLoading bitstream into PL");
-	if ((res = _zynq_loadPL(ADDR_BITSTREAM, addr - ADDR_BITSTREAM)) < 0) {
-		log_error("\nPL was not initialized, bitstream is incorrect");
-		return res;
+	res = _zynq_loadPL(ADDR_BITSTREAM, addr - ADDR_BITSTREAM);
+	if (res < 0) {
+		log_error("\nPL was not initialized, bitstream is incorrect (%d)", res);
+		return CMD_EXIT_FAILURE;
 	}
 
 	log_info("\nPL was successfully initialized");
 
-	return EOK;
+	return CMD_EXIT_SUCCESS;
 }
 
 

--- a/cmds/bitstream.c
+++ b/cmds/bitstream.c
@@ -78,9 +78,6 @@ static int cmd_bitstream(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_appreg(void)
-{
-	const static cmd_t app_cmd = { .name = "bitstream", .run = cmd_bitstream, .info = cmd_bistreamInfo };
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t bitstream_cmd __attribute__((section("commands"), used)) = {
+	.name = "bitstream", .run = cmd_bitstream, .info = cmd_bistreamInfo
+};

--- a/cmds/bootcm4.c
+++ b/cmds/bootcm4.c
@@ -184,11 +184,6 @@ static int cmd_bootcm4(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_bootcm4Reg(void)
-{
-	const static cmd_t app_cmd = {
-		.name = "bootcm4", .run = cmd_bootcm4, .info = cmd_bootcm4Info
-	};
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t bootcm4_cmd __attribute__((section("commands"), used)) = {
+	.name = "bootcm4", .run = cmd_bootcm4, .info = cmd_bootcm4Info
+};

--- a/cmds/bootrom.c
+++ b/cmds/bootrom.c
@@ -121,11 +121,6 @@ static int cmd_bootrom(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_bootromReg(void)
-{
-	const static cmd_t app_cmd = {
-		.name = "bootrom", .run = cmd_bootrom, .info = cmd_bootromInfo
-	};
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t bootrom_cmd __attribute__((section("commands"), used)) = {
+	.name = "bootrom", .run = cmd_bootrom, .info = cmd_bootromInfo
+};

--- a/cmds/call.c
+++ b/cmds/call.c
@@ -104,8 +104,6 @@ static int cmd_call(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_callReg(void)
-{
-	const static cmd_t app_cmd = { .name = "call", .run = cmd_call, .info = cmd_callInfo };
-	cmd_reg(&app_cmd);
-}
+static const cmd_t call_cmd __attribute__((section("commands"), used)) = {
+	.name = "call", .run = cmd_call, .info = cmd_callInfo
+};

--- a/cmds/console.c
+++ b/cmds/console.c
@@ -32,11 +32,11 @@ static int cmd_console(int argc, char *argv[])
 
 	if (argc == 1) {
 		log_error("\n%s: Arguments have to be defined", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 	else if (argc != 2) {
 		log_error("\n%s: Wrong argument count", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 
@@ -44,17 +44,17 @@ static int cmd_console(int argc, char *argv[])
 	major = lib_strtoul(argv[1], &endptr, 0);
 	if (*endptr != '.') {
 		log_error("\nWrong major value: %s", argv[1]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	minor = lib_strtoul(++endptr, &endptr, 0);
 	if (*endptr != '\0') {
 		log_error("\nWrong minor value: %s", argv[1]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	lib_consoleSet(major, minor);
-	return EOK;
+	return CMD_EXIT_SUCCESS;
 }
 
 

--- a/cmds/console.c
+++ b/cmds/console.c
@@ -58,8 +58,6 @@ static int cmd_console(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_consoleReg(void)
-{
-	const static cmd_t app_cmd = { .name = "console", .run = cmd_console, .info = cmd_consoleInfo };
-	cmd_reg(&app_cmd);
-}
+static const cmd_t console_cmd __attribute__((section("commands"), used)) = {
+	.name = "console", .run = cmd_console, .info = cmd_consoleInfo
+};

--- a/cmds/copy.c
+++ b/cmds/copy.c
@@ -160,9 +160,6 @@ static int cmd_copy(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_copyReg(void)
-{
-	const static cmd_t app_cmd = { .name = "copy", .run = cmd_copy, .info = cmd_copyInfo };
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t copy_cmd __attribute__((section("commands"), used)) = {
+	.name = "copy", .run = cmd_copy, .info = cmd_copyInfo
+};

--- a/cmds/copy.c
+++ b/cmds/copy.c
@@ -128,15 +128,16 @@ static int cmd_copy(int argc, char *argv[])
 	/* Parse all comand's arguments */
 	if (argc < 5) {
 		log_error("\n%s: Wrong argument count", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
-	if ((res = cmd_devParse(&h[0], &offs[0], &sz[0], argc, argv, 0, &argvID, &file[0])) < 0)
-		return res;
+	if (cmd_devParse(&h[0], &offs[0], &sz[0], argc, argv, 0, &argvID, &file[0]) < 0) {
+		return CMD_EXIT_FAILURE;
+	}
 
-	if ((res = cmd_devParse(&h[1], &offs[1], &sz[1], argc, argv, 1, &argvID, &file[1])) < 0) {
+	if (cmd_devParse(&h[1], &offs[1], &sz[1], argc, argv, 1, &argvID, &file[1]) < 0) {
 		phfs_close(h[0]);
-		return res;
+		return CMD_EXIT_FAILURE;
 	}
 
 	/* Copy data between devices */
@@ -148,15 +149,14 @@ static int cmd_copy(int argc, char *argv[])
 
 	if (res < 0) {
 		log_error("\nCopying failed");
-		return res;
+		return CMD_EXIT_FAILURE;
 	}
 
 	log_info("\nFinished copying");
 
-	if ((res = phfs_aliasReg((file[1] == NULL) ? file[0] : file[1], offs[1], res)) < 0)
-		return res;
+	res = phfs_aliasReg((file[1] == NULL) ? file[0] : file[1], offs[1], res);
 
-	return EOK;
+	return (res < 0) ? CMD_EXIT_FAILURE : CMD_EXIT_SUCCESS;
 }
 
 

--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -160,9 +160,6 @@ static int cmd_dump(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_dumpReg(void)
-{
-	const static cmd_t app_cmd = { .name = "dump", .run = cmd_dump, .info = cmd_dumpInfo };
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t dump_cmd __attribute__((section("commands"), used)) = {
+	.name = "dump", .run = cmd_dump, .info = cmd_dumpInfo
+};

--- a/cmds/dump.c
+++ b/cmds/dump.c
@@ -99,7 +99,7 @@ static int cmd_dump(int argc, char *argv[])
 	while ((argn < argc) && (argv[argn][0] == '-')) {
 		if ((argv[argn][1] == '\0') || (argv[argn][2] != '\0')) {
 			log_error("\n%s: Wrong arguments", argv[0]);
-			return -EINVAL;
+			return CMD_EXIT_FAILURE;
 		}
 
 		switch (argv[argn][1]) {
@@ -119,7 +119,7 @@ static int cmd_dump(int argc, char *argv[])
 
 			default:
 				log_error("\n%s: Wrong arguments", argv[0]);
-				return -EINVAL;
+				return CMD_EXIT_FAILURE;
 		}
 
 		argn++;
@@ -127,13 +127,13 @@ static int cmd_dump(int argc, char *argv[])
 
 	if (argn >= argc) {
 		log_error("\n%s: Wrong arguments", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	start = lib_strtoul(argv[argn], &endptr, 0);
 	if (*endptr != '\0') {
 		log_error("\n%s: Wrong arguments", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	argn++;
@@ -141,7 +141,7 @@ static int cmd_dump(int argc, char *argv[])
 		length = lib_strtoul(argv[argn], &endptr, 0);
 		if ((*endptr != '\0') || (length == 0u)) {
 			log_error("\n%s: Wrong arguments", argv[0]);
-			return -EINVAL;
+			return CMD_EXIT_FAILURE;
 		}
 	}
 
@@ -156,7 +156,7 @@ static int cmd_dump(int argc, char *argv[])
 		dump_phfs(devname, start, length);
 	}
 
-	return EOK;
+	return CMD_EXIT_SUCCESS;
 }
 
 

--- a/cmds/echo.c
+++ b/cmds/echo.c
@@ -36,12 +36,12 @@ static int cmd_echo(int argc, char *argv[])
 			lib_printf("\nEcho is 'off'");
 		}
 
-		return EOK;
+		return CMD_EXIT_SUCCESS;
 	}
 
 	if (argc != 2) {
 		log_error("\n%s: Wrong arguments", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	/* Set echo */
@@ -53,10 +53,10 @@ static int cmd_echo(int argc, char *argv[])
 	}
 	else {
 		log_error("\n%s: Wrong arguments", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
-	return EOK;
+	return CMD_EXIT_SUCCESS;
 }
 
 

--- a/cmds/echo.c
+++ b/cmds/echo.c
@@ -60,8 +60,6 @@ static int cmd_echo(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_echoReg(void)
-{
-	const static cmd_t app_cmd = { .name = "echo", .run = cmd_echo, .info = cmd_echoInfo };
-	cmd_reg(&app_cmd);
-}
+static const cmd_t echo_cmd __attribute__((section("commands"), used)) = {
+	.name = "echo", .run = cmd_echo, .info = cmd_echoInfo
+};

--- a/cmds/erase.c
+++ b/cmds/erase.c
@@ -38,45 +38,46 @@ static int cmd_erase(int argc, char *argv[])
 
 	if (argc != 2 && argc != 4) {
 		log_error("\n%s: Wrong argument count", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	if (argc != 2) {
 		offs = lib_strtoul(argv[2], &endptr, 0);
 		if (argv[2] == endptr) {
 			log_error("\n%s: Wrong arguments", argv[0]);
-			return -EINVAL;
+			return CMD_EXIT_FAILURE;
 		}
 		len = lib_strtoul(argv[3], &endptr, 0);
 		if (argv[3] == endptr) {
 			log_error("\n%s: Wrong arguments", argv[0]);
-			return -EINVAL;
+			return CMD_EXIT_FAILURE;
 		}
 	}
 
 	res = phfs_open(argv[1], NULL, PHFS_OPEN_RAWONLY, &h);
 	if (res < 0) {
 		lib_printf("\n%s: Invalid phfs name provided: %s\n", argv[0], argv[1]);
-		return res;
+		return CMD_EXIT_FAILURE;
 	}
 
 	res = lib_promptConfirm("\nWARNING!\nSerious risk of data loss, type %s to proceed.\n", "YES!", 10 * 1000);
 	if (res != 1) {
 		lib_printf("Aborted.\n");
-		return EOK;
+		return CMD_EXIT_SUCCESS;
 	}
 
 	res = phfs_erase(h, offs, len, 0);
 	if (res < 0) {
 		lib_printf("\n%s: Error %zd", argv[0], res);
-		return res;
+		(void)phfs_close(h);
+		return CMD_EXIT_FAILURE;
 	}
 
 	(void)phfs_close(h);
 
 	lib_printf("\nErased %zd bytes from %s phfs device.\n", res, argv[1]);
 
-	return EOK;
+	return CMD_EXIT_SUCCESS;
 }
 
 

--- a/cmds/erase.c
+++ b/cmds/erase.c
@@ -81,9 +81,6 @@ static int cmd_erase(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_eraseReg(void)
-{
-	const static cmd_t app_cmd = { .name = "erase", .run = cmd_erase, .info = cmd_eraseInfo };
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t erase_cmd __attribute__((section("commands"), used)) = {
+	.name = "erase", .run = cmd_erase, .info = cmd_eraseInfo
+};

--- a/cmds/go.c
+++ b/cmds/go.c
@@ -31,7 +31,7 @@ static int cmd_go(int argc, char *argv[])
 {
 	if (argc != 1) {
 		log_error("\n%s: Command does not accept arguments", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	log_info("\nRunning Phoenix-RTOS\n");
@@ -41,7 +41,8 @@ static int cmd_go(int argc, char *argv[])
 	hal_done();
 	hal_cpuJump();
 
-	return EOK;
+	/* Never reached */
+	return CMD_EXIT_FAILURE;
 }
 
 

--- a/cmds/go.c
+++ b/cmds/go.c
@@ -46,9 +46,6 @@ static int cmd_go(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_goReg(void)
-{
-	const static cmd_t app_cmd = { .name = "go!", .run = cmd_go, .info = cmd_goInfo };
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t go_cmd __attribute__((section("commands"), used)) = {
+	.name = "go!", .run = cmd_go, .info = cmd_goInfo
+};

--- a/cmds/help.c
+++ b/cmds/help.c
@@ -41,9 +41,6 @@ static int cmd_help(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_helpReg(void)
-{
-	const static cmd_t app_cmd = { .name = "help", .run = cmd_help, .info = cmd_helpInfo };
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t help_cmd __attribute__((section("commands"), used)) = {
+	.name = "help", .run = cmd_help, .info = cmd_helpInfo
+};

--- a/cmds/help.c
+++ b/cmds/help.c
@@ -29,7 +29,7 @@ static int cmd_help(int argc, char *argv[])
 
 	if (argc != 1) {
 		log_error("\n%s: Command does not accept arguments", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	while ((cmd = cmd_getCmd(i++)) != NULL) {
@@ -37,7 +37,7 @@ static int cmd_help(int argc, char *argv[])
 		cmd->info();
 	}
 
-	return EOK;
+	return CMD_EXIT_SUCCESS;
 }
 
 

--- a/cmds/jffs2.c
+++ b/cmds/jffs2.c
@@ -167,9 +167,7 @@ static int cmd_jffs2(int argc, char *argv[])
 	return CMD_EXIT_SUCCESS;
 }
 
-__attribute__((constructor)) static void cmd_jffs2Reg(void)
-{
-	static const cmd_t app_cmd = { .name = "jffs2", .run = cmd_jffs2, .info = cmd_jffs2Info };
 
-	cmd_reg(&app_cmd);
-}
+static const cmd_t jffs2_cmd __attribute__((section("commands"), used)) = {
+	.name = "jffs2", .run = cmd_jffs2, .info = cmd_jffs2Info
+};

--- a/cmds/jffs2.c
+++ b/cmds/jffs2.c
@@ -135,7 +135,7 @@ static int cmd_jffs2(int argc, char *argv[])
 	err = devs_check(major, minor);
 	if (err < 0) {
 		log_error("\nInvalid device %d\n", err);
-		return -1;
+		return CMD_EXIT_FAILURE;
 	}
 
 	cleanmarker.magic = JFFS2_MAGIC_BITMASK;

--- a/cmds/kernel.c
+++ b/cmds/kernel.c
@@ -131,9 +131,6 @@ static int cmd_kernel(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_kernelReg(void)
-{
-	const static cmd_t app_cmd = { .name = "kernel", .run = cmd_kernel, .info = cmd_kernelInfo };
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t kernel_cmd __attribute__((section("commands"), used)) = {
+	.name = "kernel", .run = cmd_kernel, .info = cmd_kernelInfo
+};

--- a/cmds/kernelimg.c
+++ b/cmds/kernelimg.c
@@ -41,24 +41,26 @@ static int cmd_kernelimg(int argc, char *argv[])
 	const mapent_t *entry;
 
 	/* Parse arguments */
-	if (argc < 6 || argc > 7) {
+	if ((argc < 6) || (argc > 7)) {
 		log_error("\n%s: Wrong argument count", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	kname = (argc == 7) ? argv[2] : PATH_KERNEL;
 
-	if ((res = phfs_open(argv[1], kname, 0, &handle)) < 0) {
-		log_error("\nCannot open %s, on %s", kname, argv[1]);
-		return res;
+	res = phfs_open(argv[1], kname, 0, &handle);
+	if (res < 0) {
+		log_error("\nCannot open %s, on %s (%d)", kname, argv[1], res);
+		return CMD_EXIT_FAILURE;
 	}
 
 	hal_kernelGetEntryPointOffset(&entryoff, &indirect);
 	if (indirect) {
-		if ((res = phfs_read(handle, entryoff, &kentry, sizeof(kentry))) < 0) {
-			log_error("\nCan't read %s, on %s", kname, argv[1]);
+		res = phfs_read(handle, entryoff, &kentry, sizeof(kentry));
+		if (res < 0) {
+			log_error("\nCan't read %s, on %s (%d)", kname, argv[1], res);
 			phfs_close(handle);
-			return res;
+			return CMD_EXIT_FAILURE;
 		}
 	}
 	else {
@@ -69,62 +71,68 @@ static int cmd_kernelimg(int argc, char *argv[])
 	if (*endptr) {
 		log_error("\n%s: Wrong arguments", argv[0]);
 		phfs_close(handle);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	tsz = lib_strtoul(argv[argc - 3], &endptr, 16);
 	if (*endptr) {
 		log_error("\n%s: Wrong arguments", argv[0]);
 		phfs_close(handle);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	dbeg = lib_strtoul(argv[argc - 2], &endptr, 16);
 	if (*endptr) {
 		log_error("\n%s: Wrong arguments", argv[0]);
 		phfs_close(handle);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	dsz = lib_strtoul(argv[argc - 1], &endptr, 16);
 	if (*endptr) {
 		log_error("\n%s: Wrong arguments", argv[0]);
 		phfs_close(handle);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
-	if (phfs_aliasAddrResolve(handle, &offs) < 0)
+	if (phfs_aliasAddrResolve(handle, &offs) < 0) {
 		offs = 0;
+	}
 
 	/* Get file's properties */
-	if ((res = phfs_stat(handle, &stat)) < 0) {
-		log_error("\nCan't get stat from %s", kname);
-		return res;
+	res = phfs_stat(handle, &stat);
+	if (res < 0) {
+		log_error("\nCan't get stat from %s (%d)", kname, res);
+		phfs_close(handle);
+		return CMD_EXIT_FAILURE;
 	}
 
 	/* Check whether map's range coincides with device's address space */
-	if ((res = phfs_map(handle, offs, stat.size, mAttrRead | mAttrExec, tbeg, tsz, mAttrRead | mAttrExec, &addr)) < 0) {
-		log_error("\nDevice is not mappable in %s", argv[1]);
+	res = phfs_map(handle, offs, stat.size, mAttrRead | mAttrExec, tbeg, tsz, mAttrRead | mAttrExec, &addr);
+	if (res < 0) {
+		log_error("\nDevice is not mappable in %s (%d)", argv[1], res);
 		phfs_close(handle);
-		return res;
+		return CMD_EXIT_FAILURE;
 	}
 
 	if (res != dev_isMappable) {
-		log_error("\n%s is not mappable in %s", kname, argv[1]);
+		log_error("\n%s is not mappable in %s (%d)", kname, argv[1], res);
 		phfs_close(handle);
-		return res;
+		return CMD_EXIT_FAILURE;
 	}
 
-	if ((entry = syspage_entryAdd(NULL, tbeg, tsz, sizeof(long long))) == NULL) {
+	entry = syspage_entryAdd(NULL, tbeg, tsz, sizeof(long long));
+	if (entry == NULL) {
 		log_error("\nCannot allocate memory for '%s'", kname);
 		phfs_close(handle);
-		return -ENOMEM;
+		return CMD_EXIT_FAILURE;
 	}
 
-	if ((entry = syspage_entryAdd(NULL, dbeg, dsz, sizeof(long long))) == NULL) {
+	entry = syspage_entryAdd(NULL, dbeg, dsz, sizeof(long long));
+	if (entry == NULL) {
 		log_error("\nCannot allocate memory for '%s'", kname);
 		phfs_close(handle);
-		return -ENOMEM;
+		return CMD_EXIT_FAILURE;
 	}
 
 	hal_kernelEntryPoint(hal_kernelGetAddress(kentry));
@@ -132,7 +140,7 @@ static int cmd_kernelimg(int argc, char *argv[])
 
 	log_info("\nLoaded %s", kname);
 
-	return EOK;
+	return CMD_EXIT_SUCCESS;
 }
 
 

--- a/cmds/kernelimg.c
+++ b/cmds/kernelimg.c
@@ -144,9 +144,6 @@ static int cmd_kernelimg(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_kernelimgReg(void)
-{
-	const static cmd_t app_cmd = { .name = "kernelimg", .run = cmd_kernelimg, .info = cmd_kernelimgInfo };
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t kernelimg_cmd __attribute__((section("commands"), used)) = {
+	.name = "kernelimg", .run = cmd_kernelimg, .info = cmd_kernelimgInfo
+};

--- a/cmds/lspci.c
+++ b/cmds/lspci.c
@@ -227,11 +227,6 @@ static int cmd_lspciMain(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_lspciReg(void)
-{
-	const static cmd_t app_cmd = {
-		.name = "lspci", .run = cmd_lspciMain, .info = cmd_lspciInfo
-	};
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t lspci_cmd __attribute__((section("commands"), used)) = {
+	.name = "lspci", .run = cmd_lspciMain, .info = cmd_lspciInfo
+};

--- a/cmds/map.c
+++ b/cmds/map.c
@@ -33,34 +33,35 @@ static int cmd_map(int argc, char *argv[])
 
 	if (argc == 1) {
 		syspage_mapShow();
-		return EOK;
+		return CMD_EXIT_SUCCESS;
 	}
 	else if (argc != 5) {
 		log_error("\n%s: Wrong argument count", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	start = lib_strtoul(argv[2], &endptr, 0);
 	if (*endptr) {
 		log_error("\n%s: Wrong arguments", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	end = lib_strtoul(argv[3], &endptr, 0);
 	if (*endptr) {
 		log_error("\n%s: Wrong arguments", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 
-	if ((res = syspage_mapAdd(argv[1], start, end, argv[4])) < 0) {
-		log_error("\nCan't create map %s", argv[1]);
-		return res;
+	res = syspage_mapAdd(argv[1], start, end, argv[4]);
+	if (res < 0) {
+		log_error("\nCan't create map %s (%d)", argv[1], res);
+		return CMD_EXIT_FAILURE;
 	}
 
 	log_info("\nCreated map %s", argv[1]);
 
-	return EOK;
+	return CMD_EXIT_SUCCESS;
 }
 
 

--- a/cmds/map.c
+++ b/cmds/map.c
@@ -65,9 +65,6 @@ static int cmd_map(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_mapReg(void)
-{
-	const static cmd_t app_cmd = { .name = "map", .run = cmd_map, .info = cmd_mapInfo };
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t map_cmd __attribute__((section("commands"), used)) = {
+	.name = "map", .run = cmd_map, .info = cmd_mapInfo
+};

--- a/cmds/mem.c
+++ b/cmds/mem.c
@@ -250,8 +250,6 @@ static int cmd_memMain(int argc, char **argv)
 }
 
 
-__attribute__((constructor)) static void cmd_memReg(void)
-{
-	const static cmd_t app_cmd = { .name = "mem", .run = cmd_memMain, .info = cmd_memInfo };
-	cmd_reg(&app_cmd);
-}
+static const cmd_t mem_cmd __attribute__((section("commands"), used)) = {
+	.name = "mem", .run = cmd_memMain, .info = cmd_memInfo
+};

--- a/cmds/mpu.c
+++ b/cmds/mpu.c
@@ -135,9 +135,6 @@ static int cmd_mpu(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_mpuReg(void)
-{
-	const static cmd_t app_cmd = { .name = "mpu", .run = cmd_mpu, .info = cmd_mpuInfo };
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t mpu_cmd __attribute__((section("commands"), used)) = {
+	.name = "mpu", .run = cmd_mpu, .info = cmd_mpuInfo
+};

--- a/cmds/mpu.c
+++ b/cmds/mpu.c
@@ -99,19 +99,19 @@ static int cmd_mpu(int argc, char *argv[])
 	else if (argc == 2) {
 		if (hal_strcmp(argv[1], "all") != 0) {
 			log_error("\n%s: Wrong arguments", argv[0]);
-			return -EINVAL;
+			return CMD_EXIT_FAILURE;
 		}
 
 		regCnt = mpu_common->regMax;
 	}
 	else {
 		log_error("\n%s: Wrong argument count", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	if (mpu_common->regMax != sizeof(((hal_syspage_t *)0)->mpu.table) / sizeof(((hal_syspage_t *)0)->mpu.table[0])) {
 		log_error("\n%s: MPU hal is not initialized or unsupported type was detected", argv[0]);
-		return -EFAULT;
+		return CMD_EXIT_FAILURE;
 	}
 
 	lib_printf(CONSOLE_BOLD "\n%-9s %-7s %-4s %-11s %-11s %-3s %-3s %-9s %-4s %-2s %-2s %-2s\n" CONSOLE_NORMAL,
@@ -119,8 +119,11 @@ static int cmd_mpu(int argc, char *argv[])
 
 	for (i = 0; i < regCnt; i++) {
 		region = &mpu_common->region[i];
-		if ((name = syspage_mapName(mpu_common->mapId[i])) == NULL)
+		name = syspage_mapName(mpu_common->mapId[i]);
+
+		if (name == NULL) {
 			name = "<none>";
+		}
 
 		mpu_regionPrint(name, region->rbar, region->rasr);
 	}
@@ -128,7 +131,7 @@ static int cmd_mpu(int argc, char *argv[])
 	lib_printf("\nConfigured %d of %d MPU regions based on %d map definitions.\n",
 		mpu_common->regCnt, mpu_common->regMax, mpu_common->mapCnt);
 
-	return EOK;
+	return CMD_EXIT_SUCCESS;
 }
 
 

--- a/cmds/otp.c
+++ b/cmds/otp.c
@@ -95,8 +95,6 @@ int cmd_otp(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_otpReg(void)
-{
-	const static cmd_t app_cmd = { .name = "otp", .run = cmd_otp, .info = cmd_otpInfo };
-	cmd_reg(&app_cmd);
-}
+static const cmd_t otp_cmd __attribute__((section("commands"), used)) = {
+	.name = "otp", .run = cmd_otp, .info = cmd_otpInfo
+};

--- a/cmds/phfs.c
+++ b/cmds/phfs.c
@@ -33,34 +33,35 @@ static int cmd_phfs(int argc, char *argv[])
 
 	if (argc == 1) {
 		phfs_devsShow();
-		return EOK;
+		return CMD_EXIT_SUCCESS;
 	}
 	else if (argc < 3 || argc > 4) {
 		log_error("\n%s: Wrong argument count", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	/* Get major/minor */
 	major = lib_strtoul(argv[2], &endptr, 0);
 	if (*endptr != '.') {
 		log_error("\n%s: Wrong major value for %s", argv[0], argv[1]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	minor = lib_strtoul(++endptr, &endptr, 0);
 	if (*endptr != '\0') {
 		log_error("\n%s: Wrong minor value for %s", argv[0], argv[1]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
-	if ((res = phfs_devReg(argv[1], major, minor, (argc == 3) ? NULL : argv[3])) < 0) {
-		log_error("\nCan't register %s in phfs", argv[0]);
-		return res;
+	res = phfs_devReg(argv[1], major, minor, (argc == 3) ? NULL : argv[3]);
+	if (res < 0) {
+		log_error("\nCan't register %s in phfs (%d)", argv[0], res);
+		return CMD_EXIT_FAILURE;
 	}
 
 	log_info("\nRegistering phfs %s", argv[1]);
 
-	return EOK;
+	return CMD_EXIT_SUCCESS;
 }
 
 

--- a/cmds/phfs.c
+++ b/cmds/phfs.c
@@ -65,9 +65,6 @@ static int cmd_phfs(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_phfsReg(void)
-{
-	const static cmd_t app_cmd = { .name = "phfs", .run = cmd_phfs, .info = cmd_phfsInfo };
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t phfs_cmd __attribute__((section("commands"), used)) = {
+	.name = "phfs", .run = cmd_phfs, .info = cmd_phfsInfo
+};

--- a/cmds/reboot.c
+++ b/cmds/reboot.c
@@ -44,9 +44,6 @@ static int cmd_reboot(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_rebootReg(void)
-{
-	const static cmd_t app_cmd = { .name = "reboot", .run = cmd_reboot, .info = cmd_rebootInfo };
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t reboot_cmd __attribute__((section("commands"), used)) = {
+	.name = "reboot", .run = cmd_reboot, .info = cmd_rebootInfo
+};

--- a/cmds/reboot.c
+++ b/cmds/reboot.c
@@ -30,7 +30,7 @@ static int cmd_reboot(int argc, char *argv[])
 {
 	if (argc != 1) {
 		log_error("\n%s: Command does not accept arguments", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	log_info("\nRebooting\n");
@@ -38,7 +38,9 @@ static int cmd_reboot(int argc, char *argv[])
 	hal_done();
 	hal_interruptsDisableAll();
 	hal_cpuReboot();
-	return EOK;
+
+	/* Never reached */
+	return CMD_EXIT_FAILURE;
 }
 
 

--- a/cmds/script.c
+++ b/cmds/script.c
@@ -88,8 +88,6 @@ static int cmd_script(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_scriptReg(void)
-{
-	const static cmd_t app_cmd = { .name = "script", .run = cmd_script, .info = cmd_scriptInfo };
-	cmd_reg(&app_cmd);
-}
+static const cmd_t script_cmd __attribute__((section("commands"), used)) = {
+	.name = "script", .run = cmd_script, .info = cmd_scriptInfo
+};

--- a/cmds/test-ddr.c
+++ b/cmds/test-ddr.c
@@ -247,9 +247,6 @@ static int cmd_ddr(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_ddrReg(void)
-{
-	const static cmd_t ddrCmd = { .name = "test-ddr", .run = cmd_ddr, .info = cmd_ddrInfo };
-
-	cmd_reg(&ddrCmd);
-}
+static const cmd_t testddr_cmd __attribute__((section("commands"), used)) = {
+	.name = "test-ddr", .run = cmd_ddr, .info = cmd_ddrInfo
+};

--- a/cmds/test-ddr.c
+++ b/cmds/test-ddr.c
@@ -227,7 +227,7 @@ static int cmd_ddr(int argc, char *argv[])
 
 	if (argc != 1) {
 		log_error("\n%s: Command does not accept arguments", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	lib_printf(CONSOLE_BOLD "\nTest are executing, please wait ...");
@@ -243,7 +243,7 @@ static int cmd_ddr(int argc, char *argv[])
 	err = cmd_ddrBitChargeLeakage(ADDR_DDR);
 	cmd_errPrint(err);
 
-	return EOK;
+	return CMD_EXIT_SUCCESS;
 }
 
 

--- a/cmds/test-dev.c
+++ b/cmds/test-dev.c
@@ -286,9 +286,6 @@ static int cmd_testDev(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_testDevReg(void)
-{
-	const static cmd_t app_cmd = { .name = "test-dev", .run = cmd_testDev, .info = cmd_testDevInfo };
-
-	cmd_reg(&app_cmd);
-}
+static const cmd_t testdev_cmd __attribute__((section("commands"), used)) = {
+	.name = "test-dev", .run = cmd_testDev, .info = cmd_testDevInfo
+};

--- a/cmds/wait.c
+++ b/cmds/wait.c
@@ -70,9 +70,6 @@ static int cmd_wait(int argc, char *argv[])
 }
 
 
-__attribute__((constructor)) static void cmd_waitReg(void)
-{
-	const static cmd_t app_cmd = { .name = "wait", .run = cmd_wait, .info = cmd_waitInfo };
-
-	cmd_reg(&app_cmd);
-}
+static cmd_t wait_cmd __attribute__((section("commands"), used)) = {
+	.name = "wait", .run = cmd_wait, .info = cmd_waitInfo
+};

--- a/cmds/wait.c
+++ b/cmds/wait.c
@@ -40,8 +40,10 @@ static int cmd_wait(int argc, char *argv[])
 			lib_printf("\r%*s \r%s ", sizeof(prompt) + 4, "", prompt);
 			for (i = 0; i < 3; ++i) {
 				lib_printf(".");
-				if (lib_consoleGetc(&c, 500) > 0)
+				if (lib_consoleGetc(&c, 500) > 0) {
+					/* FIXME: this is not an error, break to console */
 					return -1;
+				}
 			}
 		}
 	}
@@ -50,19 +52,21 @@ static int cmd_wait(int argc, char *argv[])
 	time = lib_strtoul(argv[1], &endptr, 0);
 	if (*endptr) {
 		log_error("\n%s: Wrong argument count", argv[0]);
-		return -EINVAL;
+		return CMD_EXIT_FAILURE;
 	}
 
 	while (time > 0) {
 		step = time >= 100 ? 100 : time;
 		time -= step;
 		lib_printf("\r%*s \r%s, %5d [ms]", sizeof(prompt) + 14, "", prompt, time);
-		if (lib_consoleGetc(&c, step) > 0)
+		if (lib_consoleGetc(&c, step) > 0) {
+			/* FIXME: this is not an error, break to console */
 			return -1;
+		}
 	}
 	lib_printf("\r%*s \r%s, %5d [ms]\n", sizeof(prompt) + 14, "", prompt, 0);
 
-	return EOK;
+	return CMD_EXIT_SUCCESS;
 }
 
 

--- a/ld/common/plo-arm.lds
+++ b/ld/common/plo-arm.lds
@@ -58,6 +58,14 @@ SECTIONS
 		__rodata_end = .;
 	} > PLO_IMAGE
 
+	/* section dedicated for PLO commands */
+	.commands : ALIGN(4)
+	{
+		__cmd_start = .;
+		KEEP (*(SORT_BY_NAME(commands)))
+		__cmd_end = .;
+	} > PLO_IMAGE
+
 	/* put .ARM.ex* the sections containing information for unwinding the stack */
 	.ARM.extab : {
 		PROVIDE_HIDDEN(__extab_start = .);

--- a/ld/common/plo-ia32.lds
+++ b/ld/common/plo-ia32.lds
@@ -57,6 +57,15 @@ SECTIONS
 		*(.rodata .rodata.* .gnu.linkonce.r.*)
 		__rodata_end = .;
 	} > PLO_IMAGE
+
+	/* section dedicated for PLO commands */
+	.commands : ALIGN(4)
+	{
+		__cmd_start = .;
+		KEEP (*(SORT_BY_NAME(commands)))
+		__cmd_end = .;
+	} > PLO_IMAGE
+
 	.eh_frame_hdr : { *(.eh_frame_hdr) *(.eh_frame_entry .eh_frame_entry.*) } > PLO_IMAGE
 	.eh_frame : ONLY_IF_RO { KEEP (*(.eh_frame)) *(.eh_frame.*) } > PLO_IMAGE
 

--- a/ld/common/plo-riscv64.lds
+++ b/ld/common/plo-riscv64.lds
@@ -55,6 +55,13 @@ SECTIONS
 		__rodata_end = .;
 	} > PLO_IMAGE
 
+	/* section dedicated for PLO commands */
+	.commands : ALIGN(8) {
+		__cmd_start = .;
+		KEEP (*(SORT_BY_NAME(commands)))
+		__cmd_end = .;
+	} > PLO_IMAGE
+
 	.eh_frame_hdr : { *(.eh_frame_hdr) *(.eh_frame_entry .eh_frame_entry.*) } > PLO_IMAGE
 	.eh_frame : ONLY_IF_RO { KEEP (*(.eh_frame)) *(.eh_frame.*) } > PLO_IMAGE
 

--- a/ld/common/plo-sparc.lds
+++ b/ld/common/plo-sparc.lds
@@ -40,6 +40,14 @@ SECTIONS
 		__rodata_end = .;
 	} > RODATA AT > PLO_IMAGE
 
+	/* section dedicated for PLO commands */
+	.commands : ALIGN(4)
+	{
+		__cmd_start = .;
+		KEEP (*(SORT_BY_NAME(commands)))
+		__cmd_end = .;
+	} > PLO_IMAGE
+
 	.eh_frame_hdr : { *(.eh_frame_hdr) *(.eh_frame_entry .eh_frame_entry.*) } > PLO_IMAGE
 	.eh_frame : ONLY_IF_RO { KEEP (*(.eh_frame)) *(.eh_frame.*) } > PLO_IMAGE
 


### PR DESCRIPTION
## Motivation and Context


* Added special section which contains all commands, removed functions for command registering functionality. ~~Registering new commands when the command list was overflowing `SIZE_CMDS` resulted in silent ignoring newly added commands, which resulted in the fact that, depending on the compilation iteration, an unpredictable set of commands was registered (some commands were missing, like `call` or even `go!`), especially when adding new commands required by closed source project - now if it will happen, will be caught in endless loop, no way to assert, log, etc because of the fact that `cmd_reg(..)` is handled in commands constructor early before console is available, that's why it was previously silently ignored.~~

* There is no need for this with linker scripts: ~~Increase `SIZE_CMDS` to 28.~~

* Unification of exit codes from applets - `CMD_EXIT_FAILURE/SUCCESS`, except for the specifics of the `call` command which may return negative error codes.

* Added closing of open handles in phfs in case of errors (where missing `phfs_close(h)`).

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `mimxrt1064-evk`, `mimxrt1052-evk`, `imxrt1176-nil`, `ia32-generic`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
