### PR TITLE
imxrt-flash: Add IS25LP256 NOR flash support

### DIFF
--- a/devices/flash-imxrt/nor/nor.c
+++ b/devices/flash-imxrt/nor/nor.c
@@ -5,7 +5,7 @@
  *
  * i.MX RT NOR flash device driver
  *
- * Copyright 2021-2023 Phoenix Systems
+ * Copyright 2021-2024 Phoenix Systems
  * Author: Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
@@ -50,6 +50,8 @@ static const struct nor_info flashInfo[] = {
 	{ FLASH_ID(0x9d, 0x7016), "IS25WP032", 4 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric3Byte, NULL },
 	{ FLASH_ID(0x9d, 0x7017), "IS25WP064", 8 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric3Byte, NULL },
 	{ FLASH_ID(0x9d, 0x7018), "IS25WP128", 16 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric3Byte, NULL },
+	{ FLASH_ID(0x9d, 0x7019), "IS25WP256", 32 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric4Byte, nor_mxQuadEnable },
+	{ FLASH_ID(0x9d, 0x6019), "IS25LP256", 32 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric4Byte, nor_mxQuadEnable },
 
 	/* Micron */
 	{ FLASH_ID(0x20, 0xba19), "MT25QL256", 32 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC | NOR_CAPS_EN4B, lutMicronMono, NULL },

--- a/devices/flash-imxrt/nor/nor_mx.c
+++ b/devices/flash-imxrt/nor/nor_mx.c
@@ -4,9 +4,9 @@
  * Operating system loader
  *
  * i.MX RT nor flash device driver
- * Macronix Specific
+ * Macronix & ISSI Specific
  *
- * Copyright 2021-2023 Phoenix Systems
+ * Copyright 2021-2024 Phoenix Systems
  * Author: Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
@@ -24,14 +24,15 @@
 #include "nor.h"
 
 
+/* Generic Quad Enable for Macronix and ISSI chips */
 int nor_mxQuadEnable(struct nor_device *dev)
 {
 	int res;
 	struct xferOp xfer;
-	u32 quadEnable = 0x40;
+	u32 quadEnable = 0x40u;
 	const time_t timeout = 1000;
 
-	if (!dev->active) {
+	if (dev->active == 0) {
 		return -ENODEV;
 	}
 
@@ -59,12 +60,12 @@ int nor_mxQuadEnable(struct nor_device *dev)
 		return res;
 	}
 
-	if (quadEnable & (1 << 6)) {
+	if ((quadEnable & (1uL << 6u)) != 0uL) {
 		/* Already enabled */
 		return EOK;
 	}
 
-	quadEnable |= (1 << 6);
+	quadEnable |= (1uL << 6u);
 
 	res = nor_writeEnable(&dev->fspi, dev->port, 1, timeout);
 	if (res < EOK) {


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

Adds `IS25LP256` and `IS25WP256` flash chips to the supported devices, these chips supports quad lane communication only when appropriate bit (Quad Enable) is set in non-volatile config register, by default only Single and Dual is supported `IO0`, `IO2` and `WP#`,`HOLD#/RESET#` pins are enabled, switching to Quad SPI enables `IO2` and `IO3` instead of `WP#`,`HOLD#/RESET#` pins.

Chip operates at 133MHz clock, same for the rest chips used with i.MX RT117x/10xx, verified to work at 166MHz (but we don't have laboratory tests regarding EMI for 166MHz, so I leave it with 133MHz clock).

JIRA: NIL-539

![2024-04-03-001210_1296x582_scrot](https://github.com/phoenix-rtos/plo/assets/141153/2eea0fcd-0f84-487e-9f73-5f93c8af2a10)

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-nil`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
