### PR TITLE
imxrt: fix .noxip code calling functions from .text

### DIFF
--- a/_startc.c
+++ b/_startc.c
@@ -33,8 +33,12 @@ void _startc(int argc, char **argv, char **env)
 	size_t i, size;
 
 	/* Load .fastram.text, .data and .rodata sections */
-	if (__ramtext_start != __ramtext_load)
-		hal_memcpy(__ramtext_start, __ramtext_load, __ramtext_end - __ramtext_start);
+	if (__ramtext_start != __ramtext_load) {
+		/* hal_memcpy may reside in fastram. */
+		for (i = 0; i <= __ramtext_end - __ramtext_start; i++) {
+			__ramtext_start[i] = __ramtext_load[i];
+		}
+	}
 
 	if (__data_start != __data_load)
 		hal_memcpy(__data_start, __data_load, __data_end - __data_start);

--- a/devices/flash-imx6ull/nor/nor.c
+++ b/devices/flash-imx6ull/nor/nor.c
@@ -82,7 +82,7 @@ static int nor_readID(qspi_t *qspi, u8 port, u32 *retValue, time_t timeout)
 }
 
 
-__attribute__((section(".noxip"))) int nor_readStatus(qspi_t *qspi, u8 port, u8 *statusByte, time_t timeout)
+int nor_readStatus(qspi_t *qspi, u8 port, u8 *statusByte, time_t timeout)
 {
 	struct xferOp xfer;
 
@@ -98,7 +98,7 @@ __attribute__((section(".noxip"))) int nor_readStatus(qspi_t *qspi, u8 port, u8 
 }
 
 
-__attribute__((section(".noxip"))) int nor_waitBusy(qspi_t *qspi, u8 port, time_t timeout)
+int nor_waitBusy(qspi_t *qspi, u8 port, time_t timeout)
 {
 	int res;
 	u8 status = 0;
@@ -114,7 +114,7 @@ __attribute__((section(".noxip"))) int nor_waitBusy(qspi_t *qspi, u8 port, time_
 }
 
 
-__attribute__((section(".noxip"))) int nor_writeEnable(qspi_t *qspi, u8 port, int enable, time_t timeout)
+int nor_writeEnable(qspi_t *qspi, u8 port, int enable, time_t timeout)
 {
 	struct xferOp xfer;
 	int res, seqCode;
@@ -151,7 +151,7 @@ __attribute__((section(".noxip"))) int nor_writeEnable(qspi_t *qspi, u8 port, in
 }
 
 
-__attribute__((section(".noxip"))) int nor_eraseSector(qspi_t *qspi, u8 port, addr_t addr, time_t timeout)
+int nor_eraseSector(qspi_t *qspi, u8 port, addr_t addr, time_t timeout)
 {
 	struct xferOp xfer;
 
@@ -175,7 +175,7 @@ __attribute__((section(".noxip"))) int nor_eraseSector(qspi_t *qspi, u8 port, ad
 }
 
 
-__attribute__((section(".noxip"))) int nor_eraseChip(qspi_t *qspi, u8 port, time_t timeout)
+int nor_eraseChip(qspi_t *qspi, u8 port, time_t timeout)
 {
 	struct xferOp xfer;
 
@@ -199,7 +199,7 @@ __attribute__((section(".noxip"))) int nor_eraseChip(qspi_t *qspi, u8 port, time
 }
 
 
-__attribute__((section(".noxip"))) int nor_pageProgram(qspi_t *qspi, u8 port, addr_t dstAddr, const void *src, size_t pageSz, time_t timeout)
+int nor_pageProgram(qspi_t *qspi, u8 port, addr_t dstAddr, const void *src, size_t pageSz, time_t timeout)
 {
 	struct xferOp xfer;
 

--- a/devices/flash-imx6ull/qspi/qspi.c
+++ b/devices/flash-imx6ull/qspi/qspi.c
@@ -88,7 +88,7 @@
 #define WATERMARK 16u
 
 
-__attribute__((section(".noxip"))) static void qspi_setMux(int dev_no)
+static void qspi_setMux(int dev_no)
 {
 	size_t i;
 	static const struct {
@@ -119,7 +119,7 @@ __attribute__((section(".noxip"))) static void qspi_setMux(int dev_no)
 }
 
 
-__attribute__((section(".noxip"))) static void qspi_enable(int enable)
+static void qspi_enable(int enable)
 {
 	if (enable == 0) {
 		QSPI_BASE[QSPI_MCR] |= QSPI_MCR_CLR_MDIS;
@@ -130,7 +130,7 @@ __attribute__((section(".noxip"))) static void qspi_enable(int enable)
 }
 
 
-__attribute__((section(".noxip"))) void qspi_lutUpdate(qspi_t *qspi, u32 index, const u32 *lutTable, size_t count)
+void qspi_lutUpdate(qspi_t *qspi, u32 index, const u32 *lutTable, size_t count)
 {
 	u32 lutCopy[64];
 	size_t i;
@@ -162,7 +162,7 @@ __attribute__((section(".noxip"))) void qspi_lutUpdate(qspi_t *qspi, u32 index, 
 }
 
 
-__attribute__((section(".noxip"))) static void qspi_swReset(void)
+static void qspi_swReset(void)
 {
 	QSPI_BASE[QSPI_MCR] |= (QSPI_MCR_SWRSTHD | QSPI_MCR_SWRSTSD);
 	qspi_enable(0);
@@ -171,7 +171,7 @@ __attribute__((section(".noxip"))) static void qspi_swReset(void)
 }
 
 
-__attribute__((section(".noxip"))) static void qspi_setClk(void)
+static void qspi_setClk(void)
 {
 	imx6ull_setDevClock(clk_qspi, 0x03);
 
@@ -183,7 +183,7 @@ __attribute__((section(".noxip"))) static void qspi_setClk(void)
 }
 
 
-__attribute__((section(".noxip"))) static void qspi_pinConfig(u8 slPortMask)
+static void qspi_pinConfig(u8 slPortMask)
 {
 	if ((slPortMask & (qspi_slBusA1 | qspi_slBusA2)) != 0u) {
 		qspi_setMux(0);
@@ -218,7 +218,7 @@ void qspi_setFlashSize(qspi_t *qspi, const size_t flashSizes[4])
 }
 
 
-__attribute__((section(".noxip"))) static addr_t qspi_getAddressByPort(qspi_t *qspi, u8 port, addr_t addr)
+static addr_t qspi_getAddressByPort(qspi_t *qspi, u8 port, addr_t addr)
 {
 	u32 reg;
 
@@ -255,7 +255,7 @@ int qspi_deinit(qspi_t *qspi)
 }
 
 
-__attribute__((section(".noxip"))) static void qspi_setIPCR(unsigned int seq_num, size_t idatsz)
+static void qspi_setIPCR(unsigned int seq_num, size_t idatsz)
 {
 	u32 reg = QSPI_BASE[QSPI_IPCR];
 
@@ -268,7 +268,7 @@ __attribute__((section(".noxip"))) static void qspi_setIPCR(unsigned int seq_num
 }
 
 
-__attribute__((section(".noxip"))) static ssize_t qspi_opRead(time_t start, struct xferOp *xfer)
+static ssize_t qspi_opRead(time_t start, struct xferOp *xfer)
 {
 	unsigned int i;
 	size_t byte, len = 0;
@@ -312,7 +312,7 @@ __attribute__((section(".noxip"))) static ssize_t qspi_opRead(time_t start, stru
 }
 
 
-__attribute__((section(".noxip"))) static size_t qspi_writeTx(const void *data, size_t size)
+static size_t qspi_writeTx(const void *data, size_t size)
 {
 	size_t byte, sent = 0;
 	int align64 = 0;
@@ -336,7 +336,7 @@ __attribute__((section(".noxip"))) static size_t qspi_writeTx(const void *data, 
 }
 
 
-__attribute__((section(".noxip"))) static ssize_t qspi_opWrite(time_t start, struct xferOp *xfer)
+static ssize_t qspi_opWrite(time_t start, struct xferOp *xfer)
 {
 	size_t sent = 0;
 
@@ -364,7 +364,7 @@ __attribute__((section(".noxip"))) static ssize_t qspi_opWrite(time_t start, str
 }
 
 
-__attribute__((section(".noxip"))) ssize_t qspi_xferExec(qspi_t *qspi, struct xferOp *xfer)
+ssize_t qspi_xferExec(qspi_t *qspi, struct xferOp *xfer)
 {
 	ssize_t res;
 	time_t start = hal_timerGet();
@@ -407,7 +407,7 @@ __attribute__((section(".noxip"))) ssize_t qspi_xferExec(qspi_t *qspi, struct xf
 	return res;
 }
 
-__attribute__((section(".noxip"))) int qspi_init(qspi_t *qspi, u8 slPortMask)
+int qspi_init(qspi_t *qspi, u8 slPortMask)
 {
 	unsigned i;
 	u32 lut[4];

--- a/devices/flash-imxrt/fspi/fspi_rt105x.h
+++ b/devices/flash-imxrt/fspi/fspi_rt105x.h
@@ -30,12 +30,12 @@ enum { mcr0 = 0, mcr1, mcr2, ahbcr, inten, intr, lutkey, lutcr, ahbrxbuf0cr0, ah
 #define AHBRXBUF_CNT 4
 
 
-static inline addr_t flexspi_ahbAddr(int instance)
+__attribute__((section(".noxip"))) static inline addr_t flexspi_ahbAddr(int instance)
 {
 	return (instance == flexspi_instance1) ? 0x60000000 : 0;
 }
 
-static inline void *flexspi_getBase(int instance)
+__attribute__((section(".noxip"))) static inline void *flexspi_getBase(int instance)
 {
 	return instance == flexspi_instance1 ? (void *)0x402a8000 : NULL;
 }

--- a/devices/flash-imxrt/fspi/fspi_rt106x.h
+++ b/devices/flash-imxrt/fspi/fspi_rt106x.h
@@ -30,7 +30,7 @@ enum { mcr0 = 0, mcr1, mcr2, ahbcr, inten, intr, lutkey, lutcr, ahbrxbuf0cr0, ah
 #define AHBRXBUF_CNT 4
 
 
-static addr_t flexspi_ahbAddr(int instance)
+__attribute__((section(".noxip"))) static addr_t flexspi_ahbAddr(int instance)
 {
 	switch (instance) {
 		case flexspi_instance1: return 0x60000000;
@@ -40,7 +40,7 @@ static addr_t flexspi_ahbAddr(int instance)
 }
 
 
-static void *flexspi_getBase(int instance)
+__attribute__((section(".noxip"))) static void *flexspi_getBase(int instance)
 {
 	switch (instance) {
 		case flexspi_instance1: return (void *)0x402a8000;

--- a/devices/flash-imxrt/fspi/fspi_rt117x.h
+++ b/devices/flash-imxrt/fspi/fspi_rt117x.h
@@ -33,7 +33,7 @@ enum { mcr0 = 0, mcr1, mcr2, ahbcr, inten, intr, lutkey, lutcr, ahbrxbuf0cr0, ah
 #define AHBRXBUF_CNT 8
 
 
-static addr_t flexspi_ahbAddr(int instance)
+__attribute__((section(".noxip"))) static addr_t flexspi_ahbAddr(int instance)
 {
 	switch (instance) {
 		case flexspi_instance1: return 0x30000000;
@@ -43,7 +43,7 @@ static addr_t flexspi_ahbAddr(int instance)
 }
 
 
-static void *flexspi_getBase(int instance)
+__attribute__((section(".noxip"))) static void *flexspi_getBase(int instance)
 {
 	switch (instance) {
 		case flexspi_instance1: return (void *)0x400cc000;

--- a/devices/uart-imxrt106x/uart.c
+++ b/devices/uart-imxrt106x/uart.c
@@ -117,15 +117,14 @@ __attribute__((section(".noxip"))) static int uart_handleIntr(unsigned int irq, 
 	*(uart->base + statr) |= flags;
 
 	/* Receive */
-	while (uart_getRXcount(uart)) {
+	while (uart_getRXcount(uart) != 0) {
 		c = *(uart->base + datar);
-		lib_cbufWrite(&uart->cbuffRx, &c, 1);
+		lib_cbufWriteByte(&uart->cbuffRx, c);
 	}
 
 	/* Transmit */
 	while (uart_getTXcount(uart) < uart->txFifoSz) {
-		if (!lib_cbufEmpty(&uart->cbuffTx)) {
-			lib_cbufRead(&uart->cbuffTx, &c, 1);
+		if (lib_cbufReadByte(&uart->cbuffTx, &c) != 0) {
 			*(uart->base + datar) = c;
 		}
 		else {

--- a/hal/armv7m/cpu.c
+++ b/hal/armv7m/cpu.c
@@ -298,7 +298,7 @@ unsigned int hal_cpuID(void)
 }
 
 
-void hal_cpuReboot(void)
+__attribute__((section(".noxip"))) void hal_cpuReboot(void)
 {
 	hal_cpuDataSyncBarrier();
 	*(cpu_common.scb + scb_aircr) = ((0x5fa << 16) | (*(cpu_common.scb + scb_aircr) & (0x700)) | (1 << 0x02));

--- a/hal/armv7m/cpu.h
+++ b/hal/armv7m/cpu.h
@@ -21,28 +21,19 @@
 #include <hal/hal.h>
 
 
-static inline void hal_cpuDataMemoryBarrier(void)
-{
-	__asm__ volatile ("dmb");
-}
+/* NOTE: defined as macros to make sure there are no calls to code in flash in .noxip sections. */
+/* clang-format off */
+#define hal_cpuDataMemoryBarrier() do { __asm__ volatile ("dmb"); } while(0)
 
 
-static inline void hal_cpuDataSyncBarrier(void)
-{
-	__asm__ volatile ("dsb");
-}
+#define hal_cpuDataSyncBarrier() do { __asm__ volatile ("dsb"); } while(0)
 
 
-static inline void hal_cpuInstrBarrier(void)
-{
-	__asm__ volatile ("isb");
-}
+#define hal_cpuInstrBarrier() do { __asm__ volatile ("isb"); } while(0)
 
 
-static inline void hal_cpuHalt(void)
-{
-	__asm__ volatile ("wfi");
-}
+#define hal_cpuHalt() do { __asm__ volatile ("wfi"); } while(0)
+/* clang-format on */
 
 
 extern void hal_scbSetPriorityGrouping(u32 group);

--- a/hal/armv7m/imxrt/10xx/console.c
+++ b/hal/armv7m/imxrt/10xx/console.c
@@ -76,7 +76,7 @@ void hal_consoleSetHooks(ssize_t (*writeHook)(int, const void *, size_t))
 }
 
 
-void hal_consolePrint(const char *s)
+__attribute__((section(".noxip"))) void hal_consolePrint(const char *s)
 {
 	const char *ptr;
 

--- a/hal/armv7m/imxrt/117x/console.c
+++ b/hal/armv7m/imxrt/117x/console.c
@@ -140,7 +140,7 @@ void hal_consoleSetHooks(ssize_t (*writeHook)(int, const void *, size_t))
 }
 
 
-void hal_consolePrint(const char *s)
+__attribute__((section(".noxip"))) void hal_consolePrint(const char *s)
 {
 	const char *ptr;
 

--- a/hal/armv7m/string.c
+++ b/hal/armv7m/string.c
@@ -17,7 +17,7 @@
 #include <hal/string.h>
 
 
-void *hal_memcpy(void *dst, const void *src, size_t l)
+__attribute__((section(".noxip"))) void *hal_memcpy(void *dst, const void *src, size_t l)
 {
 	void *ret = dst;
 
@@ -105,7 +105,7 @@ void hal_memset(void *dst, int v, size_t l)
 }
 
 
-size_t hal_strlen(const char *s)
+__attribute__((section(".noxip"))) size_t hal_strlen(const char *s)
 {
 	size_t k = 0;
 
@@ -186,7 +186,7 @@ int hal_strncmp(const char *s1, const char *s2, size_t count)
 }
 
 
-char *hal_strcpy(char *dest, const char *src)
+__attribute__((section(".noxip"))) char *hal_strcpy(char *dest, const char *src)
 {
 	char *p = dest;
 
@@ -240,7 +240,7 @@ char *hal_strchr(const char *s, int c)
 }
 
 
-int hal_i2s(char *prefix, char *s, unsigned int i, unsigned char b, char zero)
+__attribute__((section(".noxip"))) int hal_i2s(char *prefix, char *s, unsigned int i, unsigned char b, char zero)
 {
 	static const char digits[] = "0123456789abcdef";
 	char c;

--- a/lib/cbuffer.c
+++ b/lib/cbuffer.c
@@ -60,6 +60,21 @@ size_t lib_cbufWrite(cbuffer_t *buf, const void *data, size_t sz)
 }
 
 
+__attribute__((section(".noxip"))) int lib_cbufWriteByte(cbuffer_t *buf, char data)
+{
+	if (buf->full != 0) {
+		return 0;
+	}
+
+	*((char *)buf->data + buf->tail) = data;
+
+	buf->tail = (buf->tail + 1) % buf->capacity;
+	buf->full = (buf->tail == buf->head);
+
+	return 1;
+}
+
+
 size_t lib_cbufRead(cbuffer_t *buf, void *data, size_t sz)
 {
 	int bytes = 0;
@@ -85,6 +100,21 @@ size_t lib_cbufRead(cbuffer_t *buf, void *data, size_t sz)
 	buf->full = 0;
 
 	return bytes;
+}
+
+
+__attribute__((section(".noxip"))) int lib_cbufReadByte(cbuffer_t *buf, char *data)
+{
+	if ((buf->head == buf->tail) && (buf->full == 0)) {
+		return 0;
+	}
+
+	*data = *((char *)buf->data + buf->head);
+
+	buf->head = (buf->head + 1) % buf->capacity;
+	buf->full = 0;
+
+	return 1;
 }
 
 

--- a/lib/cbuffer.h
+++ b/lib/cbuffer.h
@@ -40,6 +40,12 @@ extern size_t lib_cbufRead(cbuffer_t *buf, void *data, size_t sz);
 extern size_t lib_cbufWrite(cbuffer_t *buf, const void *data, size_t sz);
 
 
+extern int lib_cbufReadByte(cbuffer_t *buf, char *data) __attribute__((section(".noxip")));
+
+
+extern int lib_cbufWriteByte(cbuffer_t *buf, char data) __attribute__((section(".noxip")));
+
+
 extern void lib_cbufInit(cbuffer_t *buf, void *data, size_t capacity);
 
 


### PR DESCRIPTION
JIRA: RTOS-936

## Description
imxrt-106x didn't add map entries for text, rodata, init, init_array, fini_array etc in what could have caused memory overrides if PLO was executed from RAM. (those entries got added on STM32 in https://github.com/phoenix-rtos/plo/pull/197)

imxrt used `.noxip` section for code that should be executed from XIP, however those functions called some function residing in `.text` what make `.noxip` faulty. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
