### PR TITLE
imxrt-flash: fast read fix for ISSI NOR flash

### DIFF
--- a/devices/flash-imxrt/Makefile
+++ b/devices/flash-imxrt/Makefile
@@ -9,11 +9,11 @@
 FLEXSPI_OBJS := fspi/fspi.o
 
 ifneq (, $(findstring imxrt117x, $(TARGET_SUBFAMILY)))
-  FLEXSPI_OBJS += flashdrv.o nor/nor.o nor/nor_mx.o
+  FLEXSPI_OBJS += flashdrv.o nor/nor.o nor/nor_mx.o nor/nor_issi.o
 else ifneq (, $(findstring imxrt106x, $(TARGET_SUBFAMILY)))
-  FLEXSPI_OBJS += flashdrv.o nor/nor.o nor/nor_mx.o
+  FLEXSPI_OBJS += flashdrv.o nor/nor.o nor/nor_mx.o nor/nor_issi.o
 else ifneq (, $(findstring imxrt105x, $(TARGET_SUBFAMILY)))
-  FLEXSPI_OBJS += flashdrv.o nor/nor.o nor/nor_mx.o hyperbus/hyper.o
+  FLEXSPI_OBJS += flashdrv.o nor/nor.o nor/nor_mx.o nor/nor_issi.o hyperbus/hyper.o
 endif
 
 OBJS += $(addprefix $(PREFIX_O)devices/flash-imxrt/, $(FLEXSPI_OBJS))

--- a/devices/flash-imxrt/flashdrv.c
+++ b/devices/flash-imxrt/flashdrv.c
@@ -443,6 +443,8 @@ static int flashdrv_init(unsigned int minor)
 		flashSz[port] = dev->nor->totalSz;
 		flexspi_setFlashSize(&dev->fspi, flashSz, FLEXSPI_PORTS);
 
+		flexspi_postinit(&dev->fspi);
+
 		lib_printf("\ndev/flash/nor: Configured %s %s %dMB nor flash(%d.%d)",
 			vendor, dev->nor->name, dev->nor->totalSz >> 20, DEV_STORAGE, minor);
 

