### PR TITLE
cmd: Add blob command

### DIFF
--- a/cmds/Makefile
+++ b/cmds/Makefile
@@ -6,8 +6,8 @@
 # %LICENSE%
 #
 
-PLO_ALLCOMMANDS = alias app bankswitch bitstream bootcm4 bootrom call console copy dump \
-  echo erase go help jffs2 kernel kernelimg lspci map mem mpu otp phfs reboot script \
+PLO_ALLCOMMANDS = alias app blob bankswitch bitstream bootcm4 bootrom call console copy \
+  dump echo erase go help jffs2 kernel kernelimg lspci map mem mpu otp phfs reboot script \
   test-dev test-ddr wait
 
 PLO_COMMANDS ?= $(PLO_ALLCOMMANDS)

--- a/cmds/app.c
+++ b/cmds/app.c
@@ -6,7 +6,7 @@
  * Load application
  *
  * Copyright 2020-2021 Phoenix Systems
- * Author: Hubert Buczynski, Gerard Swiderski
+ * Author: Hubert Buczynski, Gerard Swiderski, Aleksander Kaminski
  *
  * This file is part of Phoenix-RTOS.
  *

--- a/cmds/blob.c
+++ b/cmds/blob.c
@@ -1,0 +1,170 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system loader
+ *
+ * Load application
+ *
+ * Copyright 2020-2021, 2024 Phoenix Systems
+ * Author: Hubert Buczynski, Gerard Swiderski, Aleksander Kaminski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#include "cmd.h"
+
+#include <lib/lib.h>
+#include <hal/hal.h>
+#include <phfs/phfs.h>
+#include <syspage.h>
+
+
+static void cmd_blobInfo(void)
+{
+	lib_printf("put file in the syspage, usage: blob [<dev> <name> <map>]");
+}
+
+static int cmd_cp2ent(handler_t handler, const mapent_t *entry)
+{
+	ssize_t len;
+	u8 buff[SIZE_MSG_BUFF];
+	size_t offs, sz = entry->end - entry->start;
+
+	for (offs = 0; offs < sz; offs += len) {
+		len = phfs_read(handler, offs, buff, min(SIZE_MSG_BUFF, sz - offs));
+		if (len < 0) {
+			log_error("\nCan't read data");
+			return len;
+		}
+		hal_memcpy((void *)(entry->start + offs), buff, len);
+	}
+
+	return EOK;
+}
+
+static int cmd_blobLoad(handler_t handler, size_t size, const char *name, const char *map)
+{
+	int res;
+
+	unsigned int attr;
+	addr_t start, end, offs, addr;
+
+	syspage_prog_t *prog;
+	const mapent_t *entry;
+
+	if (phfs_aliasAddrResolve(handler, &offs) < 0) {
+		offs = 0;
+	}
+
+	if (syspage_mapAttrResolve(map, &attr) < 0 ||
+			syspage_mapRangeResolve(map, &start, &end) < 0) {
+		log_error("\n%s does not exist", map);
+		return -EINVAL;
+	}
+
+	/* Check whether map's range coincides with device's address space */
+	res = phfs_map(handler, offs, size, mAttrRead, start, end - start, attr, &addr);
+	if (res < 0) {
+		log_error("\nDevice is not mappable in %s", map);
+		return res;
+	}
+
+	if (res == dev_isMappable) {
+		entry = syspage_entryAdd(NULL, addr + offs, size, SIZE_PAGE);
+		if (entry == NULL) {
+			log_error("\nCannot allocate memory for %s", name);
+			return -ENOMEM;
+		}
+	}
+	else if (res == dev_isNotMappable) {
+		entry = syspage_entryAdd(map, (addr_t)-1, size, SIZE_PAGE);
+		if (entry == NULL) {
+			log_error("\nCannot allocate memory for %s", name);
+			return -ENOMEM;
+		}
+
+		/* Copy file to the selected entry */
+		res = cmd_cp2ent(handler, entry);
+		if (res < 0) {
+			return res;
+		}
+	}
+	else {
+		log_error("\nDevice mappable routine failed");
+		return -ENOMEM;
+	}
+
+	prog = syspage_progAdd(name, 0);
+	if (prog == NULL) {
+		log_error("\nCannot add syspage program for %s", name);
+	}
+
+	prog->imaps = NULL;
+	prog->imapSz = 0;
+	prog->dmaps = NULL;
+	prog->dmapSz = 0;
+	prog->start = entry->start;
+	prog->end = entry->end;
+
+	return EOK;
+}
+
+
+static int cmd_blob(int argc, char *argv[])
+{
+	int res;
+	const char *dev;
+	const char *name;
+	const char *map;
+
+	handler_t handler;
+	phfs_stat_t stat;
+
+	/* Parse command arguments */
+	if (argc == 1) {
+		syspage_progShow();
+		return CMD_EXIT_SUCCESS;
+	}
+	if (argc != 4) {
+		log_error("\n%s: Wrong argument count", argv[0]);
+		return CMD_EXIT_FAILURE;
+	}
+
+	dev = argv[1];
+	name = argv[2];
+	map = argv[3];
+
+	/* Open file */
+	res = phfs_open(dev, name, 0, &handler);
+	if (res < 0) {
+		log_error("\nCan't open %s on %s (%d)", name, dev, res);
+		return CMD_EXIT_FAILURE;
+	}
+
+	/* Get file's properties */
+	res = phfs_stat(handler, &stat);
+	if (res < 0) {
+		log_error("\nCan't get stat from %s (%d)", name, res);
+		phfs_close(handler);
+		return CMD_EXIT_FAILURE;
+	}
+
+	res = cmd_blobLoad(handler, stat.size, name, map);
+	if (res < 0) {
+		log_error("\nCan't load %s to %s via %s (%d)", name, map, dev, res);
+		phfs_close(handler);
+		return CMD_EXIT_FAILURE;
+	}
+
+	log_info("\nLoaded %s", name);
+	phfs_close(handler);
+
+	return CMD_EXIT_SUCCESS;
+}
+
+
+static const cmd_t blob_cmd __attribute__((section("commands"), used)) = {
+	.name = "blob", .run = cmd_blob, .info = cmd_blobInfo
+};

