### PR TITLE
riscv64: adapt PLO to multicore

### DIFF
--- a/cmds/kernel.c
+++ b/cmds/kernel.c
@@ -102,7 +102,7 @@ static int cmd_kernel(int argc, char *argv[])
 			}
 
 			/* Save kernel's beginning address */
-			if (phdr.p_flags == (ELF_WORD)(PHF_R | PHF_X)) {
+			if ((phdr.p_flags & (ELF_WORD)PHF_X) != 0) {
 				kernelPAddr = entry->start;
 			}
 

--- a/hal/riscv64/_init.S
+++ b/hal/riscv64/_init.S
@@ -21,10 +21,6 @@
 
 .section .init, "ax"
 
-.globl dtbAddr
-dtbAddr:
-	.dword
-
 .globl _start
 .type _start, @function
 _start:
@@ -32,6 +28,10 @@ _start:
 	sd a1, (t0)
 	/* Mask all interrupts */
 	csrw sie, zero
+
+	mv tp, a0
+	la t0, boothartId
+	sw tp, (t0)
 
 .option push
 .option norelax
@@ -45,3 +45,13 @@ _start:
 	la sp, _stack
 	j _startc
 .size _start, . - _start
+
+.align 8
+.globl dtbAddr
+dtbAddr:
+	.dword 0
+
+.align 4
+.globl boothartId
+boothartId:
+	.word 0

--- a/hal/riscv64/cpu.h
+++ b/hal/riscv64/cpu.h
@@ -98,6 +98,16 @@ static inline void hal_cpuReboot(void)
 }
 
 
+static inline unsigned long hal_cpuGetHartId(void)
+{
+	unsigned long id;
+	/* clang-format off */
+	__asm__ volatile ("mv %0, tp" : "=r"(id));
+	/* clang-format on */
+	return id;
+}
+
+
 #endif /* __ASSEMBLY__ */
 
 

--- a/hal/riscv64/generic/hal.c
+++ b/hal/riscv64/generic/hal.c
@@ -22,6 +22,7 @@ static struct {
 } hal_common;
 
 extern void *dtbAddr;
+extern unsigned int boothartId;
 
 
 /* Linker symbols */
@@ -36,8 +37,6 @@ extern char __bss_start[], __bss_end[];
 extern char __heap_base[], __heap_limit[];
 extern char __stack_top[], __stack_limit[];
 
-/* Timer */
-extern void timer_init(void);
 
 /* Interrupts */
 extern void interrupts_init(void);
@@ -49,7 +48,6 @@ void hal_init(void)
 	dtb_parse(dtbAddr);
 	sbi_init();
 	interrupts_init();
-	timer_init();
 }
 
 
@@ -60,6 +58,7 @@ void hal_done(void)
 
 void hal_syspageSet(hal_syspage_t *hs)
 {
+	hs->boothartId = boothartId;
 	hal_common.hs = hs;
 }
 
@@ -177,8 +176,9 @@ int hal_cpuJump(void)
 	hal_interruptsDisableAll();
 
 	__asm__ volatile(
-		"mv a1, %0\n\t"
-		"mv a0, %1\n\t"
+		"mv a0, tp\n\t"
+		"mv a2, %0\n\t"
+		"mv a1, %1\n\t"
 		"jr %2\n\t"
 		:
 		: "r"(dtbAddr), "r"(hal_common.hs), "r"(hal_common.entry)

--- a/hal/riscv64/interrupts.c
+++ b/hal/riscv64/interrupts.c
@@ -57,7 +57,7 @@ void hal_interruptsDisable(unsigned int irqn)
 		csr_clear(sie, 1u << (irqn & ~CLINT_IRQ_FLG));
 	}
 	else {
-		plic_disableInterrupt(1, irqn);
+		plic_disableInterrupt(PLIC_SCONTEXT(hal_cpuGetHartId()), irqn);
 	}
 }
 
@@ -76,7 +76,7 @@ void hal_interruptsDisableAll(void)
 
 static void interrupts_dispatchPlic(void)
 {
-	unsigned int irq = plic_claim(1);
+	unsigned int irq = plic_claim(PLIC_SCONTEXT(hal_cpuGetHartId()));
 
 	if (irq == 0) {
 		return;
@@ -86,7 +86,7 @@ static void interrupts_dispatchPlic(void)
 		interrupts_common.plicHandlers[irq].isr(irq, interrupts_common.plicHandlers[irq].data);
 	}
 
-	plic_complete(1, irq);
+	plic_complete(PLIC_SCONTEXT(hal_cpuGetHartId()), irq);
 }
 
 