--- a/devices/flash-imxrt/fspi.h
+++ b/devices/flash-imxrt/fspi.h
@@ -82,6 +82,10 @@ struct xferOp {
 extern int flexspi_init(flexspi_t *fspi, int instance, u8 slPortMask);
 
 
+/* Post-initialize single FlexSPI module */
+extern int flexspi_postinit(flexspi_t *fspi);
+
+
 /* Safely deinit leaving XIP working */
 extern int flexspi_deinit(flexspi_t *fspi);
 

--- a/devices/flash-imxrt/fspi/fspi.c
+++ b/devices/flash-imxrt/fspi/fspi.c
@@ -139,7 +139,8 @@ __attribute__((section(".noxip"))) int flexspi_init(flexspi_t *fspi, int instanc
 	hal_invalDCacheAll();
 	hal_cleanDCache();
 
-	flexspi_clockConfig(fspi);
+	/* Configure clock for normal read */
+	flexspi_clockConfig(fspi, 0);
 
 	/* Release FlexSPI from reset and power SRAM */
 	flexspi_disable(fspi, 0);
@@ -212,10 +213,10 @@ __attribute__((section(".noxip"))) int flexspi_init(flexspi_t *fspi, int instanc
 	/* Enable FlexSPI before updating LUT */
 	flexspi_disable(fspi, 0);
 
-	/* Default fast (up to 133MHz) read (single pad) used by AHB and XIP */
-	lut[0] = LUT_SEQ(lutCmd_SDR, lutPad1, 0x0b, lutCmdRADDR_SDR, lutPad1, 0x18);
-	lut[1] = LUT_SEQ(lutCmdDUMMY_SDR, lutPad1, 0x08, lutCmdREAD_SDR, lutPad1, 0x04);
-	lut[2] = LUT_SEQ(lutCmdSTOP, lutPad1, 0, 0, 0, 0);
+	/* Default normal (up to 80 MHz) read (single pad) used by AHB and XIP */
+	lut[0] = LUT_SEQ(lutCmd_SDR, lutPad1, 0x03, lutCmdRADDR_SDR, lutPad1, 0x18);
+	lut[1] = LUT_SEQ(lutCmdREAD_SDR, lutPad1, 0x04, lutCmdSTOP, lutPad1, 0);
+	lut[2] = 0;
 	lut[3] = 0;
 
 	/* Configure initial LUT sequences as needed (for AHB read and IP) */
@@ -228,6 +229,15 @@ __attribute__((section(".noxip"))) int flexspi_init(flexspi_t *fspi, int instanc
 	hal_enableDCache();
 
 	hal_interruptsEnableAll();
+
+	return EOK;
+}
+
+
+__attribute__((section(".noxip"))) int flexspi_postinit(flexspi_t *fspi)
+{
+	/* Reconfigure clock for fast read */
+	flexspi_clockConfig(fspi, 1);
 
 	return EOK;
 }

--- a/devices/flash-imxrt/fspi/fspi_rt105x.h
+++ b/devices/flash-imxrt/fspi/fspi_rt105x.h
@@ -41,12 +41,12 @@ static inline void *flexspi_getBase(int instance)
 }
 
 
-__attribute__((section(".noxip"))) static void flexspi_clockConfig(flexspi_t *fspi)
+__attribute__((section(".noxip"))) static void flexspi_clockConfig(flexspi_t *fspi, u8 fast)
 {
 	_imxrt_ccmControlGate(pctl_clk_flexspi, clk_state_off);
-	_imxrt_ccmSetDiv(clk_div_flexspi, 1); /* div2 -> 130 MHz */
-	_imxrt_ccmSetMux(clk_mux_flexspi, 3); /* PLL3 PFD0 */
-	_imxrt_ccmInitUsb1Pfd(clk_pfd0, 33);  /* PLL3_PDF0=261.818MHz */
+	_imxrt_ccmSetDiv(clk_div_flexspi, fast ? 1 : 3); /* Fast: 261 / (1 + 1) => 130 MHz, Normal: 261 / (3 + 1) => 65 MHz */
+	_imxrt_ccmSetMux(clk_mux_flexspi, 3);            /* PLL3 PFD0 */
+	_imxrt_ccmInitUsb1Pfd(clk_pfd0, 33);             /* PLL3_PDF0=261.818MHz */
 	_imxrt_ccmControlGate(pctl_clk_flexspi, clk_state_run_wait);
 }
 

--- a/devices/flash-imxrt/fspi/fspi_rt106x.h
+++ b/devices/flash-imxrt/fspi/fspi_rt106x.h
@@ -50,20 +50,20 @@ static void *flexspi_getBase(int instance)
 }
 
 
-__attribute__((section(".noxip"))) static void flexspi_clockConfig(flexspi_t *fspi)
+__attribute__((section(".noxip"))) static void flexspi_clockConfig(flexspi_t *fspi, u8 fast)
 {
 	if (fspi->instance == flexspi_instance1) {
 		_imxrt_ccmControlGate(pctl_clk_flexspi, clk_state_off);
-		_imxrt_ccmInitUsb1Pfd(clk_pfd0, 13);  /* PLL3_PDF0=664.6MHz */
-		_imxrt_ccmSetDiv(clk_div_flexspi, 4); /* div5 */
-		_imxrt_ccmSetMux(clk_mux_flexspi, 3); /* PLL3 PFD0 */
+		_imxrt_ccmInitUsb1Pfd(clk_pfd0, 13);             /* PLL3_PDF0=664.6MHz */
+		_imxrt_ccmSetDiv(clk_div_flexspi, fast ? 4 : 9); /* Fast: 664 / (4 + 1) => 132 MHz, Normal: 664 / (9 + 1) => 66 MHz */
+		_imxrt_ccmSetMux(clk_mux_flexspi, 3);            /* PLL3 PFD0 */
 		_imxrt_ccmControlGate(pctl_clk_flexspi, clk_state_run_wait);
 	}
 	else if (fspi->instance == flexspi_instance2) {
 		_imxrt_ccmControlGate(pctl_clk_flexspi2, clk_state_off);
-		_imxrt_ccmInitUsb1Pfd(clk_pfd0, 13);   /* PLL3_PDF0=664.6MHz */
-		_imxrt_ccmSetDiv(clk_div_flexspi2, 4); /* div5 */
-		_imxrt_ccmSetMux(clk_mux_flexspi2, 1); /* PLL3 PFD0 */
+		_imxrt_ccmInitUsb1Pfd(clk_pfd0, 13);              /* PLL3_PDF0=664.6MHz */
+		_imxrt_ccmSetDiv(clk_div_flexspi2, fast ? 4 : 9); /* Fast: 664 / (4 + 1) => 132 MHz, Normal: 664 / (9 + 1) => 66 MHz */
+		_imxrt_ccmSetMux(clk_mux_flexspi2, 1);            /* PLL3 PFD0 */
 		_imxrt_ccmControlGate(pctl_clk_flexspi2, clk_state_run_wait);
 	}
 }

--- a/devices/flash-imxrt/fspi/fspi_rt117x.h
+++ b/devices/flash-imxrt/fspi/fspi_rt117x.h
@@ -53,7 +53,7 @@ static void *flexspi_getBase(int instance)
 }
 
 
