### PR TITLE
rtt: Improve buffer allocation and handling

### DIFF
--- a/hal/armv7m/imxrt/10xx/105x/Makefile
+++ b/hal/armv7m/imxrt/10xx/105x/Makefile
@@ -15,7 +15,7 @@ CFLAGS+= -mfloat-abi=soft
 PLO_COMMANDS ?= alias app blob bridge call console copy devices dump echo erase go help kernel \
   kernelimg map mem mpu otp phfs ptable reboot script stop wait
 
-# pipe-rtt is disabled due to small amount of space in DTCM; RTT_ADDR is not defined for this architecture
+# pipe-rtt is disabled due to small amount of space in DTCM; RTT_ENABLED_PLO is not defined for this architecture
 PLO_ALLDEVICES := usbc-cdc uart-imxrt106x flash-imxrt
 
 OBJS += $(addprefix $(PREFIX_O)hal/$(TARGET_SUFF)/imxrt/10xx/105x/, _init.o imxrt.o)

--- a/hal/armv7m/imxrt/10xx/106x/peripherals.h
+++ b/hal/armv7m/imxrt/10xx/106x/peripherals.h
@@ -26,9 +26,8 @@
 
 
 /* DEBUG - RTT PIPE */
-#ifndef RTT_ADDR
-/* RTT descriptors location, last 256 bytes of DTCM */
-#define RTT_ADDR (0x20058000 - 0x100)
+#ifndef RTT_ENABLED_PLO
+#define RTT_ENABLED_PLO 1
 #endif
 
 

--- a/hal/armv7m/imxrt/117x/peripherals.h
+++ b/hal/armv7m/imxrt/117x/peripherals.h
@@ -27,9 +27,8 @@
 
 /* DEBUG - RTT PIPE */
 
-#ifndef RTT_ADDR
-/* RTT descriptors location, last 256 bytes of DTCM */
-#define RTT_ADDR (0x20040000 - 0x100)
+#ifndef RTT_ENABLED_PLO
+#define RTT_ENABLED_PLO 1
 #endif
 
 

--- a/hal/armv7m/imxrt/hal.c
+++ b/hal/armv7m/imxrt/hal.c
@@ -30,6 +30,9 @@ extern char __data_start[], __data_end[];
 extern char __bss_start[], __bss_end[];
 extern char __heap_base[], __heap_limit[];
 extern char __stack_top[], __stack_limit[];
+#if RTT_ENABLED_PLO
+extern char __rttmem_rttcb[];
+#endif
 
 /* Timer */
 extern void timer_init(void);
@@ -58,8 +61,8 @@ void hal_init(void)
 	timer_init();
 	otp_init();
 
-#ifdef RTT_ADDR
-	rtt_init((void *)RTT_ADDR);
+#if RTT_ENABLED_PLO
+	rtt_init(__rttmem_rttcb);
 #endif
 
 	console_init();

--- a/hal/armv7m/stm32/hal.c
+++ b/hal/armv7m/stm32/hal.c
@@ -33,6 +33,9 @@ extern char __data_start[], __data_end[];
 extern char __bss_start[], __bss_end[];
 extern char __heap_base[], __heap_limit[];
 extern char __stack_top[], __stack_limit[];
+#if RTT_ENABLED_PLO
+extern char __rttmem_rttcb[];
+#endif
 
 /* Timer */
 extern void timer_init(void);
@@ -60,8 +63,8 @@ void hal_init(void)
 	mpu_init();
 	timer_init();
 
-#ifdef RTT_ADDR
-	rtt_init((void *)RTT_ADDR);
+#if RTT_ENABLED_PLO
+	rtt_init(__rttmem_rttcb);
 #endif
 
 	console_init();

--- a/ld/armv7m4-stm32l4x6.ldt
+++ b/ld/armv7m4-stm32l4x6.ldt
@@ -33,13 +33,17 @@
 /* Space reserved for kernel data */
 #define AREA_KERNEL 0x10000
 