--- a/hal/armv7a/imx6ull/Makefile
+++ b/hal/armv7a/imx6ull/Makefile
@@ -18,7 +18,7 @@ CFLAGS:=$(filter-out -mfpu% , $(CFLAGS))
 
 CFLAGS += -DVADDR_KERNEL_INIT=$(VADDR_KERNEL_INIT)
 
-PLO_COMMANDS ?= alias app call console copy dump echo erase go help jffs2 kernel map mem phfs script \
+PLO_COMMANDS ?= alias app blob call console copy dump echo erase go help jffs2 kernel map mem phfs script \
   test-dev test-ddr wait
 
 PLO_ALLDEVICES := nand-imx6ull flash-imx6ull uart-imx6ull usbc-cdc

--- a/hal/armv7a/zynq7000/Makefile
+++ b/hal/armv7a/zynq7000/Makefile
@@ -14,7 +14,7 @@ CFLAGS := $(filter-out -mfpu% , $(CFLAGS))
 
 CFLAGS += -DVADDR_KERNEL_INIT=$(VADDR_KERNEL_INIT)
 
-PLO_COMMANDS ?= alias app bitstream call console copy dump echo erase go help jffs2 kernel map mem \
+PLO_COMMANDS ?= alias app blob bitstream call console copy dump echo erase go help jffs2 kernel map mem \
   phfs reboot script test-ddr test-dev wait
 
 PLO_ALLDEVICES := gpio-zynq7000 usbc-cdc uart-zynq7000 flash-zynq7000 sdcard-zynq7000

--- a/hal/armv7m/imxrt/10xx/105x/Makefile
+++ b/hal/armv7m/imxrt/10xx/105x/Makefile
@@ -12,7 +12,7 @@ LDFLAGS:=$(filter-out -Tdata% , $(LDFLAGS))
 CFLAGS:=$(filter-out -mfloat-abi% , $(CFLAGS))
 CFLAGS+= -mfloat-abi=soft
 