-__attribute__((section(".noxip"))) static void flexspi_clockConfig(flexspi_t *fspi)
+__attribute__((section(".noxip"))) static void flexspi_clockConfig(flexspi_t *fspi, u8 fast)
 {
 	int gate, clk, div, mux, mfd, mfn;
 
@@ -61,7 +61,7 @@ __attribute__((section(".noxip"))) static void flexspi_clockConfig(flexspi_t *fs
 		case flexspi_instance1:
 			clk = pctl_clk_flexspi1;
 			gate = pctl_lpcg_flexspi1;
-			div = 3;                               /* SYS_PLL2_CLK / (3 + 1) => 132 MHz */
+			div = fast ? 3 : 7;                    /* Fast: 528 / (3 + 1) => 132 MHz, Normal: 528 / (7 + 1) => 66 MHz */
 			mux = mux_clkroot_flexspi1_syspll2out; /* Select main clock: SYS_PLL2_CLK = 528 MHz */
 			mfd = 0;
 			mfn = 0;
@@ -70,8 +70,8 @@ __attribute__((section(".noxip"))) static void flexspi_clockConfig(flexspi_t *fs
 		case flexspi_instance2:
 			clk = pctl_clk_flexspi2;
 			gate = pctl_lpcg_flexspi2;
-			div = 3;                               /* SYS_PLL2_CLK / (3 + 1) => 132 MHz */
-			mux = mux_clkroot_flexspi2_syspll2out; /* Select main clock: SYS_PLL2_CLK = 528 MHz */
+			div = fast ? 3 : 7;                    /* Fast: 528 / (3 + 1) => 132 MHz, Normal: 528 / (7 + 1) => 66 MHz */
+			mux = mux_clkroot_flexspi1_syspll2out; /* Select main clock: SYS_PLL2_CLK = 528 MHz */
 			mfd = 0;
 			mfn = 0;
 			break;

--- a/devices/flash-imxrt/nor/flash.h
+++ b/devices/flash-imxrt/nor/flash.h
@@ -66,6 +66,8 @@
 #define FLASH_CMD_ERRS       0x7a /* Program/erase resume */
 #define FLASH_CMD_EN4B       0xb7 /* Enter 4-byte address mode */
 #define FLASH_CMD_EX4B       0xe9 /* Exit 4-byte address mode */
+#define FLASH_CMD_RDRD       0x61 /* ISSI: Read Read Parameters (volatile) */
+#define FLASH_CMD_SRPV       0x63 /* ISSI: Set Read Parameters (volatile) */
 
 
 #endif /* _FLASH_H_ */

--- a/devices/flash-imxrt/nor/nor.c
+++ b/devices/flash-imxrt/nor/nor.c
@@ -47,11 +47,11 @@ static const struct nor_info flashInfo[] = {
 	{ FLASH_ID(0xef, 0x8019), "W25Q256JW-M", 32 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric4Byte, NULL },
 
 	/* ISSI */
-	{ FLASH_ID(0x9d, 0x7016), "IS25WP032", 4 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric3Byte, NULL },
-	{ FLASH_ID(0x9d, 0x7017), "IS25WP064", 8 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric3Byte, NULL },
-	{ FLASH_ID(0x9d, 0x7018), "IS25WP128", 16 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric3Byte, NULL },
-	{ FLASH_ID(0x9d, 0x7019), "IS25WP256", 32 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric4Byte, nor_mxQuadEnable },
-	{ FLASH_ID(0x9d, 0x6019), "IS25LP256", 32 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutGeneric4Byte, nor_mxQuadEnable },
+	{ FLASH_ID(0x9d, 0x7016), "IS25WP032", 4 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutIssi3Byte, nor_issiInit },
+	{ FLASH_ID(0x9d, 0x7017), "IS25WP064", 8 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutIssi3Byte, nor_issiInit },
+	{ FLASH_ID(0x9d, 0x7018), "IS25WP128", 16 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutIssi3Byte, nor_issiInit },
+	{ FLASH_ID(0x9d, 0x7019), "IS25WP256", 32 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutIssi4Byte, nor_issiInit },
+	{ FLASH_ID(0x9d, 0x6019), "IS25LP256", 32 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC, lutIssi4Byte, nor_issiInit },
 
 	/* Micron */
 	{ FLASH_ID(0x20, 0xba19), "MT25QL256", 32 * 1024 * 1024, 0x100, 0x1000, NOR_CAPS_GENERIC | NOR_CAPS_EN4B, lutMicronMono, NULL },

--- a/devices/flash-imxrt/nor/nor.h
+++ b/devices/flash-imxrt/nor/nor.h
@@ -92,4 +92,8 @@ extern int nor_probe(flexspi_t *fspi, u8 port, const struct nor_info **pInfo, co
 int nor_mxQuadEnable(struct nor_device *dev);
 
 
+/* ISSI chip init */
+int nor_issiInit(struct nor_device *dev);
+
+
 #endif /* _FLEXSPI_NOR_H_ */

--- a/devices/flash-imxrt/nor/nor_issi.c
+++ b/devices/flash-imxrt/nor/nor_issi.c
@@ -1,0 +1,118 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system loader
+ *
+ * i.MX RT nor flash device driver
+ * ISSI Specific
+ *
+ * Copyright 2024 Phoenix Systems
+ * Authors: Ziemowit Leszczynski
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+
+#include <lib/lib.h>
+#include <devices/devs.h>
+#include "../fspi.h"
+#include "../lut.h"
+
+#include "flash.h"
+#include "nor.h"
+
+
+int nor_issiInit(struct nor_device *dev)
+{
+	int res;
+	struct xferOp xfer;
+	u8 status, params;
+	const time_t timeout = 1000;
+
+	if (dev->active == 0) {
+		return -ENODEV;
+	}
+
+	/* Load only the necessary commands to enable quad mode and set dummy cycles. */
+	flexspi_lutUpdateEntries(&dev->fspi, fspi_readStatus * LUT_SEQSZ, dev->nor->lut + fspi_readStatus, 1, LUT_SEQSZ);
+	flexspi_lutUpdateEntries(&dev->fspi, fspi_writeStatus * LUT_SEQSZ, dev->nor->lut + fspi_writeStatus, 1, LUT_SEQSZ);
+	flexspi_lutUpdateEntries(&dev->fspi, fspi_writeEnable * LUT_SEQSZ, dev->nor->lut + fspi_writeEnable, 1, LUT_SEQSZ);
+	flexspi_lutUpdateEntries(&dev->fspi, fspi_cmdCustom1 * LUT_SEQSZ, dev->nor->lut + fspi_cmdCustom1, 1, LUT_SEQSZ);
+	flexspi_lutUpdateEntries(&dev->fspi, fspi_cmdCustom2 * LUT_SEQSZ, dev->nor->lut + fspi_cmdCustom2, 1, LUT_SEQSZ);
+
+	res = nor_readStatus(&dev->fspi, dev->port, &status, timeout);
+	if (res < EOK) {
+		return res;
+	}
+
+	if ((status & (1uL << 6u)) == 0uL) {
+		res = nor_writeEnable(&dev->fspi, dev->port, 1, timeout);
+		if (res < EOK) {
+			return res;
+		}
+
+		/* Quad Enable */
+		status |= (1uL << 6u);
+
+		xfer.op = xfer_opWrite;
+		xfer.port = dev->port;
+		xfer.timeout = timeout;
+		xfer.addr = 0;
+		xfer.seqIdx = LUT_SEQIDX(fspi_writeStatus);
+		xfer.seqNum = LUT_SEQNUM(fspi_writeStatus);
+		xfer.data.write.ptr = &status;
+		xfer.data.write.sz = 1;
+
+		res = flexspi_xferExec(&dev->fspi, &xfer);
+		if (res < EOK) {
+			return res;
+		}
+
+		res = nor_waitBusy(&dev->fspi, dev->port, timeout);
+		if (res < EOK) {
+			return res;
+		}
+	}
+
+	xfer.op = xfer_opRead;
+	xfer.port = dev->port;
+	xfer.timeout = timeout;
+	xfer.addr = 0;
+	xfer.seqIdx = LUT_SEQIDX(fspi_cmdCustom1);
+	xfer.seqNum = LUT_SEQNUM(fspi_cmdCustom1);
+	xfer.data.read.ptr = &params;
+	xfer.data.read.sz = 1;
+
+	res = flexspi_xferExec(&dev->fspi, &xfer);
+	if (res < EOK) {
+		return res;
+	}
+
+	if (((params & 0x87) >> 3u) != 11) {
+		/* 11 dummy cycles */
+		params = (params & 0x87) | (11uL << 3u);
+
+		xfer.op = xfer_opWrite;
+		xfer.port = dev->port;
+		xfer.timeout = timeout;
+		xfer.addr = 0;
+		xfer.seqIdx = LUT_SEQIDX(fspi_cmdCustom2);
+		xfer.seqNum = LUT_SEQNUM(fspi_cmdCustom2);
+		xfer.data.read.ptr = &params;
+		xfer.data.write.sz = 1;
+
+		res = flexspi_xferExec(&dev->fspi, &xfer);
+		if (res < EOK) {
+			return res;
+		}
+
+		res = nor_waitBusy(&dev->fspi, dev->port, timeout);
+		if (res < EOK) {
+			return res;
+		}
+	}
+
+	return EOK;
+}

--- a/devices/flash-imxrt/nor/nor_lut.h
+++ b/devices/flash-imxrt/nor/nor_lut.h
@@ -181,7 +181,42 @@ static const u32 seq_micronExit4Byte[NOR_LUTSEQSZ] = {
 };
 
 
-/* Generic chips: ISSI, Winbond, Macronix (3-byte address) */
+/*
+ * ISSI NOR dedicated Command Sequences
+ */
+
+/* Read Fast Quad (3-byte address) for 133 MHz and 11 dummy cycles */
+static const u32 seq_issiReadData3Byte[NOR_LUTSEQSZ] = {
+	LUT_SEQ(lutCmd_SDR, lutPad1, FLASH_CMD_QIOR, lutCmdRADDR_SDR, lutPad4, 0x18),
+	LUT_SEQ(lutCmdMODE8_SDR, lutPad4, 0x00, lutCmdDUMMY_SDR, lutPad4, 0x09),
+	LUT_SEQ(lutCmdREAD_SDR, lutPad4, 0x04, lutCmdSTOP, lutPad1, 0),
+	0
+};
+
+/* Read Fast Quad (4-byte address) for 133 MHz and 11 dummy cycles */
+static const u32 seq_issiReadData4Byte[NOR_LUTSEQSZ] = {
+	LUT_SEQ(lutCmd_SDR, lutPad1, FLASH_CMD_4QIOR, lutCmdRADDR_SDR, lutPad4, 0x20),
+	LUT_SEQ(lutCmdMODE8_SDR, lutPad4, 0x00, lutCmdDUMMY_SDR, lutPad4, 0x09),
+	LUT_SEQ(lutCmdREAD_SDR, lutPad4, 0x04, lutCmdSTOP, lutPad1, 0),
+	0
+};
+
+/* Read Read Parameters */
+static const u32 seq_issiReadReadParameters[NOR_LUTSEQSZ] = {
+	LUT_SEQ(lutCmd_SDR, lutPad1, FLASH_CMD_RDRD, lutCmdREAD_SDR, lutPad1, 0x01),
+	LUT_SEQ(lutCmdSTOP, lutPad1, 0, 0, 0, 0),
+	0, 0
+};
+
+/* Write Read Parameters */
+static const u32 seq_issiWriteReadParameters[NOR_LUTSEQSZ] = {
+	LUT_SEQ(lutCmd_SDR, lutPad1, FLASH_CMD_SRPV, lutCmdWRITE_SDR, lutPad1, 0x01),
+	LUT_SEQ(lutCmdSTOP, lutPad1, 0, 0, 0, 0),
+	0, 0
+};
+
+
+/* Generic chips: Winbond, Macronix (3-byte address) */
 static const u32 *lutGeneric3Byte[LUT_ENTRIES] = {
 	[fspi_readData] = seq_genericReadData3Byte,
 	[fspi_readStatus] = seq_genericReadStatus,
@@ -195,7 +230,7 @@ static const u32 *lutGeneric3Byte[LUT_ENTRIES] = {
 	[fspi_readID] = seq_genericReadID,
 };
 
-/* Generic chips: ISSI, Winbond, Macronix (4-byte address) */
+/* Generic chips: Winbond, Macronix (4-byte address) */
 static const u32 *lutGeneric4Byte[LUT_ENTRIES] = {
 	[fspi_readData] = seq_genericReadData4Byte,
 	[fspi_readStatus] = seq_genericReadStatus,
@@ -237,6 +272,38 @@ static const u32 *lutMicronDie[LUT_ENTRIES] = {
 	[fspi_readID] = seq_genericReadID,
 	[fspi_enter4byteAddr] = seq_micronEnter4Byte,
 	[fspi_exit4byteAddr] = seq_micronExit4Byte,
+};
+
+/* ISSI chips (3-byte address) */
+static const u32 *lutIssi3Byte[LUT_ENTRIES] = {
+	[fspi_readData] = seq_issiReadData3Byte,
+	[fspi_readStatus] = seq_genericReadStatus,
+	[fspi_writeStatus] = seq_genericWriteStatus,
+	[fspi_writeEnable] = seq_genericWriteEnable,
+	[fspi_writeDisable] = seq_genericWriteDisable,
+	[fspi_eraseSector] = seq_genericEraseSector3Byte,
+	[fspi_eraseBlock] = seq_genericEraseBlock3Byte,
+	[fspi_eraseChip] = seq_genericEraseChip,
+	[fspi_programQPP] = seq_genericProgramQPP3Byte,
+	[fspi_readID] = seq_genericReadID,
+	[fspi_cmdCustom1] = seq_issiReadReadParameters,
+	[fspi_cmdCustom2] = seq_issiWriteReadParameters,
+};
+
+/* ISSI chips (4-byte address) */
+static const u32 *lutIssi4Byte[LUT_ENTRIES] = {
+	[fspi_readData] = seq_issiReadData4Byte,
+	[fspi_readStatus] = seq_genericReadStatus,
+	[fspi_writeStatus] = seq_genericWriteStatus,
+	[fspi_writeEnable] = seq_genericWriteEnable,
+	[fspi_writeDisable] = seq_genericWriteDisable,
+	[fspi_eraseSector] = seq_genericEraseSector4Byte,
+	[fspi_eraseBlock] = seq_genericEraseBlock4Byte,
+	[fspi_eraseChip] = seq_genericEraseChip,
+	[fspi_programQPP] = seq_genericProgramQPP4Byte,
+	[fspi_readID] = seq_genericReadID,
+	[fspi_cmdCustom1] = seq_issiReadReadParameters,
+	[fspi_cmdCustom2] = seq_issiWriteReadParameters,
 };
 
 #endif /* _LUTTABLES_H_ */

--- a/hal/armv7m/imxrt/10xx/105x/_init.S
+++ b/hal/armv7m/imxrt/10xx/105x/_init.S
@@ -52,7 +52,7 @@ _fcfb:
 .word 0x00000010 /* controllerMiscOption */
 .byte 0x1        /* deviceType */
 .byte 0x4        /* sflashPadType */
-.byte 0x8        /* serialClkFreq */
+.byte 0x3        /* serialClkFreq */
 .byte 0x0        /* lutCustomSeqEnable */
 .word 0, 0
 .word 0x800000   /* sflashA1Size */
@@ -70,7 +70,7 @@ _fcfb:
 .byte 0x0, 0     /* busyBitPolarity */
 
 /* lookupTable */
-.word 0x0818040b, 0x24043008, 0x00000000, 0x00000000
+.word 0x08180403, 0x00002404, 0x00000000, 0x00000000
 .word 0x00000000, 0x00000000, 0x00000000, 0x00000000
 .word 0x00000000, 0x00000000, 0x00000000, 0x00000000
 .word 0x00000000, 0x00000000, 0x00000000, 0x00000000

--- a/hal/armv7m/imxrt/10xx/106x/_init.S
+++ b/hal/armv7m/imxrt/10xx/106x/_init.S
@@ -52,7 +52,7 @@ _fcfb:
 .word 0x00000010 /* controllerMiscOption */
 .byte 0x1        /* deviceType */
 .byte 0x4        /* sflashPadType */
-.byte 0x8        /* serialClkFreq */
+.byte 0x3        /* serialClkFreq */
 .byte 0x0        /* lutCustomSeqEnable */
 .word 0, 0
 .word 0x800000   /* sflashA1Size */
@@ -70,7 +70,7 @@ _fcfb:
 .byte 0x0, 0     /* busyBitPolarity */
 
 /* lookupTable */
-.word 0x0818040b, 0x24043008, 0x00000000, 0x00000000
+.word 0x08180403, 0x00002404, 0x00000000, 0x00000000
 .word 0x00000000, 0x00000000, 0x00000000, 0x00000000
 .word 0x00000000, 0x00000000, 0x00000000, 0x00000000
 .word 0x00000000, 0x00000000, 0x00000000, 0x00000000

--- a/hal/armv7m/imxrt/117x/_init.S
+++ b/hal/armv7m/imxrt/117x/_init.S
@@ -66,7 +66,7 @@ _fcfb:
 .word 0x00000010 /* controllerMiscOption */
 .byte 0x1        /* deviceType */
 .byte 0x4        /* sflashPadType */
-.byte 0x7        /* serialClkFreq */
+.byte 0x3        /* serialClkFreq */
 .byte 0x0        /* lutCustomSeqEnable */
 .word 0, 0
 .word 0x00010000 /* sflashA1Size */
@@ -85,7 +85,7 @@ _fcfb:
 
 /* lookupTable */
 
-.word 0x0818040b, 0x24043008, 0x00000000, 0x00000000
+.word 0x08180403, 0x00002404, 0x00000000, 0x00000000
 .word 0x00000000, 0x00000000, 0x00000000, 0x00000000
 .word 0x00000000, 0x00000000, 0x00000000, 0x00000000
 .word 0x00000000, 0x00000000, 0x00000000, 0x00000000


### PR DESCRIPTION
ISSI NOR chips use selecteble dummy cycles to support fast read command. For 133 MHz fast read should include 11 dummy cycles (default is 6). To set correct number of dummy cycles:

 - FCFB and flexspi_init() use 60 MHz clock and normal read
 - add custom ISSI commands and nor_issiInit()
 - add flexspi_postinit() which switches to final 133 MHz clock

DONE: RTOS-128

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1170).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
