### PR TITLE
hal/armv8m add mpu support

### DIFF
--- a/hal/armv8m/mpu.c
+++ b/hal/armv8m/mpu.c
@@ -3,10 +3,10 @@
  *
  * Operating system loader
  *
- * MPU API - not implemented
+ * MPU API
  *
- * Copyright 2021, 2022 Phoenix Systems
- * Author: Gerard Swiderski, Damian Loewnau
+ * Copyright 2021, 2022, 2025 Phoenix Systems
+ * Author: Gerard Swiderski, Damian Loewnau, Krzysztof Radzewicz
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -20,27 +20,166 @@
 static mpu_common_t mpu_common;
 
 
+enum { mpu_type,
+	mpu_ctrl,
+	mpu_rnr,
+	mpu_rbar,
+	mpu_rlar,
+	mpu_rbar_a1,
+	mpu_rlar_a1,
+	mpu_rbar_a2,
+	mpu_rlar_a2,
+	mpu_rbar_a3,
+	mpu_rlar_a3,
+	mpu_mair0 = 0xC,
+	mpu_mair1 };
+
+
+/* Translate memory map attributes to RLAR attribute bits */
+static u32 mpu_regionAttrsRlar(u32 attr, unsigned int enable)
+{
+	u8 attrIndx = 0, execNever = 0;
+	attrIndx |= ((attr & mAttrCacheable) != 0) ? 1 : 0;
+	attrIndx |= ((attr & mAttrBufferable) != 0) ? (1 << 1) : 0;
+	execNever |= ((attr & mAttrExec) == 0) ? 1 : 0;
+	return (execNever << 4) | (attrIndx << 1) | (enable != 0);
+}
+
+
+/* Translate memory map attributes to RLAR attribute bits */
+static u32 mpu_regionAttrsRbar(u32 attr, unsigned int enable)
+{
+	u8 ap = 0; /* set privileged read-write access, unprivileged no access */
+
+	if ((attr & mAttrRead) != 0) {
+		/*
+		 * set privileged read-write access, unprivileged read only access
+		 * armv8m does not support that
+		 * instead set both levels to read/write
+		 */
+		ap = 1;
+	}
+
+	if ((attr & mAttrWrite) != 0) {
+		ap = 1; /* set priviliged read-write access, unprivileged read and write access */
+	}
+
+	return (((attr & mAttrShareable) != 0) << 4) |
+			(ap << 1) |
+			((attr & mAttrExec) == 0);
+}
+
+/* Setup single MPU region entry in local MPU context */
+static int mpu_regionSet(unsigned int *idx, addr_t start, addr_t end, u32 rbarAttr, u32 rlarAttr, u32 mapId)
+{
+	/* Allow end == 0, this means end of address range */
+	const size_t size = (end - start) & 0xffffffffu;
+	u32 limit = end - 1;
+
+	if (*idx >= mpu_common.regMax) {
+		return -EPERM;
+	}
+
+	/* Allow end == 0, this means end of address range */
+	if ((end != 0) && (end <= start)) {
+		return -EINVAL;
+	}
+
+	/* Check if entire address range is requested */
+	if (size == 0) {
+		limit = 0xffffffff;
+	}
+	else if (size < 32 || ((size & 0x1f) != 0) || ((start & 0x1f) != 0)) {
+		/* Not supported by MPU */
+		return -EPERM;
+	}
+
+	mpu_common.region[*idx].rbar = (start & ~0x1f) | rbarAttr;
+	mpu_common.region[*idx].rlar = (limit & ~0x1f) | rlarAttr;
+	mpu_common.mapId[*idx] = mapId;
+
+	*idx += 1;
+	return EOK;
+}
+
+
 const mpu_common_t *const mpu_getCommon(void)
 {
-	/* TODO: return initialized structure, when enabling MPU on armv8m */
 	return &mpu_common;
+}
+
+
+/* Invalidate range of regions */
+static void mpu_regionInvalidate(u8 first, u8 last)
+{
+	unsigned int i;
+
+	for (i = first; i < last && i < mpu_common.regMax; i++) {
+		/* set multi-map to none */
+		mpu_common.mapId[i] = (u32)-1;
+
+		/* mark i-th region as disabled */
+		mpu_common.region[i].rlar = 0;
+
+		/* set exec never */
+		mpu_common.region[i].rbar = 1;
+	}
 }
 
 
 void mpu_init(void)
 {
-	/* TODO: add implementation, when enabling MPU on armv8m */
+	volatile u32 *mpu_base = (void *)0xe000ed90;
+	mpu_common.type = *(mpu_base + mpu_type);
+	mpu_common.regMax = (u8)(mpu_common.type >> 8);
+	mpu_common.regCnt = mpu_common.mapCnt = 0;
+
+	mpu_regionInvalidate(0, sizeof(mpu_common.region) / sizeof(mpu_common.region[0]));
+
+	/*
+	 * syspage structure lacks fields for mair registers, instead programming them in plo
+	 * MPU_MAIR0 Attrn:
+	 * 3: Cacheable & Bufferable -> outer and inner write back, read alloc policy
+	 * 1: Cacheable & !Bufferable -> outer and inner Write-Through, read alloc policy
+	 * 2: !Cacheable & Bufferable -> device memory (armv7m), nGnRE
+	 * 0: !Cacheable & !Bufferable -> device memory (armv7m strongly ordered) nGnRnE
+	 */
+
+	*(mpu_base + mpu_mair0) = 0xee04aa00;
 }
 
 
 int mpu_regionAlloc(addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int enable)
 {
-	/* TODO: add implementation, when enabling MPU on armv8m */
-	return 0;
-}
+	int res;
+	unsigned int regCur = mpu_common.regCnt;
+	u32 rbarAttr = mpu_regionAttrsRbar(attr, enable);
+	u32 rlarAttr = mpu_regionAttrsRlar(attr, enable);
 