@@ -119,11 +119,11 @@ static int interrupts_setPlic(unsigned int n, int (*isr)(unsigned int, void *), 
 	interrupts_common.plicHandlers[n].isr = isr;
 
 	if (isr == NULL) {
-		plic_disableInterrupt(1, n);
+		plic_disableInterrupt(PLIC_SCONTEXT(hal_cpuGetHartId()), n);
 	}
 	else {
 		plic_priority(n, 2);
-		plic_enableInterrupt(1, n);
+		plic_enableInterrupt(PLIC_SCONTEXT(hal_cpuGetHartId()), n);
 	}
 
 	return 0;

--- a/hal/riscv64/plic.c
+++ b/hal/riscv64/plic.c
@@ -14,6 +14,7 @@
  */
 
 #include "plic.h"
+#include "cpu.h"
 
 #include <board_config.h>
 
@@ -21,7 +22,7 @@
 /* clang-format off */
 
 /* PLIC register offsets */
-#define PLIC_PRIORITY(irqn)            (0x0000 + (n) * 4)
+#define PLIC_PRIORITY(irqn)            (0x0000 + (irqn) * 4)
 #define PLIC_REG_PENDING(irqn)         (0x1000 + ((irqn) / 32) * 4)
 #define PLIC_REG_ENABLE(context, irqn) (0x2000 + (context) * 0x80 + ((irqn) / 32) * 4)
 #define PLIC_REG_THRESHOLD(context)    (0x200000 + (context) * 0x1000)
@@ -115,8 +116,8 @@ void _plic_init(void)
 	/* Disable and mask external interrupts, irq 0 is unused */
 	for (i = 1; i < PLIC_IRQ_SIZE; i++) {
 		plic_priority(i, 0);
-		plic_disableInterrupt(1, i);
+		plic_disableInterrupt(PLIC_SCONTEXT(hal_cpuGetHartId()), i);
 	}
 
-	plic_tresholdSet(1, 1);
+	plic_tresholdSet(PLIC_SCONTEXT(hal_cpuGetHartId()), 1);
 }

--- a/hal/riscv64/plic.h
+++ b/hal/riscv64/plic.h
@@ -19,6 +19,9 @@
 #include <types.h>
 
 
+#define PLIC_SCONTEXT(hartId) (2 * (hartId) + 1)
+
+
 void plic_priority(unsigned int n, unsigned int priority);
 
 

--- a/hal/riscv64/timer.c
+++ b/hal/riscv64/timer.c
@@ -15,45 +15,8 @@
 
 #include <hal/hal.h>
 
-/* CLINT Timer interrupt */
-#define TIMER_IRQ (5u | CLINT_IRQ_FLG)
-
-
-static struct {
-	volatile time_t jiffies;
-	u32 interval;
-} timer_common;
-
-
-static int timer_irqHandler(unsigned int n, void *arg)
-{
-	(void)n;
-	(void)arg;
-
-	timer_common.jiffies++;
-	sbi_setTimer(csr_read(time) + timer_common.interval);
-
-	return 0;
-}
-
 
 time_t hal_timerGet(void)
 {
-	time_t val;
-
-	hal_interruptsDisable(TIMER_IRQ);
-	val = timer_common.jiffies;
-	hal_interruptsEnable(TIMER_IRQ);
-
-	return val;
-}
-
-
-void timer_init(void)
-{
-	timer_common.jiffies = 0;
-	timer_common.interval = TIMER_FREQ / 1000; /* 1ms */
-
-	hal_interruptsSet(TIMER_IRQ, timer_irqHandler, NULL);
-	sbi_setTimer(csr_read(time) + timer_common.interval);
+	return csr_read(time) / (TIMER_FREQ / 1000);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Adapt initialization code, save boot hart ID in syspage, remove timer interrupts.

Needs changes in kernel to work
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `riscv64-generic-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/543
- [ ] I will merge this PR by myself when appropriate.
