### PR TITLE
imxrt, rtt: Make RTT buffer and region sizes configurable

### DIFF
--- a/hal/armv7m/imxrt/10xx/106x/peripherals.h
+++ b/hal/armv7m/imxrt/10xx/106x/peripherals.h
@@ -30,6 +30,22 @@
 #define RTT_ENABLED_PLO 1
 #endif
 
+#ifndef RTT_BUFSZ_CONSOLE_TX
+#define RTT_BUFSZ_CONSOLE_TX 1024
+#endif
+
+#ifndef RTT_BUFSZ_CONSOLE_RX
+#define RTT_BUFSZ_CONSOLE_RX 1024
+#endif
+
+#ifndef RTT_BUFSZ_PHOENIXD_TX
+#define RTT_BUFSZ_PHOENIXD_TX 1024
+#endif
+
+#ifndef RTT_BUFSZ_PHOENIXD_RX
+#define RTT_BUFSZ_PHOENIXD_RX 1024
+#endif
+
 
 /* UART */
 #define UART_MAX_CNT 8

--- a/hal/armv7m/imxrt/117x/peripherals.h
+++ b/hal/armv7m/imxrt/117x/peripherals.h
@@ -31,6 +31,22 @@
 #define RTT_ENABLED_PLO 1
 #endif
 
+#ifndef RTT_BUFSZ_CONSOLE_TX
+#define RTT_BUFSZ_CONSOLE_TX 1024
+#endif
+
+#ifndef RTT_BUFSZ_CONSOLE_RX
+#define RTT_BUFSZ_CONSOLE_RX 1024
+#endif
+
+#ifndef RTT_BUFSZ_PHOENIXD_TX
+#define RTT_BUFSZ_PHOENIXD_TX 1024
+#endif
+
+#ifndef RTT_BUFSZ_PHOENIXD_RX
+#define RTT_BUFSZ_PHOENIXD_RX 1024
+#endif
+
 
 /* UART */
 

--- a/hal/armv7m/stm32/l4/peripherals.h
+++ b/hal/armv7m/stm32/l4/peripherals.h
@@ -22,6 +22,30 @@
 /* Interrupts */
 #define SIZE_INTERRUPTS (217 + 16)
 
+
+/* DEBUG - RTT PIPE */
+
+#ifndef RTT_ENABLED_PLO
+#define RTT_ENABLED_PLO 0
+#endif
+
+#ifndef RTT_BUFSZ_CONSOLE_TX
+#define RTT_BUFSZ_CONSOLE_TX 1024
+#endif
+
+#ifndef RTT_BUFSZ_CONSOLE_RX
+#define RTT_BUFSZ_CONSOLE_RX 1024
+#endif
+
+#ifndef RTT_BUFSZ_PHOENIXD_TX
+#define RTT_BUFSZ_PHOENIXD_TX 1024
+#endif
+
+#ifndef RTT_BUFSZ_PHOENIXD_RX
+#define RTT_BUFSZ_PHOENIXD_RX 1024
+#endif
+
+
 /* UART */
 #define UART_MAX_CNT 5
 

--- a/ld/armv7m7-imxrt106x.ldt
+++ b/ld/armv7m7-imxrt106x.ldt
@@ -26,11 +26,15 @@
 /* Space reserved for kernel data */
 #define AREA_KERNEL 0x2000
 
-/* Space reserved for RTT control block and buffers */
-#define SIZE_RTTMEM (2 * 2 * 0x400 + 256)
-
 
 #if defined(__LINKER__)
+
+/* Space reserved for RTT control block and buffers */
+#if defined(CUSTOM_RTT_MAP_SIZE)
+RTT_MAP_SIZE = CUSTOM_RTT_MAP_SIZE;
+#else
+RTT_MAP_SIZE = 0x4000;
+#endif
 
 /* FlexRAM configuration */
 #if defined(CUSTOM_FLEXRAM_CONFIG)
