### PR TITLE
syspage: Improve HAS_GRAPHICS macro checking

### DIFF
--- a/syspage.c
+++ b/syspage.c
@@ -627,7 +627,8 @@ void syspage_progShow(void)
 }
 
 
-#if HAS_GRAPHICS
+/* TODO: function get value from hal-specific struct, consider move to target-specific code */
+#if defined(HAS_GRAPHICS) && HAS_GRAPHICS != 0
 void syspage_graphmodeSet(graphmode_t graphmode)
 {
 	syspage_common.syspage->hs.graphmode.width = graphmode.width;

--- a/syspage.h
+++ b/syspage.h
@@ -77,7 +77,7 @@ extern void syspage_progShow(void);
 extern void syspage_consoleSet(unsigned int id);
 
 
-#if HAS_GRAPHICS
+#if defined(HAS_GRAPHICS) && HAS_GRAPHICS != 0
 /* Graphics mode */
 extern void syspage_graphmodeSet(graphmode_t graphmode);
 #endif


### PR DESCRIPTION
Change HAS_GRAPHICS macro checking to rely on definition of those instead of defined value. With this approach warning stopped to be raised, when enable -Wundef flag

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
There are some useful warning flags, which are enabled in internal projects, like `-Wundef` and `-Wshadow`.

This commit allow plo to be build with `-Wundef` without warnings

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To enable `-Wundef` flag in the future

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: build successful on armv7m4-stm32l4x6-nucleo and ia32-generic-qemu; not able to verify if graphic mode still works

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