-PLO_COMMANDS ?= alias app call console copy dump echo erase go help kernel kernelimg map \
+PLO_COMMANDS ?= alias app blob call console copy dump echo erase go help kernel kernelimg map \
   mem mpu otp phfs reboot script wait
 
 # pipe-rtt is disabled due to small amount of space in DTCM; RTT_ADDR is not defined for this architecture

--- a/hal/armv7m/imxrt/10xx/106x/Makefile
+++ b/hal/armv7m/imxrt/10xx/106x/Makefile
@@ -12,7 +12,7 @@ LDFLAGS:=$(filter-out -Tdata% , $(LDFLAGS))
 CFLAGS:=$(filter-out -mfloat-abi% , $(CFLAGS))
 CFLAGS+= -mfloat-abi=soft
 
-PLO_COMMANDS ?= alias app bootrom call console copy dump echo erase go help kernel kernelimg map \
+PLO_COMMANDS ?= alias app bootrom blob call console copy dump echo erase go help kernel kernelimg map \
   mem mpu otp phfs reboot script wait
 
 PLO_ALLDEVICES := pipe-rtt usbc-cdc uart-imxrt106x flash-imxrt

--- a/hal/armv7m/imxrt/117x/Makefile
+++ b/hal/armv7m/imxrt/117x/Makefile
@@ -12,7 +12,7 @@ LDFLAGS := $(filter-out -Tdata% , $(LDFLAGS))
 CFLAGS := $(filter-out -mfloat-abi% , $(CFLAGS))
 CFLAGS += -mfloat-abi=soft
 
-PLO_COMMANDS ?= alias app bootcm4 bootrom call console copy dump echo erase go help kernel kernelimg \
+PLO_COMMANDS ?= alias app blob bootcm4 bootrom call console copy dump echo erase go help kernel kernelimg \
   map mem mpu otp phfs reboot script wait
 
 PLO_ALLDEVICES := pipe-rtt usbc-cdc uart-imxrt117x flash-imxrt

--- a/hal/armv7m/stm32/l4/Makefile
+++ b/hal/armv7m/stm32/l4/Makefile
@@ -12,7 +12,7 @@ LDFLAGS := $(filter-out -Tdata% , $(LDFLAGS))
 CFLAGS := $(filter-out -mfloat-abi% , $(CFLAGS))
 CFLAGS += -mfloat-abi=soft
 
-PLO_COMMANDS ?= alias app bankswitch call console copy dump echo go help kernelimg map mem mpu \
+PLO_COMMANDS ?= alias app bankswitch blob call console copy dump echo go help kernelimg map mem mpu \
   phfs reboot script wait
 
 PLO_ALLDEVICES := pipe-rtt uart-stm32l4x6 flash-stm32 ram-storage

--- a/hal/armv8m/nrf/91/Makefile
+++ b/hal/armv8m/nrf/91/Makefile
@@ -12,7 +12,7 @@ LDFLAGS := $(filter-out -Tdata% , $(LDFLAGS))
 CFLAGS := $(filter-out -mfloat-abi% , $(CFLAGS))
 CFLAGS += -mfloat-abi=soft
 
-PLO_COMMANDS ?= alias app call console copy dump echo go help kernel kernelimg map mem phfs \
+PLO_COMMANDS ?= alias app blob call console copy dump echo go help kernel kernelimg map mem phfs \
   reboot script wait
 
 PLO_ALLDEVICES := uart-nrf9160 flash-nrf9160

--- a/hal/ia32/Makefile
+++ b/hal/ia32/Makefile
@@ -9,7 +9,7 @@
 CFLAGS += -DVADDR_KERNEL_BASE=$(VADDR_KERNEL_BASE)
 CFLAGS += -Ihal/ia32
 
-PLO_COMMANDS ?= alias app call console copy dump echo go help kernel lspci map mem phfs script reboot syspage wait
+PLO_COMMANDS ?= alias app blob call console copy dump echo go help kernel lspci map mem phfs script reboot syspage wait
 
 PLO_ALLDEVICES := disk-bios tty-bios uart-16550
 

--- a/hal/riscv64/generic/Makefile
+++ b/hal/riscv64/generic/Makefile
@@ -10,7 +10,7 @@ CFLAGS += -DVADDR_KERNEL_INIT=$(VADDR_KERNEL_INIT)
 
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
 
