### PR TITLE
hal/imxrt117x: fix IOpad

### DIFF
--- a/hal/armv7m/imxrt/117x/imxrt.c
+++ b/hal/armv7m/imxrt/117x/imxrt.c
@@ -158,8 +158,7 @@ __attribute__((section(".noxip"))) int _imxrt_setIOpad(int pad, char sre, char d
 		return -1;
 	}
 
-	if (((pad >= pctl_pad_gpio_emc_b1_00) && (pad <= pctl_pad_gpio_emc_b2_20)) ||
-			((pad >= pctl_pad_gpio_sd_b1_00) && (pad <= pctl_pad_gpio_disp_b2_15))) {
+	if ((pad <= pctl_pad_gpio_emc_b2_20) || ((pad >= pctl_pad_gpio_sd_b1_00) && (pad <= pctl_pad_gpio_disp_b1_11))) {
 		/* Fields have slightly diffrent meaning... */
 		if (pue == 0) {
 			pull = 3;
@@ -178,13 +177,21 @@ __attribute__((section(".noxip"))) int _imxrt_setIOpad(int pad, char sre, char d
 		t = *reg & ~0x1f;
 		t |= (!!sre) | (!!dse << 1) | (!!pue << 2) | (!!pus << 3);
 
-		if ((pad >= pctl_pad_test_mode) && (pad <= pctl_pad_gpio_snvs_09)) {
+		if (pad <= pctl_pad_gpio_disp_b2_15) {
+			t &= ~(1 << 4);
+			t |= !!ode << 4;
+		}
+		else if ((pad >= pctl_pad_wakeup) && (pad <= pctl_pad_gpio_snvs_09)) {
 			t &= ~(1 << 6);
 			t |= !!ode << 6;
 		}
-		else {
+		else if (pad >= pctl_pad_gpio_lpsr_00) {
 			t &= ~(1 << 5);
 			t |= !!ode << 5;
+		}
+		else {
+			/* MISRA */
+			/* pctl_pad_test_mode, pctl_pad_por_b, pctl_pad_onoff - no ode field */
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- properly set ranges of registers configured differently
- add a way of setting ODE field in non-LPSR/SNVS GPIO registers
- set proper ranges for setting ODE field in LPSR, SNVS, and remaining GPIO registers

## Motivation and Context
related: https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/618

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `armv7m7-imxrt1170-evk`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
