### PR TITLE
hal/imxrt117x: fix IOpad set

### DIFF
--- a/hal/armv7m/imxrt/117x/imxrt.c
+++ b/hal/armv7m/imxrt/117x/imxrt.c
@@ -158,7 +158,8 @@ __attribute__((section(".noxip"))) int _imxrt_setIOpad(int pad, char sre, char d
 		return -1;
 	}
 
-	if ((pad >= pctl_pad_gpio_emc_b1_00) && (pad <= pctl_pad_gpio_disp_b2_15)) {
+	if (((pad >= pctl_pad_gpio_emc_b1_00) && (pad <= pctl_pad_gpio_emc_b2_20)) ||
+			((pad >= pctl_pad_gpio_sd_b1_00) && (pad <= pctl_pad_gpio_disp_b2_15))) {
 		/* Fields have slightly diffrent meaning... */
 		if (pue == 0) {
 			pull = 3;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
properly set the ranges of gpio pad registers that are controlled differently to the rest

## Motivation and Context
Needed for platformctl to work as intended on iMX RT1170-evk.
related change: https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/610

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
