### PR TITLE
flash-ftmctrl: disable faulty array bounds check

### DIFF
--- a/devices/flash-ftmctrl/amd-flash.c
+++ b/devices/flash-ftmctrl/amd-flash.c
@@ -19,6 +19,11 @@
 #include <lib/lib.h>
 
 
+/* GCC bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104657 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+
+
 /* Valid offset on flash - for executing commands */
 #define FLASH_VALID_OFFS 0x0
 #define STS_FULL_CHECK   ((1 << 5) | (1 << 4) | (1 << 3) | (1 << 1))
@@ -111,6 +116,9 @@ __attribute__((section(".noxip"))) static void amd_exitQuery(void)
 {
 	*(vu8 *)ADDR_FLASH = AMD_CMD_EXIT_QUERY;
 }
+
+
+#pragma GCC diagnostic pop
 
 
 /* These structures must not reside on flash */


### PR DESCRIPTION
JIRA: RTOS-927

<!--- Provide a general summary of your changes in the Title above -->

## Description
disable false positive GCC check.
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104657

```
/src/plo/devices/flash-ftmctrl/amd-flash.c: In function 'amd_statusClear':
/src/plo/devices/flash-ftmctrl/amd-flash.c:50:9: warning: array subscript 0 is outside array bounds of 'volatile vu8[0]' {aka 'volatile unsigned char[]'} [-Warray-bounds=]
   50 |         *(vu8 *)(ADDR_FLASH + 0x0aaa) = AMD_CMD_CLR_STATUS;
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: note: source object is likely at address zero
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
