### PR TITLE
imxrt-flash/imxrt117x: enable second flash memory & bug fixes

### DIFF
--- a/devices/flash-imxrt/flashdrv.c
+++ b/devices/flash-imxrt/flashdrv.c
@@ -51,16 +51,11 @@ static inline int minorToPortMask(unsigned int minor)
 {
 	switch (minor) {
 		case 0:
-			return flexspi_slBusA1;
+			return FLEXSPI1_PORT_MASK;
 
-#if defined(__CPU_IMXRT106X)
+#if defined(__CPU_IMXRT106X) || defined(__CPU_IMXRT117X)
 		case 1:
-			return flexspi_slBusA1;
-#endif
-
-#if defined(__CPU_IMXRT117X)
-		case 1:
-			return flexspi_slBusA1 | flexspi_slBusA2;
+			return FLEXSPI2_PORT_MASK;
 #endif
 
 		default:

--- a/devices/flash-imxrt/fspi/fspi_rt106x.h
+++ b/devices/flash-imxrt/fspi/fspi_rt106x.h
@@ -119,7 +119,7 @@ __attribute__((section(".noxip"))) static int flexspi_pinConfig(flexspi_t *fspi)
 		}
 
 		if (pin[i].mux >= 0) {
-			_imxrt_setIOmux(pin[i].mux, pin[i].mode, 1); /* sion is enabled */
+			_imxrt_setIOmux(pin[i].mux, 1, pin[i].mode); /* sion is enabled */
 		}
 
 		if (pin[i].pad >= 0) {

--- a/devices/flash-imxrt/fspi/fspi_rt117x.h
+++ b/devices/flash-imxrt/fspi/fspi_rt117x.h
@@ -55,14 +55,14 @@ static void *flexspi_getBase(int instance)
 
 __attribute__((section(".noxip"))) static void flexspi_clockConfig(flexspi_t *fspi)
 {
-	int gate, clk, div, mux, mfd, mfn, state;
+	int gate, clk, div, mux, mfd, mfn;
 
 	switch (fspi->instance) {
 		case flexspi_instance1:
 			clk = pctl_clk_flexspi1;
 			gate = pctl_lpcg_flexspi1;
-			div = 3; /* SYS_PLL2_CLK / (3 + 1) => 132 MHz */
-			mux = 5; /* Select main clock: SYS_PLL2_CLK = 528 MHz */
+			div = 3;                               /* SYS_PLL2_CLK / (3 + 1) => 132 MHz */
+			mux = mux_clkroot_flexspi1_syspll2out; /* Select main clock: SYS_PLL2_CLK = 528 MHz */
 			mfd = 0;
 			mfn = 0;
 			break;
@@ -70,8 +70,10 @@ __attribute__((section(".noxip"))) static void flexspi_clockConfig(flexspi_t *fs
 		case flexspi_instance2:
 			clk = pctl_clk_flexspi2;
 			gate = pctl_lpcg_flexspi2;
-			/* Copy defaults */
-			_imxrt_getDevClock(clk, &div, &mux, &mfd, &mfn, &state);
+			div = 3;                               /* SYS_PLL2_CLK / (3 + 1) => 132 MHz */
+			mux = mux_clkroot_flexspi2_syspll2out; /* Select main clock: SYS_PLL2_CLK = 528 MHz */
+			mfd = 0;
+			mfn = 0;
 			break;
 
 		default:
@@ -95,9 +97,9 @@ __attribute__((section(".noxip"))) static int flexspi_pinConfig(flexspi_t *fspi)
 		int pad;
 	} pin[] = {
 		/* FlexSPI-1 A1/A2 */
+		{ (flexspi_instance1 << 8) | flexspi_slBusA1, -1, -1, pctl_mux_gpio_sd_b2_06, 1, pctl_pad_gpio_sd_b2_06 },                                         /* SS0 */
 		{ (flexspi_instance1 << 8) | flexspi_slBusA2, -1, -1, pctl_mux_gpio_sd_b2_04, 3, pctl_pad_gpio_sd_b2_04 },                                         /* SS1 */
 		{ (flexspi_instance1 << 8) | flexspi_slBusA1 | flexspi_slBusA2, pctl_isel_flexspi1_dqs_fa, 2, pctl_mux_gpio_sd_b2_05, 1, pctl_pad_gpio_sd_b2_05 }, /* DQS */
-		{ (flexspi_instance1 << 8) | flexspi_slBusA1, -1, -1, pctl_mux_gpio_sd_b2_06, 1, pctl_pad_gpio_sd_b2_06 },                                         /* SS0 */
 		{ (flexspi_instance1 << 8) | flexspi_slBusA1 | flexspi_slBusA2, pctl_isel_flexspi1_sck_fa, 1, pctl_mux_gpio_sd_b2_07, 1, pctl_pad_gpio_sd_b2_07 }, /* SCLK */
 		{ (flexspi_instance1 << 8) | flexspi_slBusA1 | flexspi_slBusA2, pctl_isel_flexspi1_fa_0, 1, pctl_mux_gpio_sd_b2_08, 1, pctl_pad_gpio_sd_b2_08 },   /* D0 */
 		{ (flexspi_instance1 << 8) | flexspi_slBusA1 | flexspi_slBusA2, pctl_isel_flexspi1_fa_1, 1, pctl_mux_gpio_sd_b2_09, 1, pctl_pad_gpio_sd_b2_09 },   /* D1 */
@@ -105,16 +107,20 @@ __attribute__((section(".noxip"))) static int flexspi_pinConfig(flexspi_t *fspi)
 		{ (flexspi_instance1 << 8) | flexspi_slBusA1 | flexspi_slBusA2, pctl_isel_flexspi1_fa_3, 1, pctl_mux_gpio_sd_b2_11, 1, pctl_pad_gpio_sd_b2_11 },   /* D3 */
 
 		/* FlesSPI-1 B1/B2 */
+		{ (flexspi_instance1 << 8) | flexspi_slBusB1, -1, -1, pctl_mux_gpio_sd_b1_04, 8, pctl_pad_gpio_sd_b1_04 },                                         /* SS0 */
+		{ (flexspi_instance1 << 8) | flexspi_slBusB2, -1, -1, pctl_mux_gpio_sd_b1_03, 9, pctl_pad_gpio_sd_b1_03 },                                         /* SS1 */
 		{ (flexspi_instance1 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_sd_b1_05, 8, pctl_pad_gpio_sd_b1_05 },                       /* DQS */
 		{ (flexspi_instance1 << 8) | flexspi_slBusB1 | flexspi_slBusB2, pctl_isel_flexspi1_sck_fb, 1, pctl_mux_gpio_sd_b2_04, 1, pctl_pad_gpio_sd_b2_04 }, /* SCLK */
-		{ (flexspi_instance1 << 8) | flexspi_slBusB1, -1, -1, pctl_mux_gpio_sd_b2_05, 3, pctl_pad_gpio_sd_b2_05 },                                         /* SS0 */
-		{ (flexspi_instance1 << 8) | flexspi_slBusB2, -1, -1, pctl_mux_gpio_sd_b1_03, 9, pctl_pad_gpio_sd_b1_03 },                                         /* SS1 */
 		{ (flexspi_instance1 << 8) | flexspi_slBusB1 | flexspi_slBusB2, pctl_isel_flexspi1_fb_0, 1, pctl_mux_gpio_sd_b2_03, 1, pctl_pad_gpio_sd_b2_03 },   /* D0 */
 		{ (flexspi_instance1 << 8) | flexspi_slBusB1 | flexspi_slBusB2, pctl_isel_flexspi1_fb_1, 1, pctl_mux_gpio_sd_b2_02, 1, pctl_pad_gpio_sd_b2_02 },   /* D1 */
 		{ (flexspi_instance1 << 8) | flexspi_slBusB1 | flexspi_slBusB2, pctl_isel_flexspi1_fb_2, 1, pctl_mux_gpio_sd_b2_01, 1, pctl_pad_gpio_sd_b2_01 },   /* D2 */
 		{ (flexspi_instance1 << 8) | flexspi_slBusB1 | flexspi_slBusB2, pctl_isel_flexspi1_fb_3, 1, pctl_mux_gpio_sd_b2_00, 1, pctl_pad_gpio_sd_b2_00 },   /* D3 */
 
-		/* FlexSPI-2 A1/B2 */
+		/* FlexSPI-2 A1/A2 */
+		{ (flexspi_instance2 << 8) | flexspi_slBusA1, -1, -1, pctl_mux_gpio_emc_b2_11, 4, pctl_pad_gpio_emc_b2_11 },                                         /* SS0 */
+		{ (flexspi_instance2 << 8) | flexspi_slBusA2, -1, -1, pctl_mux_gpio_ad_01, 9, pctl_pad_gpio_ad_01 },                                                 /* SS1 */
+		{ (flexspi_instance2 << 8) | flexspi_slBusA1 | flexspi_slBusA2, -1, -1, pctl_mux_gpio_emc_b2_12, 4, pctl_pad_gpio_emc_b2_12 },                       /* DQS */
+		{ (flexspi_instance2 << 8) | flexspi_slBusA1 | flexspi_slBusA2, pctl_isel_flexspi2_sck_fa, 0, pctl_mux_gpio_emc_b2_10, 4, pctl_pad_gpio_emc_b2_10 }, /* SCLK */
 		{ (flexspi_instance2 << 8) | flexspi_slBusA1 | flexspi_slBusA2, pctl_isel_flexspi2_fa_0, 0, pctl_mux_gpio_emc_b2_13, 4, pctl_pad_gpio_emc_b2_13 },   /* D0 */
 		{ (flexspi_instance2 << 8) | flexspi_slBusA1 | flexspi_slBusA2, pctl_isel_flexspi2_fa_1, 0, pctl_mux_gpio_emc_b2_14, 4, pctl_pad_gpio_emc_b2_14 },   /* D1 */
 		{ (flexspi_instance2 << 8) | flexspi_slBusA1 | flexspi_slBusA2, pctl_isel_flexspi2_fa_2, 0, pctl_mux_gpio_emc_b2_15, 4, pctl_pad_gpio_emc_b2_15 },   /* D2 */
@@ -123,41 +129,42 @@ __attribute__((section(".noxip"))) static int flexspi_pinConfig(flexspi_t *fspi)
 		{ (flexspi_instance2 << 8) | flexspi_slBusA1 | flexspi_slBusA2, -1, -1, pctl_mux_gpio_emc_b2_18, 4, pctl_pad_gpio_emc_b2_18 },                       /* D5 */
 		{ (flexspi_instance2 << 8) | flexspi_slBusA1 | flexspi_slBusA2, -1, -1, pctl_mux_gpio_emc_b2_19, 4, pctl_pad_gpio_emc_b2_19 },                       /* D6 */
 		{ (flexspi_instance2 << 8) | flexspi_slBusA1 | flexspi_slBusA2, -1, -1, pctl_mux_gpio_emc_b2_20, 4, pctl_pad_gpio_emc_b2_20 },                       /* D7 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusA1 | flexspi_slBusA2, -1, -1, pctl_mux_gpio_emc_b2_12, 4, pctl_pad_gpio_emc_b2_12 },                       /* DQS */
-		{ (flexspi_instance2 << 8) | flexspi_slBusA1 | flexspi_slBusA2, pctl_isel_flexspi2_sck_fa, 0, pctl_mux_gpio_emc_b2_10, 4, pctl_pad_gpio_emc_b2_10 }, /* SCLK */
-		{ (flexspi_instance2 << 8) | flexspi_slBusA1, -1, -1, pctl_mux_gpio_emc_b2_11, 4, pctl_pad_gpio_emc_b2_11 },                                         /* SS0 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusA2, -1, -1, pctl_mux_gpio_ad_01, 9, pctl_pad_gpio_ad_01 },                                                 /* SS1 */
 
 		/* FlexSPI-2 B1/B2 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_06, 4, pctl_pad_gpio_emc_b2_07 }, /* D0 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_05, 4, pctl_pad_gpio_emc_b2_06 }, /* D1 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_04, 4, pctl_pad_gpio_emc_b2_05 }, /* D2 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_03, 4, pctl_pad_gpio_emc_b2_04 }, /* D3 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_02, 4, pctl_pad_gpio_emc_b2_03 }, /* D4 */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB1, -1, -1, pctl_mux_gpio_emc_b2_08, 4, pctl_pad_gpio_emc_b2_08 },                   /* SS0 */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB2, -1, -1, pctl_mux_gpio_ad_00, 9, pctl_pad_gpio_ad_00 },                           /* SS1 */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_07, 4, pctl_pad_gpio_emc_b2_07 }, /* DQS */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_09, 4, pctl_pad_gpio_emc_b2_09 }, /* SCLK */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_06, 4, pctl_pad_gpio_emc_b2_06 }, /* D0 */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_05, 4, pctl_pad_gpio_emc_b2_05 }, /* D1 */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_04, 4, pctl_pad_gpio_emc_b2_04 }, /* D2 */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_03, 4, pctl_pad_gpio_emc_b2_03 }, /* D3 */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_02, 4, pctl_pad_gpio_emc_b2_02 }, /* D4 */
 		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_01, 4, pctl_pad_gpio_emc_b2_01 }, /* D5 */
 		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_00, 4, pctl_pad_gpio_emc_b2_00 }, /* D6 */
 		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b1_41, 4, pctl_pad_gpio_emc_b1_41 }, /* D7 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_sd_b2_07, 8, pctl_pad_gpio_sd_b2_07 },   /* DQS */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_09, 4, pctl_pad_gpio_emc_b2_09 }, /* SCLK */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1, -1, -1, pctl_mux_gpio_emc_b2_08, 4, pctl_pad_gpio_emc_b2_08 },                   /* SS0 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB2, -1, -1, pctl_mux_gpio_ad_00, 9, pctl_pad_gpio_ad_00 },                           /* SS1 */
 	};
 
 	for (i = 0, done = 0; i < sizeof(pin) / sizeof(pin[0]); ++i) {
-		if ((pin[i].devMask & ((1 << (fspi->instance - 1)) << 8)) == 0)
+		if ((pin[i].devMask & ((1 << (fspi->instance - 1)) << 8)) == 0) {
 			continue;
+		}
 
-		if ((pin[i].devMask & fspi->slPortMask) == 0)
+		if ((pin[i].devMask & fspi->slPortMask) == 0) {
 			continue;
+		}
 
-		if (pin[i].isel >= 0)
+		if (pin[i].isel >= 0) {
 			_imxrt_setIOisel(pin[i].isel, pin[i].daisy);
+		}
 
-		if (pin[i].mux >= 0)
-			_imxrt_setIOmux(pin[i].mux, pin[i].mode, 1); /* sion is enabled */
+		if (pin[i].mux >= 0) {
+			_imxrt_setIOmux(pin[i].mux, 1, pin[i].mode); /* sion is enabled */
+		}
 
-		if (pin[i].pad >= 0)
+		if (pin[i].pad >= 0) {
 			_imxrt_setIOpad(pin[i].pad, 0, 1, 0, 1, 0, 0);
+		}
 
 		done++;
 	}

