### PR TITLE
riscv: rename sbadaddr to stval

### DIFF
--- a/hal/riscv64/_interrupts.S
+++ b/hal/riscv64/_interrupts.S
@@ -60,7 +60,7 @@ _interrupts_dispatch:
 
 	csrr t0, sstatus
 	csrr t1, sepc
-	csrr t2, sbadaddr
+	csrr t2, stval
 	csrr t3, scause
 
 	sd t0, 256(sp)

--- a/hal/riscv64/exceptions.c
+++ b/hal/riscv64/exceptions.c
@@ -58,7 +58,7 @@ typedef struct _exc_context_t {
 
 	u64 sstatus;
 	u64 sepc;
-	u64 sbadaddr;
+	u64 stval;
 	u64 scause;
 } exc_context_t;
 
@@ -131,7 +131,7 @@ void hal_exceptionsDumpContext(char *buff, exc_context_t *ctx, int n)
 
 	i += hal_i2s(" sstatus : ", &buff[i], (u64)ctx->sstatus, 16, 1);
 	i += hal_i2s(" sepc : ", &buff[i], (u64)ctx->sepc, 16, 1);
-	i += hal_i2s(" sbaddaddr : ", &buff[i], (u64)ctx->sbadaddr, 16, 1);
+	i += hal_i2s(" stval : ", &buff[i], (u64)ctx->stval, 16, 1);
 	i += hal_i2s(" scause : ", &buff[i], (u64)ctx->scause, 16, 1);
 
 	buff[i++] = '\n';


### PR DESCRIPTION
RISC-V Privileged Architectures V1.10 renamed and generalized sbadaddr to stval. binutils >= 2.43 dropped support for sbadaddr alias.

JIRA: RTOS-913

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
