### PR TITLE
imxrt-flash/rt1176: disable octobus on B1 but not B2

### DIFF
--- a/devices/flash-imxrt/fspi/fspi_rt117x.h
+++ b/devices/flash-imxrt/fspi/fspi_rt117x.h
@@ -5,7 +5,7 @@
  *
  * FlexSPI Controller driver (i.MX RT117x)
  *
- * Copyright 2021-2023 Phoenix Systems
+ * Copyright 2021-2024 Phoenix Systems
  * Author: Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
@@ -131,18 +131,18 @@ __attribute__((section(".noxip"))) static int flexspi_pinConfig(flexspi_t *fspi)
 		{ (flexspi_instance2 << 8) | flexspi_slBusA1 | flexspi_slBusA2, -1, -1, pctl_mux_gpio_emc_b2_20, 4, pctl_pad_gpio_emc_b2_20 },                       /* D7 */
 
 		/* FlexSPI-2 B1/B2 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1, -1, -1, pctl_mux_gpio_emc_b2_08, 4, pctl_pad_gpio_emc_b2_08 },                   /* SS0 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB2, -1, -1, pctl_mux_gpio_ad_00, 9, pctl_pad_gpio_ad_00 },                           /* SS1 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_07, 4, pctl_pad_gpio_emc_b2_07 }, /* DQS */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_09, 4, pctl_pad_gpio_emc_b2_09 }, /* SCLK */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_06, 4, pctl_pad_gpio_emc_b2_06 }, /* D0 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_05, 4, pctl_pad_gpio_emc_b2_05 }, /* D1 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_04, 4, pctl_pad_gpio_emc_b2_04 }, /* D2 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_03, 4, pctl_pad_gpio_emc_b2_03 }, /* D3 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_02, 4, pctl_pad_gpio_emc_b2_02 }, /* D4 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_01, 4, pctl_pad_gpio_emc_b2_01 }, /* D5 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_00, 4, pctl_pad_gpio_emc_b2_00 }, /* D6 */
-		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b1_41, 4, pctl_pad_gpio_emc_b1_41 }, /* D7 */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB1, -1, -1, pctl_mux_gpio_emc_b2_08, 4, pctl_pad_gpio_emc_b2_08 },                        /* SS0 */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB2, -1, -1, pctl_mux_gpio_ad_00, 9, pctl_pad_gpio_ad_00 },                                /* SS1 */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_07, 4, pctl_pad_gpio_emc_b2_07 },      /* DQS */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_09, 4, pctl_pad_gpio_emc_b2_09 },      /* SCLK */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_06, 4, pctl_pad_gpio_emc_b2_06 },      /* D0 */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_05, 4, pctl_pad_gpio_emc_b2_05 },      /* D1 */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_04, 4, pctl_pad_gpio_emc_b2_04 },      /* D2 */
+		{ (flexspi_instance2 << 8) | flexspi_slBusB1 | flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_03, 4, pctl_pad_gpio_emc_b2_03 },      /* D3 */
+		{ (flexspi_instance2 << 8) | /* flexspi_slBusB1 |*/ flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_02, 4, pctl_pad_gpio_emc_b2_02 }, /* D4 */
+		{ (flexspi_instance2 << 8) | /* flexspi_slBusB1 |*/ flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_01, 4, pctl_pad_gpio_emc_b2_01 }, /* D5 */
+		{ (flexspi_instance2 << 8) | /* flexspi_slBusB1 |*/ flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b2_00, 4, pctl_pad_gpio_emc_b2_00 }, /* D6 */
+		{ (flexspi_instance2 << 8) | /* flexspi_slBusB1 |*/ flexspi_slBusB2, -1, -1, pctl_mux_gpio_emc_b1_41, 4, pctl_pad_gpio_emc_b1_41 }, /* D7 */
 	};
 
 	for (i = 0, done = 0; i < sizeof(pin) / sizeof(pin[0]); ++i) {


### PR DESCRIPTION
## Description
<!--- Describe your changes shortly -->

Currently, we cannot use memory in octo-lane mode (in any existing project and including MIMXRT1170 evalkit) on the B1 bus. Using the FlexSPI2 B1 bus in internal project turns on the pins for the D4-D7 lines which are dangling/unconected and may pickup interference (EMI). This change disables the ability to use octo-lane memory on the B1 line, but leaves the possibility of using this type of memory in octo-lane mode on the B2 bus.

JIRA: NIL-539

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imxrt1176-nil`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