@@ -54,8 +58,8 @@ MEMORY
 	/* TODO: use FLEXRAM_CONFIG value to setup ocram/itcm/dtcm partitioning (*32k) */
 	m_itcm    (rwx) : ORIGIN = 0x00000000, LENGTH = FLEXRAM_ITCM_AREA
 	m_itext   (rwx) : ORIGIN = FLEXRAM_ITEXT_ADDR, LENGTH = FLEXRAM_ITEXT_AREA
-	m_dtcm    (rw)  : ORIGIN = 0x20000000 + AREA_KERNEL, LENGTH = FLEXRAM_DTCM_AREA - AREA_KERNEL - SIZE_RTTMEM
-	m_rttmem  (rw)  : ORIGIN = 0x20000000 + FLEXRAM_DTCM_AREA - SIZE_RTTMEM, LENGTH = SIZE_RTTMEM
+	m_dtcm    (rw)  : ORIGIN = 0x20000000 + AREA_KERNEL, LENGTH = FLEXRAM_DTCM_AREA - AREA_KERNEL - RTT_MAP_SIZE
+	m_rttmem  (rw)  : ORIGIN = 0x20000000 + FLEXRAM_DTCM_AREA - RTT_MAP_SIZE, LENGTH = RTT_MAP_SIZE
 	m_ocram   (rwx) : ORIGIN = 0x20200000, LENGTH = 0 * 32k
 	m_flash   (rx)  : ORIGIN = 0x70000000, LENGTH = 128k /* Not actual flash size. Initial flash size to be put into FCB block for imxrt BootROM init procedure only */
 }

--- a/ld/armv7m7-imxrt117x.ldt
+++ b/ld/armv7m7-imxrt117x.ldt
@@ -29,11 +29,15 @@
 /* Space reserved for bootloader */
 #define AREA_BOOTLOADER 0x10000
 
-/* Space reserved for RTT control block and buffers */
-#define SIZE_RTTMEM (2 * 2 * 0x400 + 256)
-
 
 #if defined(__LINKER__)
+
+/* Space reserved for RTT control block and buffers */
+#if defined(CUSTOM_RTT_MAP_SIZE)
+RTT_MAP_SIZE = CUSTOM_RTT_MAP_SIZE;
+#else
+RTT_MAP_SIZE = 0x4000;
+#endif
 
 /* FlexRAM configuration */
 #if defined(CUSTOM_FLEXRAM_CONFIG)
@@ -56,8 +60,8 @@ MEMORY
 {
 	m_itcm    (rwx) : ORIGIN = 0x00000000, LENGTH = FLEXRAM_ITCM_AREA
 	m_itext   (rwx) : ORIGIN = 0x00000000 + FLEXRAM_ITEXT_ADDR, LENGTH = FLEXRAM_ITEXT_AREA
-	m_dtcm    (rw)  : ORIGIN = 0x20000000 + AREA_KERNEL, LENGTH = FLEXRAM_DTCM_AREA - AREA_KERNEL - SIZE_RTTMEM
-	m_rttmem  (rw)  : ORIGIN = 0x20000000 + FLEXRAM_DTCM_AREA - SIZE_RTTMEM, LENGTH = SIZE_RTTMEM
+	m_dtcm    (rw)  : ORIGIN = 0x20000000 + AREA_KERNEL, LENGTH = FLEXRAM_DTCM_AREA - AREA_KERNEL - RTT_MAP_SIZE
+	m_rttmem  (rw)  : ORIGIN = 0x20000000 + FLEXRAM_DTCM_AREA - RTT_MAP_SIZE, LENGTH = RTT_MAP_SIZE
 	m_ocram1  (rwx) : ORIGIN = 0x20240000 + AREA_BOOTLOADER, LENGTH = (8 * 32k) - AREA_BOOTLOADER
 	m_ocram2  (rwx) : ORIGIN = 0x202c0000, LENGTH = 512k
 	m_flash   (rx)  : ORIGIN = 0x30000000, LENGTH = 128k /* Not actual flash size. Initial flash size to be put into FCB block for imxrt BootROM init procedure only */


### PR DESCRIPTION
Change default RTT region size to 16 KiB to fit 4 KiB of buffers and a control block on evks and align it to plo map size.

JIRA: NIL-596

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imxrt117x

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