+	res = mpu_regionSet(&regCur, addr, end, rbarAttr, rlarAttr, mapId);
+	if (res != EOK) {
+		mpu_regionInvalidate(mpu_common.regCnt, regCur);
+		return res;
+	}
+
+	mpu_common.regCnt = regCur;
+	mpu_common.mapCnt++;
+
+	return EOK;
+}
 
 void mpu_getHalData(hal_syspage_t *hal)
 {
-	/* TODO: add implementation, when enabling MPU on armv8m */
+	unsigned int i;
+
+	mpu_regionInvalidate(mpu_common.regCnt, mpu_common.regMax);
+
+	hal->mpu.type = mpu_common.type;
+	hal->mpu.allocCnt = mpu_common.regCnt;
+
+	for (i = 0; i < sizeof(hal->mpu.table) / sizeof(hal->mpu.table[0]); i++) {
+		hal->mpu.table[i].rbar = mpu_common.region[i].rbar;
+		hal->mpu.table[i].rlar = mpu_common.region[i].rlar;
+		hal->mpu.map[i] = mpu_common.mapId[i];
+	}
 }


### PR DESCRIPTION
JIRA: RTOS-1068

<!--- Provide a general summary of your changes in the Title above -->
Adding implementations for mpu api in hal/armv8m/mpu.c

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Part of [RTOS-1068] Port to STM32N6 processor

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
syspage_t populated with configuration values for the mpu, however hal_syspage_t lacks some fields, see end.

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->
Requires changes in kernel on the kradzewicz/armv8m_mpu branch

## How Has This Been Tested?
Tested by building and running the system

## Special treatment
There are two potential issues with this implementation that should be discussed:
1. pmap api from kernel always gives priviliged mode processor rw access to all mem regions. Unpriviliged processor gets either r only or rw. However armv8m doesn't support that fully, you cannot set priviliged rw and unpriviliged r. Instead giving unpriviliged mode full rw in that case.
2. hal_syspage_t doesn't include fields for mpu_mair register that allow setting memory attributes. Currently they are programmed in plo (mpu.c)
