### PR TITLE
hal/ia32: cast operands to correct sizes

### DIFF
--- a/devices/uart-16550/uarthw-pc.c
+++ b/devices/uart-16550/uarthw-pc.c
@@ -39,7 +39,7 @@ unsigned char uarthw_read(void *hwctx, unsigned int reg)
 
 	/* Read from IO-port */
 	if (addr & 0x1)
-		return hal_inb((void *)((addr & ~0x3) + reg));
+		return hal_inb((u16)((addr & ~0x3) + reg));
 
 	/* Read from memory */
 	return *(ctx->base + reg);
@@ -53,7 +53,7 @@ void uarthw_write(void *hwctx, unsigned int reg, unsigned char val)
 
 	/* Write to IO-port */
 	if (addr & 0x1) {
-		hal_outb((void *)((addr & ~0x3) + reg), val);
+		hal_outb((u16)((addr & ~0x3) + reg), val);
 		return;
 	}
 
@@ -65,21 +65,21 @@ void uarthw_write(void *hwctx, unsigned int reg, unsigned char val)
 /* SCH311X Super IO controller */
 
 
-static unsigned char uarthw_SCH311Xinb(void *base, unsigned int reg)
+static unsigned char uarthw_SCH311Xinb(u16 base, unsigned int reg)
 {
 	hal_outb(base, reg);
 	return hal_inb(base + 1);
 }
 
 
-static void uarthw_SCH311Xoutb(void *base, unsigned int reg, unsigned char val)
+static void uarthw_SCH311Xoutb(u16 base, unsigned int reg, unsigned char val)
 {
 	hal_outb(base, reg);
 	hal_outb(base + 1, val);
 }
 
 
-static int uarthw_SCH311Xdetect(void *base)
+static int uarthw_SCH311Xdetect(u16 base)
 {
 	int ret;
 
@@ -107,7 +107,7 @@ static int uarthw_SCH311Xdetect(void *base)
 }
 
 
