### PR TITLE
hal/imxrt: Fix boot from FlexSPI failing

### DIFF
--- a/hal/armv7m/imxrt/10xx/105x/_init.S
+++ b/hal/armv7m/imxrt/10xx/105x/_init.S
@@ -55,7 +55,7 @@ _fcfb:
 .byte 0x3        /* serialClkFreq */
 .byte 0x0        /* lutCustomSeqEnable */
 .word 0, 0
-.word 0x800000   /* sflashA1Size */
+.word _plo_flash_size /* sflashA1Size */
 .word 0          /* sflashA2Size */
 .word 0          /* sflashB1Size */
 .word 0          /* sflashB2Size */

--- a/hal/armv7m/imxrt/10xx/106x/_init.S
+++ b/hal/armv7m/imxrt/10xx/106x/_init.S
@@ -55,7 +55,7 @@ _fcfb:
 .byte 0x3        /* serialClkFreq */
 .byte 0x0        /* lutCustomSeqEnable */
 .word 0, 0
-.word 0x800000   /* sflashA1Size */
+.word _plo_flash_size /* sflashA1Size */
 .word 0          /* sflashA2Size */
 .word 0          /* sflashB1Size */
 .word 0          /* sflashB2Size */

--- a/hal/armv7m/imxrt/117x/_init.S
+++ b/hal/armv7m/imxrt/117x/_init.S
@@ -69,7 +69,7 @@ _fcfb:
 .byte 0x3        /* serialClkFreq */
 .byte 0x0        /* lutCustomSeqEnable */
 .word 0, 0
-.word 0x00010000 /* sflashA1Size */
+.word _plo_flash_size /* sflashA1Size */
 .word 0          /* sflashA2Size */
 .word 0          /* sflashB1Size */
 .word 0          /* sflashB2Size */

--- a/ld/armv7m7-imxrt105x.ldt
+++ b/ld/armv7m7-imxrt105x.ldt
@@ -50,8 +50,11 @@ MEMORY
 	m_itext   (rwx) : ORIGIN = FLEXRAM_ITEXT_ADDR, LENGTH = FLEXRAM_ITEXT_AREA
 	m_dtcm    (rw)  : ORIGIN = 0x20002000, LENGTH = FLEXRAM_DTCM_AREA
 	m_ocram   (rwx) : ORIGIN = 0x20200000, LENGTH = FLEXRAM_OCRAM_AREA
-	m_flash   (rx)  : ORIGIN = 0x60000000, LENGTH = 8M
+	m_flash   (rx)  : ORIGIN = 0x60000000, LENGTH = 128k /* Not actual flash size. Initial flash size to be put into FCB block for imxrt BootROM init procedure only */
 }
+
+/* Initial flash size to be put into FCB block for imxrt BootROM init procedure only */
+_plo_flash_size = LENGTH(m_flash);
 
 #if defined (ram)
 

--- a/ld/armv7m7-imxrt106x.ldt
+++ b/ld/armv7m7-imxrt106x.ldt
@@ -49,8 +49,11 @@ MEMORY
 	m_itext   (rwx) : ORIGIN = FLEXRAM_ITEXT_ADDR, LENGTH = FLEXRAM_ITEXT_AREA
 	m_dtcm    (rw)  : ORIGIN = 0x20002000, LENGTH = FLEXRAM_DTCM_AREA
 	m_ocram   (rwx) : ORIGIN = 0x20200000, LENGTH = 0 * 32k
-	m_flash   (rx)  : ORIGIN = 0x70000000, LENGTH = 4M
+	m_flash   (rx)  : ORIGIN = 0x70000000, LENGTH = 128k /* Not actual flash size. Initial flash size to be put into FCB block for imxrt BootROM init procedure only */
 }
+
+/* Initial flash size to be put into FCB block for imxrt BootROM init procedure only */
+_plo_flash_size = LENGTH(m_flash);
 
 #if defined (ram)
 

--- a/ld/armv7m7-imxrt117x.ldt
+++ b/ld/armv7m7-imxrt117x.ldt
@@ -56,8 +56,11 @@ MEMORY
 	m_dtcm    (rw)  : ORIGIN = 0x20002000 + AREA_KERNEL, LENGTH = FLEXRAM_DTCM_AREA - AREA_KERNEL
 	m_ocram1  (rwx) : ORIGIN = 0x20240000 + AREA_BOOTLOADER, LENGTH = (8 * 32k) - AREA_BOOTLOADER
 	m_ocram2  (rwx) : ORIGIN = 0x202c0000, LENGTH = 512k
-	m_flash   (rx)  : ORIGIN = 0x30000000, LENGTH = 4M
+	m_flash   (rx)  : ORIGIN = 0x30000000, LENGTH = 128k /* Not actual flash size. Initial flash size to be put into FCB block for imxrt BootROM init procedure only */
 }
+
+/* Initial flash size to be put into FCB block for imxrt BootROM init procedure only */
+_plo_flash_size = LENGTH(m_flash);
 
 #if defined (ram)
 


### PR DESCRIPTION
This change fixes a boot failure when plo image is larger than the hardcoded value in sflashA1Size, but smaller than m_flash size (the linker does not abort). Now (initial) flash size is tied to FlexSPI Configuration Block so that this never happens again. If plo grows too much, the linker will produce an error.

JIRA: RTOS-920

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt1170-evk.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