+/* Space reserved for RTT control block and buffers */
+#define SIZE_RTTMEM (2 * 2 * 0x400 + 256)
+
 
 #if defined(__LINKER__)
 
 /* Memory map setup */
 MEMORY
 {
-	m_sram    (rwx) : ORIGIN = RAM_ADDR + AREA_KERNEL, LENGTH = (256k + 64k) - AREA_KERNEL
+	m_sram    (rwx) : ORIGIN = RAM_ADDR + AREA_KERNEL, LENGTH = (256k + 64k) - AREA_KERNEL - SIZE_RTTMEM
+	m_rttmem  (rw)  : ORIGIN = RAM_ADDR + (256k + 64k) - SIZE_RTTMEM, LENGTH = SIZE_RTTMEM
 	m_flash2  (rx)  : ORIGIN = FLASH_PROGRAM_2_ADDR, LENGTH = 512k
 	m_flash1  (rx)  : ORIGIN = FLASH_PROGRAM_1_ADDR, LENGTH = 512k
 }
@@ -51,8 +55,10 @@ REGION_ALIAS("DATA", m_sram);
 REGION_ALIAS("BSS", m_sram);
 REGION_ALIAS("HEAP", m_sram);
 REGION_ALIAS("STACK", m_sram);
+REGION_ALIAS("RTTMEM", m_rttmem);
 
 #include "common/plo-arm.lds"
+#include "common/plo-rtt.lds"
 
 #endif /* end of __LINKER__ */
 

--- a/ld/armv7m7-imxrt105x.ldt
+++ b/ld/armv7m7-imxrt105x.ldt
@@ -23,6 +23,10 @@
 #define SIZE_STACK (4 * SIZE_PAGE)
 #define SIZE_HEAP  (8 * SIZE_PAGE)
 
+/* Space reserved for kernel data */
+#define AREA_KERNEL 0x2000
+
+
 #if defined(__LINKER__)
 
 /* FlexRAM configuration */
@@ -48,7 +52,7 @@ MEMORY
 {
 	m_itcm    (rwx) : ORIGIN = 0x00000000, LENGTH = FLEXRAM_ITCM_AREA
 	m_itext   (rwx) : ORIGIN = FLEXRAM_ITEXT_ADDR, LENGTH = FLEXRAM_ITEXT_AREA
-	m_dtcm    (rw)  : ORIGIN = 0x20002000, LENGTH = FLEXRAM_DTCM_AREA
+	m_dtcm    (rw)  : ORIGIN = 0x20000000 + AREA_KERNEL, LENGTH = FLEXRAM_DTCM_AREA - AREA_KERNEL
 	m_ocram   (rwx) : ORIGIN = 0x20200000, LENGTH = FLEXRAM_OCRAM_AREA
 	m_flash   (rx)  : ORIGIN = 0x60000000, LENGTH = 128k /* Not actual flash size. Initial flash size to be put into FCB block for imxrt BootROM init procedure only */
 }

--- a/ld/armv7m7-imxrt106x.ldt
+++ b/ld/armv7m7-imxrt106x.ldt
@@ -23,6 +23,10 @@
 #define SIZE_STACK (4 * SIZE_PAGE)
 #define SIZE_HEAP  (8 * SIZE_PAGE)
 
+/* Space reserved for kernel data */
+#define AREA_KERNEL 0x2000
+
+
 #if defined(__LINKER__)
 
 /* FlexRAM configuration */
@@ -47,7 +51,7 @@ MEMORY
 	/* TODO: use FLEXRAM_CONFIG value to setup ocram/itcm/dtcm partitioning (*32k) */
 	m_itcm    (rwx) : ORIGIN = 0x00000000, LENGTH = FLEXRAM_ITCM_AREA
 	m_itext   (rwx) : ORIGIN = FLEXRAM_ITEXT_ADDR, LENGTH = FLEXRAM_ITEXT_AREA