-static int uarthw_SCH311Xmode(void *base, unsigned char n, unsigned char mode)
+static int uarthw_SCH311Xmode(u16 base, unsigned char n, unsigned char mode)
 {
 	/* Enter configuration mode */
 	hal_outb(base, 0x55);
@@ -141,9 +141,9 @@ int uarthw_init(unsigned int n, void *hwctx, unsigned int *baud)
 	/* Set preferred baudrate */
 	if (baud != NULL) {
 		/* SCH311X Super IO controller has at least 2 high speed UARTS */
-		if ((n < 2) && (uarthw_SCH311Xdetect((void *)0x2e) >= 0)) {
+		if ((n < 2) && (uarthw_SCH311Xdetect((u16)0x2e) >= 0)) {
 			*baud = bps_460800;
-			uarthw_SCH311Xmode((void *)0x2e, 0x04 + n, bauds[*baud].mode);
+			uarthw_SCH311Xmode((u16)0x2e, 0x04 + n, bauds[*baud].mode);
 		}
 		else {
 			*baud = bps_115200;

--- a/hal/ia32/console-serial.c
+++ b/hal/ia32/console-serial.c
@@ -45,7 +45,7 @@ static unsigned char console_read(unsigned int reg)
 
 	/* Read from IO-port */
 	if (addr & 0x1)
-		return hal_inb((void *)((addr & ~0x3) + reg));
+		return hal_inb((u16)((addr & ~0x3) + reg));
 
 	/* Read from memory */
 	return *(halconsole_common.base + reg);
@@ -58,7 +58,7 @@ static void console_write(unsigned int reg, unsigned char val)
 
 	/* Write to IO-port */
 	if (addr & 0x1) {
-		hal_outb((void *)((addr & ~0x3) + reg), val);
+		hal_outb((u16)((addr & ~0x3) + reg), val);
 		return;
 	}
 

--- a/hal/ia32/console-vga.c
+++ b/hal/ia32/console-vga.c
@@ -42,7 +42,7 @@ static const unsigned char ansi2bg[] = {
 
 struct {
 	volatile u16 *vram;      /* Video memory */
-	void *crtc;              /* CRT controller register */
+	u16 crtc;                /* CRT controller register */
 	unsigned int rows;       /* Console height */
 	unsigned int cols;       /* Console width */
 	unsigned char attr;      /* Character attribute */
@@ -91,9 +91,9 @@ void hal_consolePrint(const char *s)
 
 	/* Print from current cursor position */
 	hal_outb(halconsole_common.crtc, 0x0f);
-	pos = hal_inb((void *)((addr_t)halconsole_common.crtc + 1));
+	pos = hal_inb(halconsole_common.crtc + 1);
 	hal_outb(halconsole_common.crtc, 0x0e);
-	pos |= (u16)hal_inb((void *)((addr_t)halconsole_common.crtc + 1)) << 8;
+	pos |= (u16)hal_inb(halconsole_common.crtc + 1) << 8;
 	row = pos / halconsole_common.cols;
 	col = pos % halconsole_common.cols;
 
@@ -277,7 +277,7 @@ void hal_consolePrint(const char *s)
 							switch (halconsole_common.parms[0]) {
 								case 25:
 									hal_outb(halconsole_common.crtc, 0x0a);
-									hal_outb((void *)((addr_t)halconsole_common.crtc + 1), hal_inb((void *)((addr_t)halconsole_common.crtc + 1)) & ~0x20);
+									hal_outb(halconsole_common.crtc + 1, hal_inb(halconsole_common.crtc + 1) & ~0x20);
 									break;
 							}
 							halconsole_common.esc = esc_init;
@@ -287,7 +287,7 @@ void hal_consolePrint(const char *s)
 							switch (halconsole_common.parms[0]) {
 								case 25:
 									hal_outb(halconsole_common.crtc, 0x0a);
-									hal_outb((void *)((addr_t)halconsole_common.crtc + 1), hal_inb((void *)((addr_t)halconsole_common.crtc + 1)) | 0x20);
+									hal_outb(halconsole_common.crtc + 1, hal_inb(halconsole_common.crtc + 1) | 0x20);
 									break;
 							}
 							halconsole_common.esc = esc_init;
@@ -319,9 +319,9 @@ void hal_consolePrint(const char *s)
 		/* Update cursor */
 		i = row * halconsole_common.cols + col;
 		hal_outb(halconsole_common.crtc, 0x0e);
-		hal_outb((void *)((addr_t)halconsole_common.crtc + 1), i >> 8);
+		hal_outb(halconsole_common.crtc + 1, i >> 8);
 		hal_outb(halconsole_common.crtc, 0x0f);
-		hal_outb((void *)((addr_t)halconsole_common.crtc + 1), i);
+		hal_outb(halconsole_common.crtc + 1, i);
 		*((u8 *)(halconsole_common.vram + i) + 1) = halconsole_common.attr;
 	}
 
@@ -340,7 +340,7 @@ void hal_consoleInit(void)
 
 	/* Initialize VGA */
 	halconsole_common.vram = (u16 *)(color ? 0xb8000 : 0xb0000);
-	halconsole_common.crtc = (void *)(color ? 0x3d4 : 0x3b4);
+	halconsole_common.crtc = (u16)(color ? 0x3d4 : 0x3b4);
 
 	/* Default 80x25 text mode with magenta color attribute */
 	halconsole_common.rows = 25;

--- a/hal/ia32/cpu.c
+++ b/hal/ia32/cpu.c
@@ -58,18 +58,18 @@ void hal_cpuReboot(void)
 
 	/* 1. Try to reboot using keyboard controller (8042) */
 	for (timeout = 0xffff; timeout != 0; --timeout) {
-		status = hal_inb((void *)0x64);
+		status = hal_inb((u16)0x64);
 		if ((status & 1) != 0) {
-			(void)hal_inb((void *)0x60);
+			(void)hal_inb((u16)0x60);
 		}
 		if ((status & 2) == 0) {
 			break;
 		}
 	}
-	hal_outb((void *)0x64, 0xfe);
+	hal_outb((u16)0x64, 0xfe);
 
 	/* 2. Try to reboot by PCI reset */
-	hal_outb((void *)0xcf9, 0xe);
+	hal_outb((u16)0xcf9, 0xe);
 
 	/* 3. Triple fault (interrupt with null idt) */
 	__asm__ volatile(

--- a/hal/ia32/cpu.h
+++ b/hal/ia32/cpu.h
@@ -18,6 +18,9 @@
 #define _CPU_H_
 
 
+#include "types.h"
+
+
 static inline void hal_cpuDataMemoryBarrier(void)
 {
 	/* not supported */
@@ -36,66 +39,92 @@ static inline void hal_cpuInstrBarrier(void)
 }
 
 
-static inline unsigned char hal_inb(void *addr)
+static inline u8 hal_inb(u16 addr)
 {
-	unsigned char val;
+	u8 b;
 
-	__asm__ volatile(
-		"inb %1, %0; "
-	: "=a" (val)
-	: "Nd" (addr));
-
-	return val;
+	/* clang-format off */
+	__asm__ volatile (
+		"inb %1, %0\n\t"
+	: "=a" (b)
+	: "d" (addr)
+	: );
+	/* clang-format on */
+	return b;
 }
 
 
-static inline void hal_outb(void *addr, unsigned char val)
+static inline void hal_outb(u16 addr, u8 b)
 {
-	__asm__ volatile(
-		"outb %0, %1; "
-	:: "a" (val), "Nd" (addr));
+	/* clang-format off */
+	__asm__ volatile (
+		"outb %1, %0"
+	:
+	: "d" (addr), "a" (b)
+	: );
+	/* clang-format on */
+
+	return;
 }
 
 
-static inline unsigned short hal_inw(void *addr)
+static inline u16 hal_inw(u16 addr)
 {
-	unsigned short val;
+	u16 w;
 
-	__asm__ volatile(
-		"inw %1, %0; "
-	: "=a" (val)
-	: "Nd" (addr));
+	/* clang-format off */
+	__asm__ volatile (
+		"inw %1, %0\n\t"
+	: "=a" (w)
+	: "d" (addr)
+	: );
+	/* clang-format on */
 
-	return val;
+	return w;
 }
 
 
-static inline void hal_outw(void *addr, unsigned short val)
+static inline void hal_outw(u16 addr, u16 w)
 {
-	__asm__ volatile(
-		"outw %0, %1; "
-	:: "a" (val), "Nd" (addr));
+	/* clang-format off */
+	__asm__ volatile (
+		"outw %1, %0"
+	:
+	: "d" (addr), "a" (w)
+	: );
+	/* clang-format on */
+
+	return;
 }
 
 
-static inline unsigned int hal_inl(void *addr)
+static inline u32 hal_inl(u16 addr)
 {
-	unsigned int val;
+	u32 l;
 
-	__asm__ volatile(
-		"inl %1, %0; "
-	: "=a" (val)
-	: "Nd" (addr));
+	/* clang-format off */
+	__asm__ volatile (
+		"inl %1, %0\n\t"
+	: "=a" (l)
+	: "d" (addr)
+	: );
+	/* clang-format on */
 
-	return val;
+	return l;
 }
 
 
-static inline void hal_outl(void *addr, unsigned int val)
+static inline void hal_outl(u16 addr, u32 l)
 {
-	__asm__ volatile(
-		"outl %0, %1; "
-	:: "a" (val), "Nd" (addr));
+	/* clang-format off */
+	__asm__ volatile (
+		"outl %1, %0"
+	:
+	: "d" (addr), "a" (l)
+	: );
+	/* clang-format on */
+
+	return;
 }
 
 

--- a/hal/ia32/efi/kernel/cpu.h
+++ b/hal/ia32/efi/kernel/cpu.h
@@ -184,84 +184,92 @@ typedef struct {
 /* io access */
 
 
-static inline u8 hal_inb(void *addr)
+static inline u8 hal_inb(u16 addr)
 {
-	u32 ioport = (u32)addr;
 	u8 b;
 
-	__asm__ volatile
-	(
-		"inb %1, %0"
+	/* clang-format off */
+	__asm__ volatile (
+		"inb %1, %0\n\t"
 	: "=a" (b)
-	: "dN" ((u16)ioport));
-
+	: "d" (addr)
+	: );
+	/* clang-format on */
 	return b;
 }
 
 
-static inline void hal_outb(void *addr, u8 b)
+static inline void hal_outb(u16 addr, u8 b)
 {
-	u32 ioport = (u32)addr;
-
-	__asm__ volatile
-	(
-		"outb %0, %1"
+	/* clang-format off */
+	__asm__ volatile (
+		"outb %1, %0"
 	:
-	: "a" (b), "dN" ((u16)ioport));
+	: "d" (addr), "a" (b)
+	: );
+	/* clang-format on */
+
+	return;
 }
 
 
-static inline u16 hal_inw(void *addr)
+static inline u16 hal_inw(u16 addr)
 {
-	u32 ioport = (u32)addr;
 	u16 w;
 
-	__asm__ volatile
-	(
-		"inw %1, %0"
+	/* clang-format off */
+	__asm__ volatile (
+		"inw %1, %0\n\t"
 	: "=a" (w)
-	: "dN" ((u16)ioport));
+	: "d" (addr)
+	: );
+	/* clang-format on */
 
 	return w;
 }
 
 
-static inline void hal_outw(void *addr, u16 w)
+static inline void hal_outw(u16 addr, u16 w)
 {
-	u32 ioport = (u32)addr;
-
-	__asm__ volatile
-	(
-		"outw %0, %1"
+	/* clang-format off */
+	__asm__ volatile (
+		"outw %1, %0"
 	:
-	: "a" (w), "dN" ((u16)ioport));
+	: "d" (addr), "a" (w)
+	: );
+	/* clang-format on */
+
+	return;
 }
 
 
-static inline u32 hal_inl(void *addr)
+static inline u32 hal_inl(u16 addr)
 {
-	u32 ioport = (u32)addr;
 	u32 l;
 
-	__asm__ volatile
-	(
-		"inl %1, %0"
+	/* clang-format off */
+	__asm__ volatile (
+		"inl %1, %0\n\t"
 	: "=a" (l)
-	: "dN" ((u16)ioport));
+	: "d" (addr)
+	: );
+	/* clang-format on */
 
 	return l;
 }
 
 
-static inline void hal_outl(void *addr, u32 l)
+static inline void hal_outl(u16 addr, u32 l)
 {
-	u32 ioport = (u32)addr;
-
-	__asm__ volatile
-	(
-		"outl %0, %1"
+	/* clang-format off */
+	__asm__ volatile (
+		"outl %1, %0"
 	:
-	: "a" (l), "dN" ((u16)ioport));
+	: "d" (addr), "a" (l)
+	: );
+	/* clang-format on */
+
+	return;
 }
 
 

--- a/hal/ia32/interrupts.c
+++ b/hal/ia32/interrupts.c
@@ -73,11 +73,11 @@ int interrupts_ack(unsigned int n)
 		return -EINVAL;
 
 	if (n < 8) {
-		hal_outb((void *)0x20, 0x60 | n);
+		hal_outb((u16)0x20, 0x60 | n);
 	}
 	else {
-		hal_outb((void *)0x20, 0x62);
-		hal_outb((void *)0xa0, 0x60 | (n - 8));
+		hal_outb((u16)0x20, 0x62);
+		hal_outb((u16)0xa0, 0x60 | (n - 8));
 	}
 
 	return EOK;
@@ -140,16 +140,16 @@ int interrupts_setIDTEntry(unsigned int n, void (*base)(void), unsigned short se
 void interrupts_remapPIC(unsigned char offs1, unsigned char offs2)
 {
 	/* Initialize primary PIC */
-	hal_outb((void *)0x20, 0x11);  /* ICW1 - master initialization sequence */
-	hal_outb((void *)0x21, offs1); /* ICW2 - master vector offset */
-	hal_outb((void *)0x21, 0x04);  /* ICW3 - slave PIC at IRQ2 */
-	hal_outb((void *)0x21, 0x01);  /* ICW4 - 8086 mode */
+	hal_outb((u16)0x20, 0x11);  /* ICW1 - master initialization sequence */
+	hal_outb((u16)0x21, offs1); /* ICW2 - master vector offset */
+	hal_outb((u16)0x21, 0x04);  /* ICW3 - slave PIC at IRQ2 */
+	hal_outb((u16)0x21, 0x01);  /* ICW4 - 8086 mode */
 
 	/* Initialize secondary PIC */
-	hal_outb((void *)0xa0, 0x11);  /* ICW1 - slave initialization sequence */
-	hal_outb((void *)0xa1, offs2); /* ICW2 - slave vector offset */
-	hal_outb((void *)0xa1, 0x02);  /* ICW3 - cascade identity */
-	hal_outb((void *)0xa1, 0x01);  /* ICW4 - 8086 mode */
+	hal_outb((u16)0xa0, 0x11);  /* ICW1 - slave initialization sequence */
+	hal_outb((u16)0xa1, offs2); /* ICW2 - slave vector offset */
+	hal_outb((u16)0xa1, 0x02);  /* ICW3 - cascade identity */
+	hal_outb((u16)0xa1, 0x01);  /* ICW4 - 8086 mode */
 }
 
 

--- a/hal/ia32/memory.c
+++ b/hal/ia32/memory.c
@@ -211,9 +211,9 @@ static int memory_empty8042(void)
 	unsigned short int timeout;
 	for (timeout = 0xffff; timeout != 0; --timeout) {
 		/* Discard input data */
-		status = hal_inb((void *)0x64);
+		status = hal_inb((u16)0x64);
 		if ((status & 0x01) != 0) {
-			hal_inb((void *)0x60);
+			hal_inb((u16)0x60);
 			continue;
 		}
 		if ((status & 0x02) == 0) {
@@ -254,11 +254,11 @@ static int memory_enableA20(void)
 		if (memory_empty8042() < 0) {
 			return -1;
 		}
-		hal_outb((void *)0x64, 0xd1);
+		hal_outb((u16)0x64, 0xd1);
 		if (memory_empty8042() < 0) {
 			return -1;
 		}
-		hal_outb((void *)0x60, 0xdf);
+		hal_outb((u16)0x60, 0xdf);
 		if (memory_empty8042() < 0) {
 			return -1;
 		}

--- a/hal/ia32/pci.c
+++ b/hal/ia32/pci.c
@@ -26,8 +26,8 @@
 
 int hal_pciDetect(void)
 {
-	hal_outl((void *)PCI_CONFIG_ADDR, PCI_ENABLE);
-	return (hal_inl((void *)PCI_CONFIG_ADDR) == PCI_ENABLE) ? 0 : -1;
+	hal_outl(PCI_CONFIG_ADDR, PCI_ENABLE);
+	return (hal_inl(PCI_CONFIG_ADDR) == PCI_ENABLE) ? 0 : -1;
 }
 
 
@@ -44,8 +44,8 @@ u32 hal_pciRead32(hal_pciAddr_t *bdf, u8 offs)
 {
 	u32 addr = hal_pciAddrBDF(bdf);
 	offs &= 256u / sizeof(u32) - 1u;
-	hal_outl((void *)PCI_CONFIG_ADDR, addr + ((u32)offs << 2u));
-	return hal_inl((void *)PCI_CONFIG_DATA);
+	hal_outl(PCI_CONFIG_ADDR, addr + ((u32)offs << 2u));
+	return hal_inl(PCI_CONFIG_DATA);
 }
 
 
@@ -53,8 +53,8 @@ void hal_pciWrite32(hal_pciAddr_t *bdf, u8 offs, u32 value)
 {
 	u32 addr = hal_pciAddrBDF(bdf);
 	offs &= 256u / sizeof(u32) - 1u;
-	hal_outl((void *)PCI_CONFIG_ADDR, addr + ((u32)offs << 2u));
-	hal_outl((void *)PCI_CONFIG_DATA, value);
+	hal_outl(PCI_CONFIG_ADDR, addr + ((u32)offs << 2u));
+	hal_outl(PCI_CONFIG_DATA, value);
 }
 
 
@@ -62,8 +62,8 @@ u16 hal_pciRead16(hal_pciAddr_t *bdf, u8 offs)
 {
 	u32 addr = hal_pciAddrBDF(bdf);
 	offs &= 256u / sizeof(u16) - 1u;
-	hal_outl((void *)PCI_CONFIG_ADDR, addr + ((u32)offs << 1u));
-	return hal_inw((void *)(PCI_CONFIG_DATA + (((addr_t)offs & 1u) << 1u)));
+	hal_outl(PCI_CONFIG_ADDR, addr + ((u32)offs << 1u));
+	return hal_inw(PCI_CONFIG_DATA + (((addr_t)offs & 1u) << 1u));
 }
 
 
@@ -71,24 +71,24 @@ void hal_pciWrite16(hal_pciAddr_t *bdf, u8 offs, u16 value)
 {
 	u32 addr = hal_pciAddrBDF(bdf);
 	offs &= 256u / sizeof(u16) - 1u;
-	hal_outl((void *)PCI_CONFIG_ADDR, addr + ((u32)offs << 1u));
-	hal_outw((void *)(PCI_CONFIG_DATA + (((addr_t)offs & 1u) << 1u)), value);
+	hal_outl(PCI_CONFIG_ADDR, addr + ((u32)offs << 1u));
+	hal_outw(PCI_CONFIG_DATA + (((addr_t)offs & 1u) << 1u), value);
 }
 
 
 u8 hal_pciRead8(hal_pciAddr_t *bdf, u8 offs)
 {
 	u32 addr = hal_pciAddrBDF(bdf);
-	hal_outl((void *)PCI_CONFIG_ADDR, addr + (u32)offs);
-	return hal_inb((void *)(PCI_CONFIG_DATA + ((addr_t)offs & 3u)));
+	hal_outl(PCI_CONFIG_ADDR, addr + (u32)offs);
+	return hal_inb(PCI_CONFIG_DATA + ((addr_t)offs & 3u));
 }
 
 
 void hal_pciWrite8(hal_pciAddr_t *bdf, u8 offs, u8 value)
 {
 	u32 addr = hal_pciAddrBDF(bdf);
-	hal_outl((void *)PCI_CONFIG_ADDR, addr + (u32)offs);
-	hal_outb((void *)(PCI_CONFIG_DATA + ((addr_t)offs & 3u)), value);
+	hal_outl(PCI_CONFIG_ADDR, addr + (u32)offs);
+	hal_outb(PCI_CONFIG_DATA + ((addr_t)offs & 3u), value);
 }
 
 


### PR DESCRIPTION
Copy "in" related function from efi.
Newer binutils versions check closely if asm instructions get operands of correct size.

JIRA: RTOS-912

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
