### PR TITLE
hal/armv7m: Support RTT as an early console

### DIFF
--- a/cmds/console.c
+++ b/cmds/console.c
@@ -53,6 +53,7 @@ static int cmd_console(int argc, char *argv[])
 		return CMD_EXIT_FAILURE;
 	}
 
+	lib_printf("\nconsole: Setting console to %d.%d", major, minor);
 	lib_consoleSet(major, minor);
 	return CMD_EXIT_SUCCESS;
 }

--- a/hal/armv7m/imxrt/10xx/console.c
+++ b/hal/armv7m/imxrt/10xx/console.c
@@ -16,6 +16,10 @@
 #include <board_config.h>
 
 #include <hal/hal.h>
+#include <lib/helpers.h>
+
+#if !ISEMPTY(UART_CONSOLE_PLO)
+
 
 #define CONCAT(a, b)         a##b
 #define CONCAT2(a, b)        CONCAT(a, b)
@@ -159,3 +163,23 @@ void console_init(void)
 	/* Enable TX and RX */
 	*(halconsole_common.uart + uart_ctrl) |= (1 << 19) | (1 << 18);
 }
+
+#else
+
+void hal_consoleSetHooks(ssize_t (*writeHook)(int, const void *, size_t))
+{
+	(void)writeHook;
+}
+
+
+void hal_consolePrint(const char *s)
+{
+	(void)s;
+}
+
+
+void console_init(void)
+{
+}
+
+#endif /* #if !ISEMPTY(UART_CONSOLE_PLO) */

--- a/hal/armv7m/imxrt/117x/console.c
+++ b/hal/armv7m/imxrt/117x/console.c
@@ -16,6 +16,10 @@
 #include <board_config.h>
 
 #include <hal/hal.h>
+#include <lib/helpers.h>
+
+#if !ISEMPTY(UART_CONSOLE_PLO)
+
 
 #define CONCAT(a, b)         a##b
 #define CONCAT2(a, b)        CONCAT(a, b)
@@ -220,3 +224,23 @@ void console_init(void)
 	/* Enable TX and RX */
 	*(halconsole_common.uart + uart_ctrl) |= (1 << 19) | (1 << 18);
 }
+
+#else
+
+void hal_consoleSetHooks(ssize_t (*writeHook)(int, const void *, size_t))
+{
+	(void)writeHook;
+}
+
+
+void hal_consolePrint(const char *s)
+{
+	(void)s;
+}
+
+
+void console_init(void)
+{
+}
+
+#endif /* #if !ISEMPTY(UART_CONSOLE_PLO) */

--- a/hal/armv7m/imxrt/hal.c
+++ b/hal/armv7m/imxrt/hal.c
@@ -15,6 +15,9 @@
 
 #include <board_config.h>
 #include <hal/hal.h>
+#include <devices/devs.h>
+#include <lib/helpers.h>
+#include <lib/console.h>
 #include "otp.h"
 
 
@@ -68,6 +71,12 @@ void hal_init(void)
 
 #if RTT_ENABLED_PLO
 	rtt_init(__rttmem_rttcb);
+
+#if ISEMPTY(UART_CONSOLE_PLO)
+	/* TODO: Channel number is already hardcoded in halconsole_common.writeHook.
+	Maybe let user redefine RTT channel to be used in plo? */
+	lib_consoleSet(DEV_PIPE, 0);
+#endif
 #endif
 
 	console_init();

--- a/hal/armv7m/stm32/hal.c
+++ b/hal/armv7m/stm32/hal.c
@@ -15,6 +15,9 @@
 
 #include <board_config.h>
 #include <hal/hal.h>