-	m_dtcm    (rw)  : ORIGIN = 0x20002000, LENGTH = FLEXRAM_DTCM_AREA
+	m_dtcm    (rw)  : ORIGIN = 0x20000000 + AREA_KERNEL, LENGTH = FLEXRAM_DTCM_AREA - AREA_KERNEL
 	m_ocram   (rwx) : ORIGIN = 0x20200000, LENGTH = 0 * 32k
 	m_flash   (rx)  : ORIGIN = 0x70000000, LENGTH = 128k /* Not actual flash size. Initial flash size to be put into FCB block for imxrt BootROM init procedure only */
 }

--- a/ld/armv7m7-imxrt106x.ldt
+++ b/ld/armv7m7-imxrt106x.ldt
@@ -26,6 +26,9 @@
 /* Space reserved for kernel data */
 #define AREA_KERNEL 0x2000
 
+/* Space reserved for RTT control block and buffers */
+#define SIZE_RTTMEM (2 * 2 * 0x400 + 256)
+
 
 #if defined(__LINKER__)
 
@@ -51,7 +54,8 @@ MEMORY
 	/* TODO: use FLEXRAM_CONFIG value to setup ocram/itcm/dtcm partitioning (*32k) */
 	m_itcm    (rwx) : ORIGIN = 0x00000000, LENGTH = FLEXRAM_ITCM_AREA
 	m_itext   (rwx) : ORIGIN = FLEXRAM_ITEXT_ADDR, LENGTH = FLEXRAM_ITEXT_AREA
-	m_dtcm    (rw)  : ORIGIN = 0x20000000 + AREA_KERNEL, LENGTH = FLEXRAM_DTCM_AREA - AREA_KERNEL
+	m_dtcm    (rw)  : ORIGIN = 0x20000000 + AREA_KERNEL, LENGTH = FLEXRAM_DTCM_AREA - AREA_KERNEL - SIZE_RTTMEM
+	m_rttmem  (rw)  : ORIGIN = 0x20000000 + FLEXRAM_DTCM_AREA - SIZE_RTTMEM, LENGTH = SIZE_RTTMEM
 	m_ocram   (rwx) : ORIGIN = 0x20200000, LENGTH = 0 * 32k
 	m_flash   (rx)  : ORIGIN = 0x70000000, LENGTH = 128k /* Not actual flash size. Initial flash size to be put into FCB block for imxrt BootROM init procedure only */
 }
@@ -78,8 +82,10 @@ REGION_ALIAS("TCM_TEXT", m_itext);
 REGION_ALIAS("BSS", m_dtcm);
 REGION_ALIAS("HEAP", m_dtcm);
 REGION_ALIAS("STACK", m_dtcm);
+REGION_ALIAS("RTTMEM", m_rttmem);
 
 #include "common/plo-arm.lds"
+#include "common/plo-rtt.lds"
 
 #endif /* end of __LINKER__ */
 

--- a/ld/armv7m7-imxrt117x.ldt
+++ b/ld/armv7m7-imxrt117x.ldt
@@ -29,6 +29,9 @@
 /* Space reserved for bootloader */
 #define AREA_BOOTLOADER 0x10000
 
+/* Space reserved for RTT control block and buffers */
+#define SIZE_RTTMEM (2 * 2 * 0x400 + 256)
+
 
 #if defined(__LINKER__)
 