--- a/devices/flash-imxrt/nor/nor.c
+++ b/devices/flash-imxrt/nor/nor.c
@@ -293,7 +293,7 @@ int nor_probe(flexspi_t *fspi, u8 port, const struct nor_info **pInfo, const cha
 
 	res = -ENXIO;
 
-	lib_printf("\ndev/flash/nor: Probing flash id 0x%08x", jedecId);
+	lib_printf("\ndev/flash/nor: Probing flash id 0x%08x on port %d.%d", jedecId, fspi->instance, port);
 
 	for (i = 0; i < sizeof(flashInfo) / sizeof(flashInfo[0]); ++i) {
 		if (flashInfo[i].jedecId == jedecId) {

--- a/hal/armv7m/imxrt/10xx/105x/peripherals.h
+++ b/hal/armv7m/imxrt/10xx/105x/peripherals.h
@@ -17,6 +17,8 @@
 #ifndef _PERIPHERALS_H_
 #define _PERIPHERALS_H_
 
+#include <board_config.h>
+
 /* Periperals configuration */
 
 /* Interrupts */
@@ -223,15 +225,15 @@
 
 /* FLASH */
 
-#define FLASH_NO                  FLASH_FLEXSPI1_MOUNTED + FLASH_FLEXSPI2_MOUNTED
+#define FLASH_NO                  FLEXSPI_COUNT
 #define FLASH_DEFAULT_SECTOR_SIZE 0x1000
 
-#define FLASH_FLEXSPI1_MOUNTED   1
-#define FLASH_FLEXSPI1           0x60000000
-#define FLASH_SIZE_FLEXSPI1      0x10000000
-#define FLASH_FLEXSPI1_INSTANCE  0x0
-#define FLASH_FLEXSPI1_QSPI_FREQ 0xc0000008
+#ifndef FLEXSPI_COUNT
+#define FLEXSPI_COUNT 1
+#endif
 
-#define FLASH_FLEXSPI2_MOUNTED 0
+#ifndef FLEXSPI1_PORT_MASK
+#define FLEXSPI1_PORT_MASK flexspi_slBusA1
+#endif
 
 #endif

--- a/hal/armv7m/imxrt/10xx/106x/peripherals.h
+++ b/hal/armv7m/imxrt/10xx/106x/peripherals.h
@@ -17,6 +17,8 @@
 #ifndef _PERIPHERALS_H_
 #define _PERIPHERALS_H_
 
+#include <board_config.h>
+
 /* Periperals configuration */
 
 /* Interrupts */
@@ -253,19 +255,19 @@
 
 /* FLASH */
 
-#define FLASH_NO                  FLASH_FLEXSPI1_MOUNTED + FLASH_FLEXSPI2_MOUNTED
+#define FLASH_NO                  FLEXSPI_COUNT
 #define FLASH_DEFAULT_SECTOR_SIZE 0x1000
 
-#define FLASH_FLEXSPI1_MOUNTED   1
-#define FLASH_FLEXSPI1           0x60000000
-#define FLASH_SIZE_FLEXSPI1      0x10000000
-#define FLASH_FLEXSPI1_INSTANCE  0x0
-#define FLASH_FLEXSPI1_QSPI_FREQ 0xc0000008
+#ifndef FLEXSPI_COUNT
+#define FLEXSPI_COUNT 2
+#endif
 
-#define FLASH_FLEXSPI2_MOUNTED   1
-#define FLASH_FLEXSPI2           0x70000000
-#define FLASH_SIZE_FLEXSPI2      0x0f000000
-#define FLASH_FLEXSPI2_INSTANCE  0x1
-#define FLASH_FLEXSPI2_QSPI_FREQ 0xc0000008
+#ifndef FLEXSPI1_PORT_MASK
+#define FLEXSPI1_PORT_MASK flexspi_slBusA1
+#endif
+
+#ifndef FLEXSPI2_PORT_MASK
+#define FLEXSPI2_PORT_MASK flexspi_slBusA1
+#endif
 
 #endif

--- a/hal/armv7m/imxrt/117x/peripherals.h
+++ b/hal/armv7m/imxrt/117x/peripherals.h
@@ -17,6 +17,8 @@
 #ifndef _PERIPHERALS_H_
 #define _PERIPHERALS_H_
 
+#include <board_config.h>
+
 /* Periperals configuration */
 
 /* Interrupts */
@@ -247,20 +249,20 @@
 
 /* FLASH */
 
-#define FLASH_NO                  (FLASH_FLEXSPI1_MOUNTED + FLASH_FLEXSPI2_MOUNTED)
+#define FLASH_NO                  FLEXSPI_COUNT
 #define FLASH_DEFAULT_SECTOR_SIZE 0x1000
 
-#define FLASH_FLEXSPI1_MOUNTED   1
-#define FLASH_FLEXSPI1           0x30000000
-#define FLASH_SIZE_FLEXSPI1      0x10000000
-#define FLASH_FLEXSPI1_INSTANCE  0x1
-#define FLASH_FLEXSPI1_QSPI_FREQ 0xc0000007
+#ifndef FLEXSPI_COUNT
+#define FLEXSPI_COUNT 1
+#endif
 
-#define FLASH_FLEXSPI2_MOUNTED   0
-#define FLASH_FLEXSPI2           0x60000000
-#define FLASH_SIZE_FLEXSPI2      0x1f800000
-#define FLASH_FLEXSPI2_INSTANCE  0x2
-#define FLASH_FLEXSPI2_QSPI_FREQ 0xc0000007
+#ifndef FLEXSPI1_PORT_MASK
+#define FLEXSPI1_PORT_MASK flexspi_slBusA1
+#endif
+
+#ifndef FLEXSPI2_PORT_MASK
+#define FLEXSPI2_PORT_MASK (flexspi_slBusA1 | flexspi_slBusA2)
+#endif
 
 
 /* USB */


### PR DESCRIPTION
 - probe second flash memory on port B1
 - set FLEXSPI2 clock to 132 MHz
 - initial flash size fix
 - flexspi_getAddressByPort() fix
 - change FLEXSPI1 SS0 pin on port B1 to SD_B1_4 (SD_B2_05 is already used for DQS on port A1)
 - fix _imxrt_setIOmux() parameters (mode and sion were switched)
 - code style changes

JIRA: NIL-570

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1176).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