+#include <devices/devs.h>
+#include <lib/helpers.h>
+#include <lib/console.h>
 
 struct {
 	hal_syspage_t *hs;
@@ -65,6 +68,12 @@ void hal_init(void)
 
 #if RTT_ENABLED_PLO
 	rtt_init(__rttmem_rttcb);
+
+#if ISEMPTY(UART_CONSOLE_PLO)
+	/* TODO: Channel number is already hardcoded in halconsole_common.writeHook.
+	Maybe let user redefine RTT channel to be used in plo? */
+	lib_consoleSet(DEV_PIPE, 0);
+#endif
 #endif
 
 	console_init();

--- a/hal/armv7m/stm32/l4/console.c
+++ b/hal/armv7m/stm32/l4/console.c
@@ -14,7 +14,10 @@
  */
 
 #include <hal/hal.h>
+#include <lib/helpers.h>
 #include "stm32l4.h"
+
+#if !ISEMPTY(UART_CONSOLE_PLO)
 
 
 static struct {
@@ -95,3 +98,23 @@ void console_init(void)
 	*(halconsole_common.base + cr1) |= 1;
 	hal_cpuDataMemoryBarrier();
 }
+
+#else
+
+void hal_consoleSetHooks(ssize_t (*writeHook)(int, const void *, size_t))
+{
+	(void)writeHook;
+}
+
+
+void hal_consolePrint(const char *s)
+{
+	(void)s;
+}
+
+
+void console_init(void)
+{
+}
+
+#endif /* #if !ISEMPTY(UART_CONSOLE_PLO) */

--- a/hal/armv7m/stm32/l4/peripherals.h
+++ b/hal/armv7m/stm32/l4/peripherals.h
@@ -49,6 +49,10 @@
 #define UART_CONSOLE 2
 #endif
 
+#ifndef UART_CONSOLE_PLO
+#define UART_CONSOLE_PLO UART_CONSOLE
+#endif
+
 #define UART_BAUDRATE 115200
 
 #define UART1_BASE ((void *)0x40013800)

--- a/lib/console.c
+++ b/lib/console.c
@@ -101,7 +101,6 @@ void lib_consoleSet(unsigned major, unsigned minor)
 	console_common.major = major;
 	console_common.minor = minor;
 	console_common.init = 1;
-	lib_printf("\nconsole: Setting console to %d.%d", major, minor);
 }
 
 

--- a/lib/helpers.h
+++ b/lib/helpers.h
@@ -1,0 +1,39 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system loader
+ *
+ * Generic useful macros
+ *
+ * Copyright 2024 Phoenix Systems
+ * Author: Daniel Sawka
+ *
+ * This file is part of Phoenix-RTOS.
+ *
+ * %LICENSE%
+ */
+
+#ifndef _LIB_HELPERS_H_
+#define _LIB_HELPERS_H_
+
+/*
+These macros should only be used in `#if` and `#elif` directives, because undefined identifiers expand to 0 there.
+Otherwise there will be "use of undefined identifier" errors (an exception: identifier is first checked for
+existence with e.g. `#ifdef`).
+
+Anything that expands to a numerical expression (or to an empty value) is fine. String literals don't work.
+*/
+
+/*
+These macros produce a logically correct result only if X is defined. You may use `#ifdef` or `defined()`
+for this purpose. Unfortunately, `defined()` cannot be conveniently put inside a macro as this is undefined
+behavior (see -Wexpansion-to-defined for details), so you have to use it directly on the spot, for example:
+`#if defined(PERIPH1) && !ISEMPTY(PERIPH1)
+// Use PERIPH1
+#endif`
+*/
+
+/* True if X is empty (has no value). The result in #if is valid only if defined(X) is true */
+#define ISEMPTY(X) ((0 - X - 1) == 1 && (X + 0) != -2)
+
+#endif


### PR DESCRIPTION
Currently RTT is available as a plo device and also mirrors UART output via hooks. This change makes it possible to replace UART completely by RTT - just define `UART_CONSOLE_PLO` as empty and keep RTT_ENABLED_PLO truthy (enabled by default).

A print is moved from `lib_consoleSet()` to console command to avoid output before the first plo log ("Phoenix-RTOS loader ...").

JIRA: RTOS-754

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt117x-evk.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