@@ -53,7 +56,8 @@ MEMORY
 {
 	m_itcm    (rwx) : ORIGIN = 0x00000000, LENGTH = FLEXRAM_ITCM_AREA
 	m_itext   (rwx) : ORIGIN = 0x00000000 + FLEXRAM_ITEXT_ADDR, LENGTH = FLEXRAM_ITEXT_AREA
-	m_dtcm    (rw)  : ORIGIN = 0x20000000 + AREA_KERNEL, LENGTH = FLEXRAM_DTCM_AREA - AREA_KERNEL
+	m_dtcm    (rw)  : ORIGIN = 0x20000000 + AREA_KERNEL, LENGTH = FLEXRAM_DTCM_AREA - AREA_KERNEL - SIZE_RTTMEM
+	m_rttmem  (rw)  : ORIGIN = 0x20000000 + FLEXRAM_DTCM_AREA - SIZE_RTTMEM, LENGTH = SIZE_RTTMEM
 	m_ocram1  (rwx) : ORIGIN = 0x20240000 + AREA_BOOTLOADER, LENGTH = (8 * 32k) - AREA_BOOTLOADER
 	m_ocram2  (rwx) : ORIGIN = 0x202c0000, LENGTH = 512k
 	m_flash   (rx)  : ORIGIN = 0x30000000, LENGTH = 128k /* Not actual flash size. Initial flash size to be put into FCB block for imxrt BootROM init procedure only */
@@ -81,8 +85,10 @@ REGION_ALIAS("TCM_TEXT", m_itext);
 REGION_ALIAS("BSS", m_dtcm);
 REGION_ALIAS("HEAP", m_dtcm);
 REGION_ALIAS("STACK", m_dtcm);
+REGION_ALIAS("RTTMEM", m_rttmem);
 
 #include "common/plo-arm.lds"
+#include "common/plo-rtt.lds"
 
 #endif /* end of __LINKER__ */
 

--- a/ld/armv7m7-imxrt117x.ldt
+++ b/ld/armv7m7-imxrt117x.ldt
@@ -53,7 +53,7 @@ MEMORY
 {
 	m_itcm    (rwx) : ORIGIN = 0x00000000, LENGTH = FLEXRAM_ITCM_AREA
 	m_itext   (rwx) : ORIGIN = 0x00000000 + FLEXRAM_ITEXT_ADDR, LENGTH = FLEXRAM_ITEXT_AREA
-	m_dtcm    (rw)  : ORIGIN = 0x20002000 + AREA_KERNEL, LENGTH = FLEXRAM_DTCM_AREA - AREA_KERNEL
+	m_dtcm    (rw)  : ORIGIN = 0x20000000 + AREA_KERNEL, LENGTH = FLEXRAM_DTCM_AREA - AREA_KERNEL
 	m_ocram1  (rwx) : ORIGIN = 0x20240000 + AREA_BOOTLOADER, LENGTH = (8 * 32k) - AREA_BOOTLOADER
 	m_ocram2  (rwx) : ORIGIN = 0x202c0000, LENGTH = 512k
 	m_flash   (rx)  : ORIGIN = 0x30000000, LENGTH = 128k /* Not actual flash size. Initial flash size to be put into FCB block for imxrt BootROM init procedure only */

--- a/ld/common/plo-rtt.lds
+++ b/ld/common/plo-rtt.lds
@@ -1,0 +1,12 @@
+/* Section for RTT control block and buffers */
+SECTIONS
+{
+    .rttmem ORIGIN(RTTMEM) (NOLOAD):
+	{
+		KEEP(*(.rttmem))
+		. = ABSOLUTE(ORIGIN(RTTMEM) + LENGTH(RTTMEM) - 256);
+		__rttmem_rttcb = .;
+		. = ALIGN(4);
+	} > RTTMEM
+
+}


### PR DESCRIPTION
## Description
Corrected memory mappings for imxrt devices, which could result in data being placed out of bounds of dtcm memory.
Added support for passing RTT details through syspage on imxrt.
Reserved dedicated memory for RTT in memory maps.

## Motivation and Context
This allows RTT buffers to be allocated at compile time and remain available after kernel is started. This also removes hard-coded RTT address, which reduces confusion when using different memory configurations.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt1170

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work
- [ ] I will merge this PR by myself when appropriate.