-PLO_COMMANDS ?= alias app call console copy dump echo go help kernel map mem phfs reboot script wait
+PLO_COMMANDS ?= alias app blob call console copy dump echo go help kernel map mem phfs reboot script wait
 
 # tty-spike and uart-16550 registers under same major
 PLO_ALLDEVICES := ram-storage tty-spike uart-16550

--- a/hal/sparcv8leon3/gaisler/gr712rc/Makefile
+++ b/hal/sparcv8leon3/gaisler/gr712rc/Makefile
@@ -8,7 +8,7 @@
 
 CFLAGS += -DVADDR_KERNEL_INIT=$(VADDR_KERNEL_INIT)
 
-PLO_COMMANDS ?= alias app call console copy dump echo go help jffs2 kernel map mem phfs reboot script wait test-dev
+PLO_COMMANDS ?= alias app blob call console copy dump echo go help jffs2 kernel map mem phfs reboot script wait test-dev
 
 PLO_ALLDEVICES := uart-grlib flash-gr712rc
 

--- a/hal/sparcv8leon3/gaisler/gr716/Makefile
+++ b/hal/sparcv8leon3/gaisler/gr716/Makefile
@@ -14,7 +14,7 @@ LDFLAGS:=$(filter-out -Wl$(comma)--section-start% , $(LDFLAGS))
 
 CFLAGS += -DVADDR_KERNEL_INIT=$(VADDR_KERNEL_INIT)
 
-PLO_COMMANDS ?= alias app call console copy dump echo go help kernel map mem phfs reboot script wait
+PLO_COMMANDS ?= alias app blob call console copy dump echo go help kernel map mem phfs reboot script wait
 
 PLO_ALLDEVICES := gpio-gr716 uart-grlib flash-gr716
 


### PR DESCRIPTION
This command allows to pass any binary blob to the kernel as a syspage program. Kernel might be unable to execute it of course, but it will not try to, unless asked to do it (i.e. -x flag is not present for blob in the syspage).

Blob can be placed in any memory map, it will be copied by the plo to the destination map, if source != dest.

DONE: NIL-571

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Building scripts need modification for this cmd to be usable. Example modification:

```
diff --git a/_targets/build.common b/_targets/build.common
index 2ddc966..2318bb1 100644
--- a/_targets/build.common
+++ b/_targets/build.common
@@ -69,6 +69,14 @@ b_mkscript_user() {
                                        ((poffs+=(psz + SIZE_PAGE - 1) & PAGE_MASK))
                                        printf "%s\n" "$cmd";;
 
+                               blob)
+                                       name=${args[2]%%;*}
+                                       PROGS+=("$name")
+                                       psz=$(wc -c < "$name")
+                                       printf "alias%s %s 0x%x 0x%x\n" "$RELATIVE_ALIAS" "$name" "$poffs" "$psz"
+                                       ((poffs+=(psz + SIZE_PAGE - 1) & PAGE_MASK))
+                                       printf "%s\n" "$cmd";;
+
                                kernel)
                                        printf "alias%s %s 0x%x 0x%x\n" "$RELATIVE_ALIAS" "${KERNEL_FILE}" "$KERNEL_OFFS" "$ksz"
                                        printf "%s\n" "$cmd";;

```
Usage: add blob command to the user script, example:

```
diff --git a/_targets/build.project.armv7m4-stm32l4x6 b/_targets/build.project.armv7m4-stm32l4x6
index c0bf5fa..9e794be 100644
--- a/_targets/build.project.armv7m4-stm32l4x6
+++ b/_targets/build.project.armv7m4-stm32l4x6
@@ -70,6 +70,7 @@ USER_SCRIPT=(
        "kernelimg ${BOOT_DEVICE}"
        "app ${BOOT_DEVICE} -x stm32l4-multi flash0 ram"
        "app ${BOOT_DEVICE} -x psh flash0 ram"
+       "blob ${BOOT_DEVICE} blob ram"
```

blob will appear in the /syspage/ dir on the target and be usable as a read-only dummyfs file.
blob file will have execute flag set by the dummyfs, but it doesn't hurt anything, I guess

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32l4).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
