### PR TITLE
devices/pipe-rtt: Properly handle timeout in RTT reads

### DIFF
--- a/devices/pipe-rtt/device.c
+++ b/devices/pipe-rtt/device.c
@@ -22,9 +22,20 @@
 static ssize_t pipe_read(unsigned int minor, addr_t offs, void *buff, size_t len, time_t timeout)
 {
 	(void)offs;
-	(void)timeout;
+	time_t start = hal_timerGet();
 
-	return rtt_read(minor + 1, buff, len);
+	while (1 == 1) {
+		ssize_t ret = rtt_read(minor + 1, buff, len);
+
+		if (ret != 0) {
+			return ret;
+		}
+		if ((hal_timerGet() - start) >= timeout) {
+			return -ETIME;
+		}
+	}
+
+	return 0;
 }
 
 


### PR DESCRIPTION
This change fixes the problem of plo's `wait` command not waiting while using RTT console. Read operation was completed immediately instead of blocking for at least `timeout`.

JIRA: NIL-596

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt1170-evk

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
