### PR TITLE
ia32/acpi: add MCFG table handler

### DIFF
--- a/hal/ia32/acpi.c
+++ b/hal/ia32/acpi.c
@@ -89,13 +89,23 @@ static void _hal_acpiHpetHandler(hal_syspage_t *hs, sdt_header_t *header)
 }
 
 
+static void _hal_acpiMcfgHandler(hal_syspage_t *hs, sdt_header_t *header)
+{
+	if (_hal_checksumVerify(header, header->length) != 0) {
+		hs->mcfg = (unsigned long)header; /* FIXME - should be addr_t */
+		hs->mcfgLength = header->length;
+	}
+}
+
+
 static const struct {
 	const char magic[4];
 	void (*handler)(hal_syspage_t *hs, sdt_header_t *);
 } acpi_knownTables[] = {
 	{ .magic = "APIC", .handler = _hal_acpiMadtHandler },
 	{ .magic = "FACP", .handler = _hal_acpiFadtHandler },
-	{ .magic = "HPET", .handler = _hal_acpiHpetHandler }
+	{ .magic = "HPET", .handler = _hal_acpiHpetHandler },
+	{ .magic = "MCFG", .handler = _hal_acpiMcfgHandler }
 };
 
 
@@ -171,6 +181,8 @@ void hal_acpiInit(hal_syspage_t *hs)
 	hs->fadtLength = 0;
 	hs->hpet = 0;
 	hs->hpetLength = 0;
+	hs->mcfg = 0;
+	hs->mcfgLength = 0;
 
 	rsdp_t *rsdp = _hal_acpiFindRsdp(hs);
 	if (rsdp != NULL) {


### PR DESCRIPTION
Required to handle ECAM access for PCIexpress.

before merge:
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/530

JIRA: RTOS-800

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: 'intel Q35', 'ia32-generic'

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/530
- [ ] I will merge this PR by myself when appropriate.
