### PR TITLE
cmd/erase: make erase confirmation optional at compile-time

### DIFF
--- a/cmds/erase.c
+++ b/cmds/erase.c
@@ -60,11 +60,13 @@ static int cmd_erase(int argc, char *argv[])
 		return CMD_EXIT_FAILURE;
 	}
 
+#ifdef PLO_ERASE_NEEDS_CONFIRMATION
 	res = lib_promptConfirm("\nWARNING!\nSerious risk of data loss, type %s to proceed.\n", "YES!", 10 * 1000);
 	if (res != 1) {
 		lib_printf("Aborted.\n");
 		return CMD_EXIT_SUCCESS;
 	}
+#endif
 
 	res = phfs_erase(h, offs, len, 0);
 	if (res < 0) {


### PR DESCRIPTION
`erase` command confirmation will be disabled by default at a compile time.

## Description
NOTE: some changes in `trunner` might be needed, but plo `erase` command is not being used in testing right now (`jffs2 -e` might be - and it doesn't require human confirmation ;)).

## Motivation and Context
JIRA: NIL-550

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `NIL`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
