### PR TITLE
zynq7000: initialize all CPUs

### DIFF
--- a/hal/armv7a/zynq7000/_init.S
+++ b/hal/armv7a/zynq7000/_init.S
@@ -23,6 +23,7 @@
 .section .init, "ax"
 .globl _vector_table
 
+.extern syspage_common
 
 .global _start
 .type _start, %function
@@ -45,19 +46,10 @@ _vector_table:
 _start:
 	cpsid aif, #SYS_MODE
 
-	/* Only CPU0 performs initialization, others go into wfi */
-	mrc p15, 0, r1, c0, c0, 5       /* Read Multiprocessor Affinity Register */
-	and r1, r1, #0xf                /* Extract CPU ID                        */
-	cmp r1, #0
-	beq initialize
+	/* Set Vector Table Address */
+	ldr	r0, =_vector_table
+	mcr	p15, 0, r0, c12, c0, 0       /* Write to VBAR (Vector Base Address Register) */
 
-/* TODO: make appropriate action when other core than CPU_0 is running */
-wait_loop:
-	wfi
-	b wait_loop
-
-
-initialize:
 	/* Enable PMU */
 	mrc p15, 0, r0, c9, c12, 0       /* Read PMCR (Performance Monitor Control Register)  */
 	orr r0, #0x7                     /* Cycle counter reset - bit[2], Performance counter reset - bit[1], enable all counters - bit[0] */
@@ -101,10 +93,35 @@ set_loop:
 	cmp r1, #4                       /* Check whether last way was reached               */
 	bne way_loop
 
-
 	/* Invalidate TLB */
 	mcr p15, 0, r1, c8, c7, 0
 
+	/* Enable SMP */
+	mrc p15, 0, r1, c1, c0, 1
+	orr r1, r1, #(1 << 6)
+	mcr p15, 0, r1, c1, c0, 1
+
+	/* CPU 0 continues initialization, other cores wait for the signal to continue */
+	mrc p15, 0, r1, c0, c0, 5       /* Read Multiprocessor Affinity Register */
+	ands r1, r1, #0xf               /* Extract CPU ID                        */
+	beq initialize
+
+/*
+	Important: the code below ONLY runs on QEMU. On real Zynq 7000 Boot ROM loads code into
+	high OCRAM and then jumps CPU 1 to that code. The code below simulates the behavior of that code.
+ */
+	mov r0, #0xfffffff0
+	ldr r1, =load_again
+	str r1, [r0]
+load_again:
+	dsb
+	wfe
+	ldr lr, [r0]
+	cmp lr, r1
+	beq load_again
+	bx	lr
+
+initialize:
 	/* Enable L1 Caches */
 	mrc p15, 0, r1, c1, c0, 0         /* Read SCTLR (System Control Register) data  */
 	orr r1, r1, #(0x1 << 2)           /* Enable data cache                          */
@@ -114,11 +131,6 @@ set_loop:
 	mcr p15, 0, r1, c1, c0, 0         /* Write SCTLR (System Control Register) data */
 	dsb
 	isb
-
-	/* Set Vector Table Address */
-	ldr	r0, =_vector_table
-	mcr	p15, 0, r0, c12, c0, 0       /* Write to VBAR (Vector Base Address Register) */
-
 
 	/* Setup initial SP */
 	ldr r0, =_stack
@@ -158,6 +170,21 @@ set_loop:
 	ldr r8, =_startc
 	bx r8
 .size _start, .-_start
+
+.globl hal_coreStart
+.type hal_coreStart, %function
+hal_coreStart:
+	/* Enable SMP */
+	mrc p15, 0, r9, c1, c0, 1
+	orr r9, r9, #(1 << 6)
+	mcr p15, 0, r9, c1, c0, 1
+
+	ldr r9, =syspage_common
+	ldr r9, [r9]
+	ldr r8, [r9, #8] /* Jump to kernel */
+	bx r8
+.size hal_coreStart, .-hal_coreStart
+.ltorg
 
 
 #include "../_interrupts.S"


### PR DESCRIPTION
This change allows all CPU cores to jump into kernel on zynq7000 (both real hardware and QEMU).

## Description
The procedure of starting other CPU cores on zynq7000 is substantially different on QEMU and real hardware. On QEMU both cores jump to start of PLO code. On real hardware boot ROM parks CPU 1 in a small bit of code in high OCRAM that monitors memory address `0xfffffff0` and sleeps using `wfe`. In order to achieve the same behavior on QEMU code was added into `_init.S` that parks all other CPU cores in the same fashion.

After change CPU 0 signals other cores that they should jump to kernel before jumping to kernel itself.

## Motivation and Context
Required to allow use of SMP kernel on zynq7000.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a9-zynq7000-zturn, armv7a9-zynq7000-qemu

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
