### PR TITLE
zynqmp: fix UART RX cleanup

### DIFF
--- a/devices/uart-zynq/uart.c
+++ b/devices/uart-zynq/uart.c
@@ -464,9 +464,13 @@ static int uart_init(unsigned int minor)
 		*(uart->base + cr) = (*(uart->base + cr) & ~0x000001ff) | 0x00000017;
 	}
 
-#if (UART_CONSOLE_ROUTED_VIA_PL != 1)
+#if (UART_CONSOLE_ROUTED_VIA_PL == 1)
 	/* Reset RX to discard possible invalid chars from PL when UART is routed via PL */
 	*(uart->base + cr) |= (1 << 0);
+	/* Wait until RX FIFO is empty */
+	while (0 != (*(uart->base + cr) & (1 << 0))) {
+		/* do nothing */
+	};
 #endif
 
 	/* Enable RX FIFO trigger */


### PR DESCRIPTION
Changes:
- fixed an error I made after testing solution, but before PR was accepted (wrong comparison in conditional macro)
- added wait until RX FIFO is empty - it looks like real trash data can fill entire RX FIFO and without wait until it is empty it does stops our board in bootloader
- see register field description on screenshot below

![image](https://github.com/user-attachments/assets/2f26b62f-8d11-4008-849a-7bd25ef3e925)


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: ZynqMP Pilot board

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
