### PR TITLE
Introduce Kernel Partitioning

### DIFF
--- a/cmds/Makefile
+++ b/cmds/Makefile
@@ -7,8 +7,8 @@
 #
 
 PLO_ALLCOMMANDS = alias app bankswitch bitstream blob bootcm4 bootrom bridge call console \
-  copy devices dump echo erase go help jffs2 kernel kernelimg lspci map mem memcrypt mpu otp phfs \
-  ptable reboot script stop test-dev test-ddr wait watchdog vbe
+  copy devices dump echo erase go help jffs2 kernel kernelimg lspci map mem memcrypt mpu otp part phfs \
+  ptable reboot sched script stop test-dev test-ddr wait watchdog vbe
 
 PLO_COMMANDS ?= $(PLO_ALLCOMMANDS)
 PLO_APPLETS = $(filter $(PLO_ALLCOMMANDS), $(PLO_COMMANDS))

--- a/cmds/Makefile
+++ b/cmds/Makefile
@@ -7,8 +7,8 @@
 #
 
 PLO_ALLCOMMANDS = alias app bankswitch bitstream blob bootcm4 bootrom bridge call console \
-  copy devices dump echo erase go help jffs2 kernel kernelimg lspci map mem memcrypt mpu otp part phfs \
-  ptable reboot sched script stop test-dev test-ddr wait watchdog vbe
+  copy devices dump echo erase go help jffs2 kernel kernelimg lspci map mem memcrypt mpu otp part port \
+  phfs ptable reboot sched script stop test-dev test-ddr wait watchdog vbe
 
 PLO_COMMANDS ?= $(PLO_ALLCOMMANDS)
 PLO_APPLETS = $(filter $(PLO_ALLCOMMANDS), $(PLO_COMMANDS))

--- a/cmds/app.c
+++ b/cmds/app.c
@@ -161,6 +161,10 @@ static int cmd_appLoad(handler_t handler, size_t size, const char *name, char *i
 	prog->start = entry->start;
 	prog->end = entry->end;
 
+	if ((res = hal_getProgData(prog, imaps, imapSz, dmaps, dmapSz)) < 0) {
+		return res;
+	}
+
 	return EOK;
 }
 

--- a/cmds/app.c
+++ b/cmds/app.c
@@ -81,7 +81,7 @@ static size_t cmd_mapsParse(char *maps, char sep)
 }
 
 
-static int cmd_appLoad(handler_t handler, size_t size, const char *name, char *imaps, char *dmaps, const char *appArgv, u32 flags)
+static int cmd_appLoad(handler_t handler, size_t size, const char *name, char *imaps, char *dmaps, const char *appArgv, u32 flags, char *partName)
 {
 	int res;
 	Elf32_Ehdr hdr;
@@ -92,6 +92,7 @@ static int cmd_appLoad(handler_t handler, size_t size, const char *name, char *i
 
 	syspage_prog_t *prog;
 	const mapent_t *entry;
+	syspage_part_t *partition;
 
 	/* Check ELF header */
 	if ((res = phfs_read(handler, 0, &hdr, sizeof(Elf32_Ehdr))) < 0) {
@@ -151,19 +152,39 @@ static int cmd_appLoad(handler_t handler, size_t size, const char *name, char *i
 		return -ENOMEM;
 	}
 
-
 	if ((res = cmd_mapsAdd2Prog(prog->imaps, imapSz, imaps)) < 0 ||
 			(res = cmd_mapsAdd2Prog(prog->dmaps, dmapSz, dmaps)) < 0)
 		return res;
+
+	/* create hal structures */
+	prog->hal = NULL;
+	if (partName == NULL) {
+		/* Default partition apps have their own hal structures */
+		partName = NAME_PART_DEFAULT;
+		prog->hal = syspage_alloc(sizeof(*prog->hal));
+		if (prog->hal == NULL) {
+			log_error("\nCannot allocate memory for %s", name);
+			return -ENOMEM;
+		}
+		res = hal_getPartData(prog->hal, imaps, imapSz, dmaps, dmapSz);
+		if (res < 0) {
+			log_error("\nCannot get partition data for %s", name);
+			return res;
+		}
+	}
+	if (syspage_partResolve(partName, &partition) != EOK) {
+		log_error("\nPartition `%s` does not exist!", partName);
+		return -EINVAL;
+	}
+	if (prog->hal == NULL) {
+		prog->hal = partition->hal;
+	}
 
 	prog->imapSz = imapSz;
 	prog->dmapSz = dmapSz;
 	prog->start = entry->start;
 	prog->end = entry->end;
-
-	if ((res = hal_getProgData(prog, imaps, imapSz, dmaps, dmapSz)) < 0) {
-		return res;
-	}
+	prog->partition = partition;
 
 	return EOK;
 }
@@ -179,6 +200,7 @@ static int cmd_app(int argc, char *argv[])
 
 	const char *appArgv;
 	char name[SIZE_CMD_ARG_LINE];
+	char *part;
 
 	handler_t handler;
 	phfs_stat_t stat;
@@ -188,7 +210,7 @@ static int cmd_app(int argc, char *argv[])
 		syspage_progShow();
 		return CMD_EXIT_SUCCESS;
 	}
-	else if (argc < 5 || argc > 6) {
+	else if (argc < 5 || argc > 7) {
 		log_error("\n%s: Wrong argument count", argv[0]);
 		return CMD_EXIT_FAILURE;
 	}
@@ -214,7 +236,7 @@ static int cmd_app(int argc, char *argv[])
 		}
 	}
 
-	if (argvID != (argc - 3)) {
+	if (argvID > (argc - 3)) {
 		log_error("\n%s: Invalid arg, 'dmap' is not declared", argv[0]);
 		return CMD_EXIT_FAILURE;
 	}
@@ -235,6 +257,14 @@ static int cmd_app(int argc, char *argv[])
 	/* ARG_5: maps for data */
 	dmaps = argv[++argvID];
 
+	/* ARG_6: partition name */
+	if (argc > ++argvID) {
+		part = argv[argvID];
+	}
+	else {
+		part = NULL;
+	}
+
 	/* Open file */
 	res = phfs_open(argv[1], name, 0, &handler);
 	if (res < 0) {
@@ -250,7 +280,7 @@ static int cmd_app(int argc, char *argv[])
 		return CMD_EXIT_FAILURE;
 	}
 
-	res = cmd_appLoad(handler, stat.size, name, imaps, dmaps, appArgv, flags);
+	res = cmd_appLoad(handler, stat.size, name, imaps, dmaps, appArgv, flags, part);
 	if (res < 0) {
 		log_error("\nCan't load %s to %s via %s (%d)", name, imaps, argv[1], res);
 		phfs_close(handler);

--- a/cmds/mpu.c
+++ b/cmds/mpu.c
@@ -82,7 +82,7 @@ static void mpu_regionPrint(const char *name, u32 rbar, u32 rasr)
 
 static void cmd_mpuInfo(void)
 {
-	lib_printf("prints the use of MPU regions, usage: mpu [prog name]");
+	lib_printf("prints the use of MPU regions, usage: mpu [partition name]");
 }
 
 
@@ -90,12 +90,12 @@ static int cmd_mpu(int argc, char *argv[])
 {
 	const char *name;
 	unsigned int i;
-	const syspage_prog_t *prog = syspage_progsGet();
-	const syspage_prog_t *firstProg = prog;
+	const syspage_part_t *part = syspage_partsGet();
+	const syspage_part_t *firstPart = part;
 	const unsigned int regMax = mpu_getMaxRegionsCount();
 
-	if (prog == NULL) {
-		log_error("\nNo programs in syspage!");
+	if (part == NULL) {
+		log_error("\nNo partitions in syspage!");
 		return CMD_EXIT_FAILURE;
 	}
 
@@ -105,33 +105,33 @@ static int cmd_mpu(int argc, char *argv[])
 	}
 
 	do {
-		name = (prog->argv[0] == 'X') ? prog->argv + 1 : prog->argv;
+		name = part->name;
 		if ((argc == 2) && (hal_strcmp(name, argv[1]) != 0)) {
-			prog = prog->next;
+			part = part->next;
 			continue;
 		}
-		lib_printf("\n%-16s 0x%08x%4s 0x%08x", name, prog->start, "", prog->end);
+		lib_printf("\n%-16s", name);
 		lib_printf(CONSOLE_BOLD "\n%-9s %-7s %-4s %-11s %-11s %-3s %-3s %-9s %-4s %-2s %-2s %-2s\n" CONSOLE_NORMAL,
 				"MAP NAME", "REGION", "SUB", "START", "END", "EN", "XN", "PERM P/U", "TEX", "S", "C", "B");
-		for (i = 0; i < prog->hal.mpu.allocCnt; i++) {
-			name = syspage_mapName(prog->hal.mpu.map[i]);
+		for (i = 0; i < part->hal->mpu.allocCnt; i++) {
+			name = syspage_mapName(part->hal->mpu.map[i]);
 			if (name == NULL) {
 				name = "<none>";
 			}
-			mpu_regionPrint(name, prog->hal.mpu.table[i].rbar, prog->hal.mpu.table[i].rasr);
+			mpu_regionPrint(name, part->hal->mpu.table[i].rbar, part->hal->mpu.table[i].rasr);
 		}
 
-		lib_printf("Configured %d of %d MPU regions.\n", prog->hal.mpu.allocCnt, regMax);
+		lib_printf("Configured %d of %d MPU regions.\n", part->hal->mpu.allocCnt, regMax);
 
 		if (argc == 2) {
 			return CMD_EXIT_SUCCESS;
 		}
 
-		prog = prog->next;
-	} while (prog != firstProg);
+		part = part->next;
+	} while (part != firstPart);
 
 	if (argc == 2) {
-		log_error("\nProgram %s not found in syspage!", argv[1]);
+		log_error("\nPartition %s not found in syspage!", argv[1]);
 		return CMD_EXIT_FAILURE;
 	}
 

--- a/cmds/part.c
+++ b/cmds/part.c
@@ -22,32 +22,7 @@
 
 static void cmd_partInfo(void)
 {
-	lib_printf("creates partition, usage: part <name> <accessmap1;accessmap2...> <schedwindowNr1;schedwindowNr2...> <memlimit>");
-}
-
-
-static int cmd_schedWindowAddToPart(u32 *schedIds, size_t nb, char *schedStr, const char *cmd)
-{
-	unsigned long window;
-	size_t i;
-
-	*schedIds = 0;
-
-	for (i = 0; i < nb; ++i) {
-		window = lib_strtoul(schedStr, &schedStr, 10);
-		if (*schedStr != '\0') {
-			log_error("\n%s: Scheduler window is not a valid number", cmd);
-			return -EINVAL;
-		}
-		if (window >= syspage_schedulerWindowCount()) {
-			log_error("\n%s: Invalid scheduler window index", cmd);
-			return -EINVAL;
-		}
-
-		*schedIds |= 1U << window;
-		schedStr += 1; /* '\0' */
-	}
-	return EOK;
+	lib_printf("creates partition, usage: part <name> <accessmap1;accessmap2...> <schedwindow> <memlimit>");
 }
 
 
@@ -70,13 +45,16 @@ static size_t cmd_listParse(char *list, char sep)
 static int cmd_part(int argc, char *argv[])
 {
 	int res, argvID = 0;
+	size_t accessSz;
 
-	char *accessMaps, *schedWindows, *availableMem;
-	size_t accessSz, schedWinSz;
-	u32 schedWindowsMask;
-
-	const char *name;
-	syspage_part_t *part, *other;
+	char *name;
+	unsigned char schedWindow;
+	size_t availableMem, i;
+	char *accessMap;
+	u8 id;
+	hal_syspage_part_t *hal;
+	syspage_part_t *part;
+	syspage_sched_t *config;
 
 	/* Parse command arguments */
 	if (argc != 5) {
@@ -86,21 +64,69 @@ static int cmd_part(int argc, char *argv[])
 
 	/* ARG_0: command name */
 
-	/* ARG_1: partition name */
 	argvID = 1;
-	name = argv[argvID++];
+
+	/* ARG_1: partition name */
+	name = syspage_alloc(hal_strlen(argv[argvID]) + 1);
+	if (name == NULL) {
+		log_error("\nCannot allocate memory for %s", argv[argvID]);
+		return -ENOMEM;
+	}
+	hal_strcpy(name, argv[argvID]);
+
+	argvID++;
 
 	/* ARG_2: accessible maps */
-	accessMaps = argv[argvID++];
+	accessSz = cmd_listParse(argv[argvID], ';');
+	if (accessSz > sizeof(part->maps) / sizeof(part->maps[0])) {
+		log_error("\n%s: Too many access maps in partition %s", argv[argvID], name);
+		return -EINVAL;
+	}
+	accessMap = argv[argvID];
+	for (i = 0; i < accessSz; ++i) {
+		if (syspage_mapNameResolve(accessMap, &id) < 0) {
+			log_error("\n%s: Invalid map name", accessMap);
+			return -EINVAL;
+		}
+		accessMap += hal_strlen(accessMap) + 1U;
+	}
+	accessMap = argv[argvID];
+
+	hal = syspage_alloc(sizeof(*hal));
+	if (hal == NULL) {
+		log_error("\nCannot allocate memory for %s", name);
+		return -ENOMEM;
+	}
+	res = hal_getPartData(hal, NULL, 0, argv[argvID], accessSz);
+	if (res < 0) {
+		return res;
+	}
+
+	argvID++;
 
 	/* ARG_3: scheduler windows */
-	schedWindows = argv[argvID++];
+	schedWindow = lib_strtoul(argv[argvID], &argv[argvID], 10);
+	if (*argv[argvID] != '\0') {
+		log_error("\n%s: Invalid arguments", argv[0]);
+		return -EINVAL;
+	}
+	config = syspage_schedulerConfigGet();
+	if ((config == NULL) || (schedWindow > config->windowCnt)) {
+		log_error("\n%s: Invalid scheduler window number", argv[0]);
+		return -EINVAL;
+	}
+
+	argvID++;
 
 	/* ARG_4: memory allocation limit */
-	availableMem = argv[argvID];
-
-	accessSz = cmd_listParse(accessMaps, ';');
-	schedWinSz = cmd_listParse(schedWindows, ';');
+	availableMem = lib_strtoul(argv[argvID], &argv[argvID], 0);
+	if (*argv[argvID] != '\0') {
+		log_error("\n%s: Invalid arguments", argv[0]);
+		return -EINVAL;
+	}
+	if (availableMem == 0) {
+		availableMem = (size_t)-1;
+	}
 
 	part = syspage_partAdd();
 	if (part == NULL) {
@@ -108,46 +134,13 @@ static int cmd_part(int argc, char *argv[])
 		return -ENOMEM;
 	}
 
-	part->name = syspage_alloc(hal_strlen(name) + 1);
-	if (part->name == NULL) {
-		log_error("\nCannot allocate memory for %s", name);
-		return -ENOMEM;
-	}
-
-	res = cmd_schedWindowAddToPart(&schedWindowsMask, schedWinSz, schedWindows, argv[0]);
-	if (res < 0) {
-		return res;
-	}
-	part->schedWindowsMask = schedWindowsMask;
-
-	other = syspage_partsGet();
-	do {
-		if (((part->schedWindowsMask & other->schedWindowsMask) != 0U) &&
-				(part->schedWindowsMask != other->schedWindowsMask)) {
-			log_error("\nUnsupported scheduler windows configuration for partitions %s and %s", name, other->name);
-			return -EINVAL;
-		}
-		other = other->next;
-	} while (other != syspage_partsGet());
-
-	part->availableMem = lib_strtoul(availableMem, &availableMem, 0);
-	if (*availableMem != '\0') {
-		log_error("\n%s: Invalid arguments", argv[0]);
-		return -EINVAL;
-	}
-	if (part->availableMem == 0) {
-		part->availableMem = (size_t)-1;
-	}
-	hal_strcpy(part->name, name);
-
-	part->hal = syspage_alloc(sizeof(*part->hal));
-	if (part->hal == NULL) {
-		log_error("\nCannot allocate memory for %s", name);
-		return -ENOMEM;
-	}
-	res = hal_getPartData(part->hal, NULL, 0, accessMaps, accessSz);
-	if (res < 0) {
-		return res;
+	part->name = name;
+	part->hal = hal;
+	part->schedWindow = schedWindow;
+	part->availableMem = availableMem;
+	for (i = 0; i < accessSz; ++i) {
+		syspage_mapNameResolve(accessMap, &part->maps[i]);
+		accessMap += hal_strlen(accessMap) + 1U;
 	}
 
 	return CMD_EXIT_SUCCESS;

--- a/cmds/part.c
+++ b/cmds/part.c
@@ -22,7 +22,7 @@
 
 static void cmd_partInfo(void)
 {
-	lib_printf("creates partition, usage: part <name> <accessmap1;accessmap2...> <schedwindow> <memlimit>");
+	lib_printf("creates partition, usage: part <name> <accessmap1;accessmap2...> <schedwindow> <memlimit> [-itcp]");
 }
 
 
@@ -55,9 +55,10 @@ static int cmd_part(int argc, char *argv[])
 	hal_syspage_part_t *hal;
 	syspage_part_t *part;
 	syspage_sched_t *config;
+	unsigned int flags = 0;
 
 	/* Parse command arguments */
-	if (argc != 5) {
+	if (argc < 5 || argc > 6) {
 		log_error("\n%s: Wrong argument count", argv[0]);
 		return CMD_EXIT_FAILURE;
 	}
@@ -128,6 +129,36 @@ static int cmd_part(int argc, char *argv[])
 		availableMem = (size_t)-1;
 	}
 
+	argvID++;
+
+	/* Flags */
+	if (argvID < argc) {
+		if (argv[argvID][0] != '-') {
+			log_error("\n%s: Invalid arguments", argv[0]);
+			return -EINVAL;
+		}
+		i = 1;
+		while (argv[argvID][i] != '\0') {
+			switch (argv[argvID][i++]) {
+				case 'i':
+					flags |= pFlagIntr;
+					break;
+				case 't':
+					flags |= pFlagTime;
+					break;
+				case 'c':
+					flags |= pFlagPctl;
+					break;
+				case 'p':
+					flags |= pFlagPerf;
+					break;
+				default:
+					log_error("\n%s: Invalid arguments", argv[0]);
+					return -EINVAL;
+			}
+		}
+	}
+
 	part = syspage_partAdd();
 	if (part == NULL) {
 		log_error("\nCannot allocate memory for %s", name);
@@ -138,6 +169,7 @@ static int cmd_part(int argc, char *argv[])
 	part->hal = hal;
 	part->schedWindow = schedWindow;
 	part->availableMem = availableMem;
+	part->flags = flags;
 	for (i = 0; i < accessSz; ++i) {
 		syspage_mapNameResolve(accessMap, &part->maps[i]);
 		accessMap += hal_strlen(accessMap) + 1U;

--- a/cmds/part.c
+++ b/cmds/part.c
@@ -1,0 +1,159 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system loader
+ *
+ * Create partition
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Jakub Klimek
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "cmd.h"
+#include "elf.h"
+
+#include <lib/lib.h>
+#include <hal/hal.h>
+#include <phfs/phfs.h>
+#include <syspage.h>
+
+
+static void cmd_partInfo(void)
+{
+	lib_printf("creates partition, usage: part <name> <accessmap1;accessmap2...> <schedwindowNr1;schedwindowNr2...> <memlimit>");
+}
+
+
+static int cmd_schedWindowAddToPart(u32 *schedIds, size_t nb, char *schedStr, const char *cmd)
+{
+	unsigned long window;
+	size_t i;
+
+	*schedIds = 0;
+
+	for (i = 0; i < nb; ++i) {
+		window = lib_strtoul(schedStr, &schedStr, 10);
+		if (*schedStr != '\0') {
+			log_error("\n%s: Scheduler window is not a valid number", cmd);
+			return -EINVAL;
+		}
+		if (window >= syspage_schedulerWindowCount()) {
+			log_error("\n%s: Invalid scheduler window index", cmd);
+			return -EINVAL;
+		}
+
+		*schedIds |= 1U << window;
+		schedStr += 1; /* '\0' */
+	}
+	return EOK;
+}
+
+
+static size_t cmd_listParse(char *list, char sep)
+{
+	size_t nb = 0;
+
+	while (*list != '\0') {
+		if (*list == sep) {
+			*list = '\0';
+			++nb;
+		}
+		list++;
+	}
+
+	return ++nb;
+}
+
+
+static int cmd_part(int argc, char *argv[])
+{
+	int res, argvID = 0;
+
+	char *accessMaps, *schedWindows, *availableMem;
+	size_t accessSz, schedWinSz;
+	u32 schedWindowsMask;
+
+	const char *name;
+	syspage_part_t *part, *other;
+
+	/* Parse command arguments */
+	if (argc != 5) {
+		log_error("\n%s: Wrong argument count", argv[0]);
+		return CMD_EXIT_FAILURE;
+	}
+
+	/* ARG_0: command name */
+
+	/* ARG_1: partition name */
+	argvID = 1;
+	name = argv[argvID++];
+
+	/* ARG_2: accessible maps */
+	accessMaps = argv[argvID++];
+
+	/* ARG_3: scheduler windows */
+	schedWindows = argv[argvID++];
+
+	/* ARG_4: memory allocation limit */
+	availableMem = argv[argvID];
+
+	accessSz = cmd_listParse(accessMaps, ';');
+	schedWinSz = cmd_listParse(schedWindows, ';');
+
+	part = syspage_partAdd();
+	if (part == NULL) {
+		log_error("\nCannot allocate memory for %s", name);
+		return -ENOMEM;
+	}
+
+	part->name = syspage_alloc(hal_strlen(name) + 1);
+	if (part->name == NULL) {
+		log_error("\nCannot allocate memory for %s", name);
+		return -ENOMEM;
+	}
+
+	res = cmd_schedWindowAddToPart(&schedWindowsMask, schedWinSz, schedWindows, argv[0]);
+	if (res < 0) {
+		return res;
+	}
+	part->schedWindowsMask = schedWindowsMask;
+
+	other = syspage_partsGet();
+	do {
+		if (((part->schedWindowsMask & other->schedWindowsMask) != 0U) &&
+				(part->schedWindowsMask != other->schedWindowsMask)) {
+			log_error("\nUnsupported scheduler windows configuration for partitions %s and %s", name, other->name);
+			return -EINVAL;
+		}
+		other = other->next;
+	} while (other != syspage_partsGet());
+
+	part->availableMem = lib_strtoul(availableMem, &availableMem, 0);
+	if (*availableMem != '\0') {
+		log_error("\n%s: Invalid arguments", argv[0]);
+		return -EINVAL;
+	}
+	if (part->availableMem == 0) {
+		part->availableMem = (size_t)-1;
+	}
+	hal_strcpy(part->name, name);
+
+	part->hal = syspage_alloc(sizeof(*part->hal));
+	if (part->hal == NULL) {
+		log_error("\nCannot allocate memory for %s", name);
+		return -ENOMEM;
+	}
+	res = hal_getPartData(part->hal, NULL, 0, accessMaps, accessSz);
+	if (res < 0) {
+		return res;
+	}
+
+	return CMD_EXIT_SUCCESS;
+}
+
+
+static const cmd_t part_cmd __attribute__((section("commands"), used)) = {
+	.name = "part", .run = cmd_part, .info = cmd_partInfo
+};

--- a/cmds/port.c
+++ b/cmds/port.c
@@ -1,0 +1,126 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system loader
+ *
+ * Create partition
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Jakub Klimek
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "cmd.h"
+#include "elf.h"
+
+#include <lib/lib.h>
+#include <hal/hal.h>
+#include <phfs/phfs.h>
+#include <syspage.h>
+
+
+static void cmd_portInfo(void)
+{
+	lib_printf("creates named port, usage: port <name> <recvPart1;recvPart2...> <sendPart1;sendPart2...>");
+}
+
+
+static size_t cmd_listParse(char *list, char sep)
+{
+	size_t nb = 0;
+
+	while (*list != '\0') {
+		if (*list == sep) {
+			*list = '\0';
+			++nb;
+		}
+		list++;
+	}
+
+	return ++nb;
+}
+
+
+static int cmd_partNamesToBitmask(char *list, char sep, unsigned int *mask)
+{
+	size_t nb = cmd_listParse(list, sep);
+	char *name = list;
+	size_t i;
+	syspage_part_t *part;
+	int res;
+
+	*mask = 0;
+
+	for (i = 0; i < nb; i++) {
+		res = syspage_partResolve(name, &part);
+		if (res != EOK) {
+			log_error("\nNo such partition to access a named port: %s", name);
+			return -EINVAL;
+		}
+		*mask |= (1UL << part->id);
+		name += hal_strlen(name) + 1;
+	}
+	return EOK;
+}
+
+
+static int cmd_port(int argc, char *argv[])
+{
+	int res, argvID = 0;
+
+	char *recvParts, *sendParts;
+
+	const char *name;
+	unsigned int mask;
+	syspage_named_port_t *port;
+
+	/* Parse command arguments */
+	if (argc != 4) {
+		log_error("\n%s: Wrong argument count", argv[0]);
+		return CMD_EXIT_FAILURE;
+	}
+
+	/* ARG_0: command name */
+
+	/* ARG_1: port name */
+	argvID = 1;
+	name = argv[argvID++];
+
+	/* ARG_2: receiving parts */
+	recvParts = argv[argvID++];
+
+	/* ARG_3: sending parts */
+	sendParts = argv[argvID++];
+
+	port = syspage_namedPortAdd();
+	if (port == NULL) {
+		log_error("\nCannot allocate memory for %s", name);
+		return -ENOMEM;
+	}
+
+	port->name = syspage_alloc(hal_strlen(name) + 1);
+	if (port->name == NULL) {
+		log_error("\nCannot allocate memory for %s", name);
+		return -ENOMEM;
+	}
+	hal_strcpy(port->name, name);
+
+	res = cmd_partNamesToBitmask(recvParts, ';', &mask);
+	if (res < 0) {
+		return res;
+	}
+	port->recvMask = mask;
+	res = cmd_partNamesToBitmask(sendParts, ';', &mask);
+	if (res < 0) {
+		return res;
+	}
+	port->sendMask = mask;
+
+	return CMD_EXIT_SUCCESS;
+}
+
+
+static const cmd_t port_cmd __attribute__((section("commands"), used)) = {
+	.name = "port", .run = cmd_port, .info = cmd_portInfo
+};

--- a/cmds/sched.c
+++ b/cmds/sched.c
@@ -1,0 +1,109 @@
+/*
+ * Phoenix-RTOS
+ *
+ * Operating system loader
+ *
+ * Configure scheduler
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Jakub Klimek
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "cmd.h"
+#include "elf.h"
+
+#include <lib/lib.h>
+#include <hal/hal.h>
+#include <phfs/phfs.h>
+#include <syspage.h>
+
+#define MAX_SCHED_WINDOWS 32U
+
+
+static void cmd_schedInfo(void)
+{
+	lib_printf("configures scheduler, usage: sched [window1Size;window2Size...]");
+}
+
+
+static size_t cmd_listParse(char *maps, char sep)
+{
+	size_t nb = 0;
+
+	while (*maps != '\0') {
+		if (*maps == sep) {
+			*maps = '\0';
+			++nb;
+		}
+		maps++;
+	}
+
+	return ++nb;
+}
+
+
+static int cmd_sched(int argc, char *argv[])
+{
+	unsigned int i;
+	unsigned long duration;
+	syspage_sched_window_t *window;
+
+	char *schedWindowsTimes;
+	size_t schedWinSz;
+	time_t curTime = 0;
+
+	/* Parse command arguments */
+	if (argc > 2) {
+		log_error("\n%s: Wrong argument count", argv[0]);
+		return CMD_EXIT_FAILURE;
+	}
+
+	if (syspage_schedulerWindowCount() > 1) {
+		log_error("\n%s: Scheduler windows are already configured!", argv[0]);
+		return CMD_EXIT_FAILURE;
+	}
+
+	/* ARG_0: command name */
+
+	/* ARG_1: duration list */
+	if (argc == 2) {
+		schedWindowsTimes = argv[1];
+		schedWinSz = cmd_listParse(schedWindowsTimes, ';');
+	}
+	else {
+		schedWindowsTimes = "";
+		schedWinSz = 0;
+	}
+
+	if (schedWinSz > MAX_SCHED_WINDOWS) {
+		log_error("\n%s: Too many scheduler windows (%zu / max %u)", argv[0], schedWinSz, MAX_SCHED_WINDOWS);
+		return CMD_EXIT_FAILURE;
+	}
+
+	for (i = 0; i < schedWinSz; ++i) {
+		duration = lib_strtoul(schedWindowsTimes, &schedWindowsTimes, 0);
+		if (*schedWindowsTimes != '\0') {
+			log_error("\n%s: Window duration is not a valid number", argv[0]);
+			return CMD_EXIT_FAILURE;
+		}
+		window = syspage_schedWindowAdd();
+		if (window == NULL) {
+			log_error("\n%s: Cannot allocate memory for scheduler configuration", argv[0]);
+			return CMD_EXIT_FAILURE;
+		}
+
+		window->id = i + 1U;
+		window->stop = curTime + duration;
+		curTime += duration;
+		schedWindowsTimes += 1; /* '\0' */
+	}
+
+	return CMD_EXIT_SUCCESS;
+}
+
+
+static const cmd_t sched_cmd __attribute__((section("commands"), used)) = {
+	.name = "sched", .run = cmd_sched, .info = cmd_schedInfo
+};

--- a/cmds/sched.c
+++ b/cmds/sched.c
@@ -19,8 +19,6 @@
 #include <phfs/phfs.h>
 #include <syspage.h>
 
-#define MAX_SCHED_WINDOWS 32U
-
 
 static void cmd_schedInfo(void)
 {
@@ -28,76 +26,118 @@ static void cmd_schedInfo(void)
 }
 
 
-static size_t cmd_listParse(char *maps, char sep)
+static syspage_sched_cycle_t *cmd_parseCycle(char *desc, unsigned char windowCnt)
 {
-	size_t nb = 0;
+	syspage_sched_cycle_t *cycle;
 
-	while (*maps != '\0') {
-		if (*maps == sep) {
-			*maps = '\0';
-			++nb;
+	unsigned char id;
+	unsigned int i = 0;
+	char *cur = desc;
+	unsigned long duration = 0;
+
+	while (*cur != '\0') {
+		if (*cur == ':') {
+			i++;
 		}
-		maps++;
+		cur++;
 	}
 
-	return ++nb;
+	cycle = syspage_alloc(sizeof(*cycle) + sizeof(*cycle->windows) * i);
+	if (cycle == NULL) {
+		log_error("\nCannot allocate memory for scheduler configuration");
+		return NULL;
+	}
+	cycle->len = i;
+
+	cur = desc;
+	id = lib_strtoul(cur, &cur, 0);
+	if (id > windowCnt) {
+		log_error("\nInvalid scheduler cycle description: window ID exceeds window count");
+		return NULL;
+	}
+	if (*cur == ':') {
+		/* No background window, use system window */
+		cycle->bgId = 0U;
+		cur = desc;
+	}
+	else if ((*cur == '\0') || (*cur == ';')) {
+		cycle->bgId = id;
+		if (*cur == ';') {
+			cur++;
+		}
+	}
+	else {
+		log_error("\nInvalid scheduler cycle description");
+		return NULL;
+	}
+	for (i = 0; *cur != '\0'; i++) {
+		if (i >= cycle->len) {
+			log_error("\nInvalid scheduler cycle description");
+			return NULL;
+		}
+		cycle->windows[i].id = lib_strtoul(cur, &cur, 0);
+		if (cycle->windows[i].id > windowCnt) {
+			log_error("\nInvalid scheduler cycle description: window ID exceeds window count");
+			return NULL;
+		}
+		if (*cur != ':') {
+			log_error("\nInvalid scheduler cycle description");
+			return NULL;
+		}
+		duration += lib_strtoul(cur + 1, &cur, 0);
+		if (duration == 0U) {
+			log_error("\nInvalid scheduler cycle: window duration cannot be zero");
+			return NULL;
+		}
+		cycle->windows[i].stop = duration;
+		if (*cur == ';') {
+			cur++;
+		}
+		else if (*cur != '\0') {
+			log_error("\nInvalid scheduler cycle description");
+			return NULL;
+		}
+	}
+	return cycle;
 }
 
 
 static int cmd_sched(int argc, char *argv[])
 {
 	unsigned int i;
-	unsigned long duration;
-	syspage_sched_window_t *window;
-
-	char *schedWindowsTimes;
-	size_t schedWinSz;
-	time_t curTime = 0;
+	syspage_sched_t *config;
 
 	/* Parse command arguments */
-	if (argc > 2) {
+	if (argc < 3) {
 		log_error("\n%s: Wrong argument count", argv[0]);
 		return CMD_EXIT_FAILURE;
 	}
 
-	if (syspage_schedulerWindowCount() > 1) {
-		log_error("\n%s: Scheduler windows are already configured!", argv[0]);
+	config = syspage_alloc(sizeof(syspage_sched_t) + sizeof(*config->cycles) * (argc - 2));
+	if (config == NULL) {
+		log_error("\n%s: Cannot allocate memory for scheduler configuration", argv[0]);
 		return CMD_EXIT_FAILURE;
 	}
+	config->flags = 0U;
 
 	/* ARG_0: command name */
 
-	/* ARG_1: duration list */
-	if (argc == 2) {
-		schedWindowsTimes = argv[1];
-		schedWinSz = cmd_listParse(schedWindowsTimes, ';');
-	}
-	else {
-		schedWindowsTimes = "";
-		schedWinSz = 0;
-	}
+	/* ARG_1: window count */
+	config->windowCnt = lib_strtoul(argv[1], NULL, 10);
 
-	if (schedWinSz > MAX_SCHED_WINDOWS) {
-		log_error("\n%s: Too many scheduler windows (%zu / max %u)", argv[0], schedWinSz, MAX_SCHED_WINDOWS);
+	/* ARG_2...N: cycles descriptions */
+	config->cycleCnt = argc - 2;
+
+	for (i = 0; i < config->cycleCnt; ++i) {
+		config->cycles[i] = cmd_parseCycle(argv[i + 2], config->windowCnt);
+		if (config->cycles[i] == NULL) {
+			log_error("\n%s: Cannot parse scheduler cycle description", argv[0]);
+			return CMD_EXIT_FAILURE;
+		}
+	}
+	if (syspage_schedulerConfigSet(config) != EOK) {
+		log_error("\n%s: Scheduler is already configured!", argv[0]);
 		return CMD_EXIT_FAILURE;
-	}
-
-	for (i = 0; i < schedWinSz; ++i) {
-		duration = lib_strtoul(schedWindowsTimes, &schedWindowsTimes, 0);
-		if (*schedWindowsTimes != '\0') {
-			log_error("\n%s: Window duration is not a valid number", argv[0]);
-			return CMD_EXIT_FAILURE;
-		}
-		window = syspage_schedWindowAdd();
-		if (window == NULL) {
-			log_error("\n%s: Cannot allocate memory for scheduler configuration", argv[0]);
-			return CMD_EXIT_FAILURE;
-		}
-
-		window->id = i + 1U;
-		window->stop = curTime + duration;
-		curTime += duration;
-		schedWindowsTimes += 1; /* '\0' */
 	}
 
 	return CMD_EXIT_SUCCESS;

--- a/hal/aarch64/zynqmp/hal.c
+++ b/hal/aarch64/zynqmp/hal.c
@@ -154,7 +154,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/aarch64/zynqmp/hal.c
+++ b/hal/aarch64/zynqmp/hal.c
@@ -154,7 +154,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/armv7a/imx6ull/hal.c
+++ b/hal/armv7a/imx6ull/hal.c
@@ -171,7 +171,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/armv7a/imx6ull/hal.c
+++ b/hal/armv7a/imx6ull/hal.c
@@ -171,7 +171,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/armv7a/zynq7000/hal.c
+++ b/hal/armv7a/zynq7000/hal.c
@@ -151,7 +151,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/armv7a/zynq7000/hal.c
+++ b/hal/armv7a/zynq7000/hal.c
@@ -151,7 +151,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/armv7m/imxrt/hal.c
+++ b/hal/armv7m/imxrt/hal.c
@@ -124,12 +124,13 @@ void hal_kernelGetEntryPointOffset(addr_t *off, int *indirect)
 void hal_kernelEntryPoint(addr_t addr)
 {
 	hal_common.entry = addr;
+	mpu_kernelEntryPoint(addr);
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
-	return mpu_regionAlloc(start, end, attr, mapId, 1);
+	return mpu_getHalProgData(prog, imaps, imapSz, dmaps, dmapSz);
 }
 
 

--- a/hal/armv7m/imxrt/hal.c
+++ b/hal/armv7m/imxrt/hal.c
@@ -128,9 +128,9 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
-	return mpu_getHalProgData(prog, imaps, imapSz, dmaps, dmapSz);
+	return mpu_getHalPartData(part, imaps, imapSz, dmaps, dmapSz);
 }
 
 

--- a/hal/armv7m/mpu.c
+++ b/hal/armv7m/mpu.c
@@ -15,9 +15,15 @@
 
 #include <lib/errno.h>
 #include "mpu.h"
+#include "lib/log.h"
+#include "syspage.h"
 
 
-static mpu_common_t mpu_common;
+static struct {
+	u32 type;
+	u32 regMax;
+	addr_t kernelEntryPoint;
+} mpu_common;
 
 
 /* clang-format off */
@@ -31,18 +37,18 @@ enum { mpu_type, mpu_ctrl, mpu_rnr, mpu_rbar, mpu_rasr, mpu_rbar_a1, mpu_rasr_a1
 
 
 /* Setup single MPU region entry in a local MPU context */
-static int mpu_regionSet(unsigned int *idx, u32 baseAddr, u8 srdMask, u8 sizeBit, u32 rasrAttr)
+static int mpu_regionSet(hal_syspage_prog_t *progHal, unsigned int *idx, u32 baseAddr, u8 srdMask, u8 sizeBit, u32 rasrAttr)
 {
 	if ((sizeBit < 5) || (*idx >= mpu_common.regMax)) {
 		return -EPERM;
 	}
 
-	mpu_common.region[*idx].rbar =
+	progHal->mpu.table[*idx].rbar =
 			baseAddr |
 			(1u << 4) | /* mark region as valid */
 			(*idx & 0xfu);
 
-	mpu_common.region[*idx].rasr =
+	progHal->mpu.table[*idx].rasr =
 			rasrAttr |
 			(((u32)srdMask) << 8) |
 			((((u32)sizeBit - 1) & 0x1fu) << 1);
@@ -76,20 +82,20 @@ static u32 mpu_regionAttrs(u32 attr, unsigned int enable)
 }
 
 
-static int mpu_checkOverlap(unsigned int idx, u32 start, u32 end)
+static int mpu_checkOverlap(hal_syspage_prog_t *progHal, unsigned int idx, u32 start, u32 end)
 {
 	unsigned int i, j;
 	u32 srStart, srEnd;
 	u8 sizeBit, subregions;
 	end -= 1;
 	for (i = 0; i < idx; i++) {
-		if (((mpu_common.region[i].rbar & 0x10u) == 0) || ((mpu_common.region[i].rasr & 0x1u) == 0)) {
+		if (((progHal->mpu.table[i].rbar & 0x10u) == 0) || ((progHal->mpu.table[i].rasr & 0x1u) == 0)) {
 			continue;
 		}
 
-		sizeBit = ((mpu_common.region[i].rasr >> 1) & 0x1fu) + 1;
-		srStart = mpu_common.region[i].rbar & ~((1u << sizeBit) - 1);
-		subregions = (mpu_common.region[i].rasr >> 8) & 0xffu;
+		sizeBit = ((progHal->mpu.table[i].rasr >> 1) & 0x1fu) + 1;
+		srStart = progHal->mpu.table[i].rbar & ~((1u << sizeBit) - 1);
+		subregions = (progHal->mpu.table[i].rasr >> 8) & 0xffu;
 		for (j = 0; j < 8; j++) {
 			srEnd = srStart + (1u << (sizeBit - 3)) - 1;
 			if (((subregions & 1u) == 0) && (start <= srEnd) && (srStart <= end)) {
@@ -105,7 +111,7 @@ static int mpu_checkOverlap(unsigned int idx, u32 start, u32 end)
 }
 
 
-static int mpu_regionCalculateAndSet(unsigned int *idx, addr_t start, addr_t end, u8 sizeBit, u32 rasrAttr)
+static int mpu_regionCalculateAndSet(hal_syspage_prog_t *progHal, unsigned int *idx, addr_t start, addr_t end, u8 sizeBit, u32 rasrAttr)
 {
 	u8 srdMask;
 	/* RBAR contains all MSBs that are the same */
@@ -116,12 +122,12 @@ static int mpu_regionCalculateAndSet(unsigned int *idx, addr_t start, addr_t end
 	srEnd = (srEnd == 0) ? 8 : srEnd;
 	/* Bit set means disable region - negate result */
 	srdMask = ~(((1u << srEnd) - 1) & (0xffu << srStart));
-	return mpu_regionSet(idx, baseAddr, srdMask, sizeBit, rasrAttr);
+	return mpu_regionSet(progHal, idx, baseAddr, srdMask, sizeBit, rasrAttr);
 }
 
 
 /* Create up to 2 regions that will represent a given map */
-static int mpu_regionGenerate(unsigned int *idx, addr_t start, addr_t end, u32 rasrAttr)
+static int mpu_regionGenerate(hal_syspage_prog_t *progHal, unsigned int *idx, addr_t start, addr_t end, u32 rasrAttr)
 {
 	int res;
 	int commonTrailingZeroes, sigBits;
@@ -138,7 +144,7 @@ static int mpu_regionGenerate(unsigned int *idx, addr_t start, addr_t end, u32 r
 	/* Check if size is power of 2 and start is aligned - necessary for handling
 	   small regions (below 256 bytes) */
 	if (size == 0) {
-		return mpu_regionSet(idx, 0, 0, 32, rasrAttr);
+		return mpu_regionSet(progHal, idx, 0, 0, 32, rasrAttr);
 	}
 
 	if ((size == (1u << __builtin_ctz(size))) && ((start & (size - 1)) == 0)) {
@@ -147,7 +153,7 @@ static int mpu_regionGenerate(unsigned int *idx, addr_t start, addr_t end, u32 r
 			return -EPERM;
 		}
 
-		return mpu_regionSet(idx, start, 0, __builtin_ctz(size), rasrAttr);
+		return mpu_regionSet(progHal, idx, start, 0, __builtin_ctz(size), rasrAttr);
 	}
 
 	commonTrailingZeroes = __builtin_ctz(start | end);
@@ -161,15 +167,15 @@ static int mpu_regionGenerate(unsigned int *idx, addr_t start, addr_t end, u32 r
 	if (sigBits <= 3) {
 		/* Can be represented with one region + 8 subregions */
 		sizeBit = commonTrailingZeroes + 3;
-		return mpu_regionCalculateAndSet(idx, start, end, sizeBit, rasrAttr);
+		return mpu_regionCalculateAndSet(progHal, idx, start, end, sizeBit, rasrAttr);
 	}
 	else if (sigBits == 4) {
 		/* Can be represented with 2 regions + up to 8 subregions each */
 		sizeBit = commonTrailingZeroes + 3;
 		diffMask = (1u << sizeBit) - 1;
 		reg1End = (start & (~diffMask)) + diffMask + 1;
-		res = mpu_regionCalculateAndSet(idx, start, reg1End, sizeBit, rasrAttr);
-		return (res == EOK) ? mpu_regionCalculateAndSet(idx, reg1End, end, sizeBit, rasrAttr) : res;
+		res = mpu_regionCalculateAndSet(progHal, idx, start, reg1End, sizeBit, rasrAttr);
+		return (res == EOK) ? mpu_regionCalculateAndSet(progHal, idx, reg1End, end, sizeBit, rasrAttr) : res;
 	}
 	else if (rasrAttr == HOLE_ATTR(rasrAttr)) {
 		/* Cannot attempt another cutout - we are already trying to make a hole */
@@ -198,49 +204,115 @@ static int mpu_regionGenerate(unsigned int *idx, addr_t start, addr_t end, u32 r
 	}
 
 	/* First check if our "hole" overrides any existing mappings. This would lead to unintuitive behaviors. */
-	if (mpu_checkOverlap(*idx, holeStart, holeEnd) != 0) {
+	if (mpu_checkOverlap(progHal, *idx, holeStart, holeEnd) != 0) {
 		return -EPERM;
 	}
 
-	res = mpu_regionCalculateAndSet(idx, alignedStart, alignedEnd, commonMsb, rasrAttr);
-	return (res == EOK) ? mpu_regionGenerate(idx, holeStart, holeEnd, HOLE_ATTR(rasrAttr)) : res;
+	res = mpu_regionCalculateAndSet(progHal, idx, alignedStart, alignedEnd, commonMsb, rasrAttr);
+	return (res == EOK) ? mpu_regionGenerate(progHal, idx, holeStart, holeEnd, HOLE_ATTR(rasrAttr)) : res;
 }
 
 
 /* Invalidate range of regions */
-static void mpu_regionInvalidate(u8 first, u8 last)
+static void mpu_regionInvalidate(hal_syspage_prog_t *progHal, u8 first, u8 last)
 {
 	unsigned int i;
 
 	for (i = first; i < last && i < mpu_common.regMax; i++) {
 		/* set multi-map to none */
-		mpu_common.mapId[i] = (u32)-1;
+		progHal->mpu.map[i] = (u32)-1;
 
-		/* mark i-th region as invalid */
-		mpu_common.region[i].rbar = i & 0xfu;
+		/* empty rbar value with automatic switch of rnr register */
+		progHal->mpu.table[i].rbar = (1 << 4) | (i & 0xfu);
 
-		/* set exec never and mark whole region as disabled */
-		mpu_common.region[i].rasr = (1u << 28) | (0x1fu << 1);
+		/* mark whole region as disabled */
+		progHal->mpu.table[i].rasr = 0;
 	}
 }
 
 
 /* Assign range of regions a multi-map id */
-static void mpu_regionAssignMap(u8 first, u8 last, u32 mapId)
+static void mpu_regionAssignMap(hal_syspage_prog_t *progHal, u8 first, u8 last, u32 mapId)
 {
 	unsigned int i;
 
 	for (i = first; i < last && i < mpu_common.regMax; i++) {
-		/* assign map only if region is valid */
-		if (mpu_common.region[i].rbar & (1u << 4))
-			mpu_common.mapId[i] = mapId;
+		progHal->mpu.map[i] = mapId;
 	}
 }
 
 
-const mpu_common_t *const mpu_getCommon(void)
+static int mpu_isMapAlloced(hal_syspage_prog_t *progHal, u32 mapId)
 {
-	return &mpu_common;
+	unsigned int i;
+
+	for (i = 0; i < progHal->mpu.allocCnt; i++) {
+		if (progHal->mpu.map[i] == mapId) {
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+
+static int mpu_regionAlloc(hal_syspage_prog_t *progHal, addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int enable)
+{
+	int res;
+	unsigned int regCur = progHal->mpu.allocCnt;
+	u32 rasrAttr = mpu_regionAttrs(attr, enable);
+
+	res = mpu_regionGenerate(progHal, &regCur, addr, end, rasrAttr);
+	if (res != EOK) {
+		mpu_regionInvalidate(progHal, progHal->mpu.allocCnt, regCur);
+		return res;
+	}
+
+	mpu_regionAssignMap(progHal, progHal->mpu.allocCnt, regCur, mapId);
+
+	progHal->mpu.allocCnt = regCur;
+
+	return EOK;
+}
+
+
+static int mpu_allocKernelMap(hal_syspage_prog_t *progHal)
+{
+	addr_t start, end;
+	u32 attr;
+	u8 id;
+	int res;
+	const char *kcodemap = NULL;
+
+	start = mpu_common.kernelEntryPoint;
+	if (start == (addr_t)-1) {
+		log_error("\nMissing kernel entry point!");
+		return -EINVAL;
+	}
+	if ((res = syspage_mapAddrResolve(start, &kcodemap)) < 0) {
+		return res;
+	}
+	if ((res = syspage_mapNameResolve(kcodemap, &id)) < 0) {
+		return res;
+	}
+	if ((res = syspage_mapRangeResolve(kcodemap, &start, &end)) < 0) {
+		return res;
+	}
+	if ((res = syspage_mapAttrResolve(kcodemap, &attr)) < 0) {
+		return res;
+	}
+	if ((res = mpu_regionAlloc(progHal, start, end, attr, id, 1)) < 0) {
+		log_error("\nCan't allocate MPU region for kernel code map (%s)", kcodemap);
+		return res;
+	}
+	return EOK;
+}
+
+
+static void mpu_initPart(hal_syspage_prog_t *progHal)
+{
+	hal_memset(progHal, 0, sizeof(hal_syspage_prog_t));
+	progHal->mpu.allocCnt = 0;
 }
 
 
@@ -250,45 +322,93 @@ void mpu_init(void)
 
 	mpu_common.type = *(mpu_base + mpu_type);
 	mpu_common.regMax = (u8)(mpu_common.type >> 8);
-	mpu_common.regCnt = mpu_common.mapCnt = 0;
+	/* Hardware may support more regions than can be stored in our code. */
+	if (mpu_common.regMax > MPU_MAX_REGIONS) {
+		mpu_common.regMax = MPU_MAX_REGIONS;
+	}
 
-	mpu_regionInvalidate(0, sizeof(mpu_common.region) / sizeof(mpu_common.region[0]));
+	mpu_common.kernelEntryPoint = (addr_t)-1;
 }
 
 
-int mpu_regionAlloc(addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int enable)
+void mpu_kernelEntryPoint(addr_t addr)
 {
-	int res;
-	unsigned int regCur = mpu_common.regCnt;
-	u32 rasrAttr = mpu_regionAttrs(attr, enable);
-
-	res = mpu_regionGenerate(&regCur, addr, end, rasrAttr);
-	if (res != EOK) {
-		mpu_regionInvalidate(mpu_common.regCnt, regCur);
-		return res;
-	}
-
-	mpu_regionAssignMap(mpu_common.regCnt, regCur, mapId);
-
-	mpu_common.regCnt = regCur;
-	mpu_common.mapCnt++;
-
-	return EOK;
+	mpu_common.kernelEntryPoint = addr;
 }
 
 
 void mpu_getHalData(hal_syspage_t *hal)
 {
-	unsigned int i;
+	hal->mpuType = mpu_common.type;
+}
 
-	mpu_regionInvalidate(mpu_common.regCnt, mpu_common.regMax);
 
-	hal->mpu.type = mpu_common.type;
-	hal->mpu.allocCnt = mpu_common.regCnt;
+unsigned int mpu_getMaxRegionsCount(void)
+{
+	return mpu_common.regMax;
+}
 
-	for (i = 0; i < sizeof(hal->mpu.table) / sizeof(hal->mpu.table[0]); i++) {
-		hal->mpu.table[i].rbar = mpu_common.region[i].rbar;
-		hal->mpu.table[i].rasr = mpu_common.region[i].rasr;
-		hal->mpu.map[i] = mpu_common.mapId[i];
+
+static int mpu_mapsAlloc(hal_syspage_prog_t *progHal, const char *maps, size_t cnt)
+{
+	int i, res;
+	addr_t start, end;
+	u32 attr;
+	u8 id;
+
+	for (i = 0; i < cnt; i++) {
+		if ((res = syspage_mapNameResolve(maps, &id)) < 0) {
+			return res;
+		}
+		if (mpu_isMapAlloced(progHal, id) != 0) {
+			maps += hal_strlen(maps) + 1; /* name + '\0' */
+			continue;
+		}
+		if ((res = syspage_mapRangeResolve(maps, &start, &end)) < 0) {
+			return res;
+		}
+		if ((res = syspage_mapAttrResolve(maps, &attr)) < 0) {
+			return res;
+		}
+		if ((res = mpu_regionAlloc(progHal, start, end, attr, id, 1)) < 0) {
+			log_error("\nCan't allocate MPU region for %s", maps);
+			return res;
+		}
+		maps += hal_strlen(maps) + 1; /* name + '\0' */
 	}
+	return EOK;
+}
+
+
+extern int mpu_getHalProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+{
+	int ret;
+
+	mpu_initPart(&prog->hal);
+
+
+	/* FIXME HACK
+	 * allow all programs to execute (and read) kernel code map.
+	 * Needed because of hal_jmp, syscalls handler and signals handler.
+	 * In these functions we need to switch to the user mode when still
+	 * executing kernel code. This will cause memory management fault
+	 * if the application does not have access to the kernel instruction
+	 * map. Possible fix - place return to the user code in the separate
+	 * region and allow this region instead. */
+	ret = mpu_allocKernelMap(&prog->hal);
+	if (ret != EOK) {
+		return ret;
+	}
+	ret = mpu_mapsAlloc(&prog->hal, imaps, imapSz);
+	if (ret != EOK) {
+		return ret;
+	}
+	ret = mpu_mapsAlloc(&prog->hal, dmaps, dmapSz);
+	if (ret != EOK) {
+		return ret;
+	}
+
+	mpu_regionInvalidate(&prog->hal, prog->hal.mpu.allocCnt, mpu_common.regMax);
+
+	return EOK;
 }

--- a/hal/armv7m/mpu.c
+++ b/hal/armv7m/mpu.c
@@ -37,18 +37,18 @@ enum { mpu_type, mpu_ctrl, mpu_rnr, mpu_rbar, mpu_rasr, mpu_rbar_a1, mpu_rasr_a1
 
 
 /* Setup single MPU region entry in a local MPU context */
-static int mpu_regionSet(hal_syspage_prog_t *progHal, unsigned int *idx, u32 baseAddr, u8 srdMask, u8 sizeBit, u32 rasrAttr)
+static int mpu_regionSet(hal_syspage_part_t *partHal, unsigned int *idx, u32 baseAddr, u8 srdMask, u8 sizeBit, u32 rasrAttr)
 {
 	if ((sizeBit < 5) || (*idx >= mpu_common.regMax)) {
 		return -EPERM;
 	}
 
-	progHal->mpu.table[*idx].rbar =
+	partHal->mpu.table[*idx].rbar =
 			baseAddr |
 			(1u << 4) | /* mark region as valid */
 			(*idx & 0xfu);
 
-	progHal->mpu.table[*idx].rasr =
+	partHal->mpu.table[*idx].rasr =
 			rasrAttr |
 			(((u32)srdMask) << 8) |
 			((((u32)sizeBit - 1) & 0x1fu) << 1);
@@ -82,20 +82,20 @@ static u32 mpu_regionAttrs(u32 attr, unsigned int enable)
 }
 
 
-static int mpu_checkOverlap(hal_syspage_prog_t *progHal, unsigned int idx, u32 start, u32 end)
+static int mpu_checkOverlap(hal_syspage_part_t *partHal, unsigned int idx, u32 start, u32 end)
 {
 	unsigned int i, j;
 	u32 srStart, srEnd;
 	u8 sizeBit, subregions;
 	end -= 1;
 	for (i = 0; i < idx; i++) {
-		if (((progHal->mpu.table[i].rbar & 0x10u) == 0) || ((progHal->mpu.table[i].rasr & 0x1u) == 0)) {
+		if (((partHal->mpu.table[i].rbar & 0x10u) == 0) || ((partHal->mpu.table[i].rasr & 0x1u) == 0)) {
 			continue;
 		}
 
-		sizeBit = ((progHal->mpu.table[i].rasr >> 1) & 0x1fu) + 1;
-		srStart = progHal->mpu.table[i].rbar & ~((1u << sizeBit) - 1);
-		subregions = (progHal->mpu.table[i].rasr >> 8) & 0xffu;
+		sizeBit = ((partHal->mpu.table[i].rasr >> 1) & 0x1fu) + 1;
+		srStart = partHal->mpu.table[i].rbar & ~((1u << sizeBit) - 1);
+		subregions = (partHal->mpu.table[i].rasr >> 8) & 0xffu;
 		for (j = 0; j < 8; j++) {
 			srEnd = srStart + (1u << (sizeBit - 3)) - 1;
 			if (((subregions & 1u) == 0) && (start <= srEnd) && (srStart <= end)) {
@@ -111,7 +111,7 @@ static int mpu_checkOverlap(hal_syspage_prog_t *progHal, unsigned int idx, u32 s
 }
 
 
-static int mpu_regionCalculateAndSet(hal_syspage_prog_t *progHal, unsigned int *idx, addr_t start, addr_t end, u8 sizeBit, u32 rasrAttr)
+static int mpu_regionCalculateAndSet(hal_syspage_part_t *partHal, unsigned int *idx, addr_t start, addr_t end, u8 sizeBit, u32 rasrAttr)
 {
 	u8 srdMask;
 	/* RBAR contains all MSBs that are the same */
@@ -122,12 +122,12 @@ static int mpu_regionCalculateAndSet(hal_syspage_prog_t *progHal, unsigned int *
 	srEnd = (srEnd == 0) ? 8 : srEnd;
 	/* Bit set means disable region - negate result */
 	srdMask = ~(((1u << srEnd) - 1) & (0xffu << srStart));
-	return mpu_regionSet(progHal, idx, baseAddr, srdMask, sizeBit, rasrAttr);
+	return mpu_regionSet(partHal, idx, baseAddr, srdMask, sizeBit, rasrAttr);
 }
 
 
 /* Create up to 2 regions that will represent a given map */
-static int mpu_regionGenerate(hal_syspage_prog_t *progHal, unsigned int *idx, addr_t start, addr_t end, u32 rasrAttr)
+static int mpu_regionGenerate(hal_syspage_part_t *partHal, unsigned int *idx, addr_t start, addr_t end, u32 rasrAttr)
 {
 	int res;
 	int commonTrailingZeroes, sigBits;
@@ -144,7 +144,7 @@ static int mpu_regionGenerate(hal_syspage_prog_t *progHal, unsigned int *idx, ad
 	/* Check if size is power of 2 and start is aligned - necessary for handling
 	   small regions (below 256 bytes) */
 	if (size == 0) {
-		return mpu_regionSet(progHal, idx, 0, 0, 32, rasrAttr);
+		return mpu_regionSet(partHal, idx, 0, 0, 32, rasrAttr);
 	}
 
 	if ((size == (1u << __builtin_ctz(size))) && ((start & (size - 1)) == 0)) {
@@ -153,7 +153,7 @@ static int mpu_regionGenerate(hal_syspage_prog_t *progHal, unsigned int *idx, ad
 			return -EPERM;
 		}
 
-		return mpu_regionSet(progHal, idx, start, 0, __builtin_ctz(size), rasrAttr);
+		return mpu_regionSet(partHal, idx, start, 0, __builtin_ctz(size), rasrAttr);
 	}
 
 	commonTrailingZeroes = __builtin_ctz(start | end);
@@ -167,15 +167,15 @@ static int mpu_regionGenerate(hal_syspage_prog_t *progHal, unsigned int *idx, ad
 	if (sigBits <= 3) {
 		/* Can be represented with one region + 8 subregions */
 		sizeBit = commonTrailingZeroes + 3;
-		return mpu_regionCalculateAndSet(progHal, idx, start, end, sizeBit, rasrAttr);
+		return mpu_regionCalculateAndSet(partHal, idx, start, end, sizeBit, rasrAttr);
 	}
 	else if (sigBits == 4) {
 		/* Can be represented with 2 regions + up to 8 subregions each */
 		sizeBit = commonTrailingZeroes + 3;
 		diffMask = (1u << sizeBit) - 1;
 		reg1End = (start & (~diffMask)) + diffMask + 1;
-		res = mpu_regionCalculateAndSet(progHal, idx, start, reg1End, sizeBit, rasrAttr);
-		return (res == EOK) ? mpu_regionCalculateAndSet(progHal, idx, reg1End, end, sizeBit, rasrAttr) : res;
+		res = mpu_regionCalculateAndSet(partHal, idx, start, reg1End, sizeBit, rasrAttr);
+		return (res == EOK) ? mpu_regionCalculateAndSet(partHal, idx, reg1End, end, sizeBit, rasrAttr) : res;
 	}
 	else if (rasrAttr == HOLE_ATTR(rasrAttr)) {
 		/* Cannot attempt another cutout - we are already trying to make a hole */
@@ -204,50 +204,50 @@ static int mpu_regionGenerate(hal_syspage_prog_t *progHal, unsigned int *idx, ad
 	}
 
 	/* First check if our "hole" overrides any existing mappings. This would lead to unintuitive behaviors. */
-	if (mpu_checkOverlap(progHal, *idx, holeStart, holeEnd) != 0) {
+	if (mpu_checkOverlap(partHal, *idx, holeStart, holeEnd) != 0) {
 		return -EPERM;
 	}
 
-	res = mpu_regionCalculateAndSet(progHal, idx, alignedStart, alignedEnd, commonMsb, rasrAttr);
-	return (res == EOK) ? mpu_regionGenerate(progHal, idx, holeStart, holeEnd, HOLE_ATTR(rasrAttr)) : res;
+	res = mpu_regionCalculateAndSet(partHal, idx, alignedStart, alignedEnd, commonMsb, rasrAttr);
+	return (res == EOK) ? mpu_regionGenerate(partHal, idx, holeStart, holeEnd, HOLE_ATTR(rasrAttr)) : res;
 }
 
 
 /* Invalidate range of regions */
-static void mpu_regionInvalidate(hal_syspage_prog_t *progHal, u8 first, u8 last)
+static void mpu_regionInvalidate(hal_syspage_part_t *partHal, u8 first, u8 last)
 {
 	unsigned int i;
 
 	for (i = first; i < last && i < mpu_common.regMax; i++) {
 		/* set multi-map to none */
-		progHal->mpu.map[i] = (u32)-1;
+		partHal->mpu.map[i] = (u32)-1;
 
 		/* empty rbar value with automatic switch of rnr register */
-		progHal->mpu.table[i].rbar = (1 << 4) | (i & 0xfu);
+		partHal->mpu.table[i].rbar = (1 << 4) | (i & 0xfu);
 
 		/* mark whole region as disabled */
-		progHal->mpu.table[i].rasr = 0;
+		partHal->mpu.table[i].rasr = 0;
 	}
 }
 
 
 /* Assign range of regions a multi-map id */
-static void mpu_regionAssignMap(hal_syspage_prog_t *progHal, u8 first, u8 last, u32 mapId)
+static void mpu_regionAssignMap(hal_syspage_part_t *partHal, u8 first, u8 last, u32 mapId)
 {
 	unsigned int i;
 
 	for (i = first; i < last && i < mpu_common.regMax; i++) {
-		progHal->mpu.map[i] = mapId;
+		partHal->mpu.map[i] = mapId;
 	}
 }
 
 
-static int mpu_isMapAlloced(hal_syspage_prog_t *progHal, u32 mapId)
+static int mpu_isMapAlloced(hal_syspage_part_t *partHal, u32 mapId)
 {
 	unsigned int i;
 
-	for (i = 0; i < progHal->mpu.allocCnt; i++) {
-		if (progHal->mpu.map[i] == mapId) {
+	for (i = 0; i < partHal->mpu.allocCnt; i++) {
+		if (partHal->mpu.map[i] == mapId) {
 			return 1;
 		}
 	}
@@ -256,27 +256,27 @@ static int mpu_isMapAlloced(hal_syspage_prog_t *progHal, u32 mapId)
 }
 
 
-static int mpu_regionAlloc(hal_syspage_prog_t *progHal, addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int enable)
+static int mpu_regionAlloc(hal_syspage_part_t *partHal, addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int enable)
 {
 	int res;
-	unsigned int regCur = progHal->mpu.allocCnt;
+	unsigned int regCur = partHal->mpu.allocCnt;
 	u32 rasrAttr = mpu_regionAttrs(attr, enable);
 
-	res = mpu_regionGenerate(progHal, &regCur, addr, end, rasrAttr);
+	res = mpu_regionGenerate(partHal, &regCur, addr, end, rasrAttr);
 	if (res != EOK) {
-		mpu_regionInvalidate(progHal, progHal->mpu.allocCnt, regCur);
+		mpu_regionInvalidate(partHal, partHal->mpu.allocCnt, regCur);
 		return res;
 	}
 
-	mpu_regionAssignMap(progHal, progHal->mpu.allocCnt, regCur, mapId);
+	mpu_regionAssignMap(partHal, partHal->mpu.allocCnt, regCur, mapId);
 
-	progHal->mpu.allocCnt = regCur;
+	partHal->mpu.allocCnt = regCur;
 
 	return EOK;
 }
 
 
-static int mpu_allocKernelMap(hal_syspage_prog_t *progHal)
+static int mpu_allocKernelMap(hal_syspage_part_t *partHal)
 {
 	addr_t start, end;
 	u32 attr;
@@ -301,7 +301,7 @@ static int mpu_allocKernelMap(hal_syspage_prog_t *progHal)
 	if ((res = syspage_mapAttrResolve(kcodemap, &attr)) < 0) {
 		return res;
 	}
-	if ((res = mpu_regionAlloc(progHal, start, end, attr, id, 1)) < 0) {
+	if ((res = mpu_regionAlloc(partHal, start, end, attr, id, 1)) < 0) {
 		log_error("\nCan't allocate MPU region for kernel code map (%s)", kcodemap);
 		return res;
 	}
@@ -309,10 +309,10 @@ static int mpu_allocKernelMap(hal_syspage_prog_t *progHal)
 }
 
 
-static void mpu_initPart(hal_syspage_prog_t *progHal)
+static void mpu_initPart(hal_syspage_part_t *partHal)
 {
-	hal_memset(progHal, 0, sizeof(hal_syspage_prog_t));
-	progHal->mpu.allocCnt = 0;
+	hal_memset(partHal, 0, sizeof(hal_syspage_part_t));
+	partHal->mpu.allocCnt = 0;
 }
 
 
@@ -349,7 +349,7 @@ unsigned int mpu_getMaxRegionsCount(void)
 }
 
 
-static int mpu_mapsAlloc(hal_syspage_prog_t *progHal, const char *maps, size_t cnt)
+static int mpu_mapsAlloc(hal_syspage_part_t *partHal, const char *maps, size_t cnt)
 {
 	int i, res;
 	addr_t start, end;
@@ -360,7 +360,7 @@ static int mpu_mapsAlloc(hal_syspage_prog_t *progHal, const char *maps, size_t c
 		if ((res = syspage_mapNameResolve(maps, &id)) < 0) {
 			return res;
 		}
-		if (mpu_isMapAlloced(progHal, id) != 0) {
+		if (mpu_isMapAlloced(partHal, id) != 0) {
 			maps += hal_strlen(maps) + 1; /* name + '\0' */
 			continue;
 		}
@@ -370,7 +370,7 @@ static int mpu_mapsAlloc(hal_syspage_prog_t *progHal, const char *maps, size_t c
 		if ((res = syspage_mapAttrResolve(maps, &attr)) < 0) {
 			return res;
 		}
-		if ((res = mpu_regionAlloc(progHal, start, end, attr, id, 1)) < 0) {
+		if ((res = mpu_regionAlloc(partHal, start, end, attr, id, 1)) < 0) {
 			log_error("\nCan't allocate MPU region for %s", maps);
 			return res;
 		}
@@ -380,11 +380,11 @@ static int mpu_mapsAlloc(hal_syspage_prog_t *progHal, const char *maps, size_t c
 }
 
 
-extern int mpu_getHalProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int mpu_getHalPartData(hal_syspage_part_t *hal, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	int ret;
 
-	mpu_initPart(&prog->hal);
+	mpu_initPart(hal);
 
 
 	/* FIXME HACK
@@ -395,20 +395,20 @@ extern int mpu_getHalProgData(syspage_prog_t *prog, const char *imaps, size_t im
 	 * if the application does not have access to the kernel instruction
 	 * map. Possible fix - place return to the user code in the separate
 	 * region and allow this region instead. */
-	ret = mpu_allocKernelMap(&prog->hal);
+	ret = mpu_allocKernelMap(hal);
 	if (ret != EOK) {
 		return ret;
 	}
-	ret = mpu_mapsAlloc(&prog->hal, imaps, imapSz);
+	ret = mpu_mapsAlloc(hal, imaps, imapSz);
 	if (ret != EOK) {
 		return ret;
 	}
-	ret = mpu_mapsAlloc(&prog->hal, dmaps, dmapSz);
+	ret = mpu_mapsAlloc(hal, dmaps, dmapSz);
 	if (ret != EOK) {
 		return ret;
 	}
 
-	mpu_regionInvalidate(&prog->hal, prog->hal.mpu.allocCnt, mpu_common.regMax);
+	mpu_regionInvalidate(hal, hal->mpu.allocCnt, mpu_common.regMax);
 
 	return EOK;
 }

--- a/hal/armv7m/mpu.h
+++ b/hal/armv7m/mpu.h
@@ -18,36 +18,23 @@
 
 #include <hal/hal.h>
 
-typedef struct {
-	u32 rbar;
-	u32 rasr;
-} mpu_region_t;
 
-
-typedef struct {
-	u32 type;
-	u32 regCnt;
-	u32 regMax;
-	u32 mapCnt;
-	mpu_region_t region[16] __attribute__((aligned(8)));
-	u32 mapId[16];
-} mpu_common_t;
-
-
-/* Get const pointer to read only mpu_common structure */
-extern const mpu_common_t *const mpu_getCommon(void);
+extern unsigned int mpu_getMaxRegionsCount(void);
 
 
 /* Reset structures and detect MPU type */
 extern void mpu_init(void);
 
 
-/* Allocate MPU sub-regions and link with a map */
-extern int mpu_regionAlloc(addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int enable);
+extern void mpu_kernelEntryPoint(addr_t addr);
 
 
-/* Get MPU regions setup into hal_syspage_t structure */
+/* Get MPU info into hal_syspage_t structure */
 extern void mpu_getHalData(hal_syspage_t *hal);
+
+
+/* Get MPU regions setup into syspage_prog_t structure */
+extern int mpu_getHalProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz);
 
 
 #endif

--- a/hal/armv7m/mpu.h
+++ b/hal/armv7m/mpu.h
@@ -33,8 +33,8 @@ extern void mpu_kernelEntryPoint(addr_t addr);
 extern void mpu_getHalData(hal_syspage_t *hal);
 
 
-/* Get MPU regions setup into syspage_prog_t structure */
-extern int mpu_getHalProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz);
+/* Get MPU regions setup into syspage_part_t structure */
+extern int mpu_getHalPartData(hal_syspage_part_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz);
 
 
 #endif

--- a/hal/armv7m/stm32/hal.c
+++ b/hal/armv7m/stm32/hal.c
@@ -118,12 +118,13 @@ void hal_kernelGetEntryPointOffset(addr_t *off, int *indirect)
 void hal_kernelEntryPoint(addr_t addr)
 {
 	hal_common.entry = addr;
+	mpu_kernelEntryPoint(addr);
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
-	return mpu_regionAlloc(start, end, attr, mapId, 1);
+	return mpu_getHalProgData(prog, imaps, imapSz, dmaps, dmapSz);
 }
 
 

--- a/hal/armv7m/stm32/hal.c
+++ b/hal/armv7m/stm32/hal.c
@@ -122,9 +122,9 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
-	return mpu_getHalProgData(prog, imaps, imapSz, dmaps, dmapSz);
+	return mpu_getHalPartData(part, imaps, imapSz, dmaps, dmapSz);
 }
 
 

--- a/hal/armv7r/mpu.c
+++ b/hal/armv7r/mpu.c
@@ -30,18 +30,18 @@ static struct {
 
 
 /* Setup single MPU region entry in a local MPU context */
-static int mpu_regionSet(hal_syspage_prog_t *progHal, unsigned int *idx, u32 baseAddr, u8 srdMask, u8 sizeBit, u32 rasrAttr)
+static int mpu_regionSet(hal_syspage_part_t *partHal, unsigned int *idx, u32 baseAddr, u8 srdMask, u8 sizeBit, u32 rasrAttr)
 {
 	if ((sizeBit < 5) || (*idx >= mpu_common.regMax)) {
 		return -EPERM;
 	}
 
-	progHal->mpu.table[*idx].rbar =
+	partHal->mpu.table[*idx].rbar =
 			baseAddr |
 			(1u << 4) | /* mark region as valid */
 			(*idx & 0xfu);
 
-	progHal->mpu.table[*idx].rasr =
+	partHal->mpu.table[*idx].rasr =
 			rasrAttr |
 			(((u32)srdMask) << 8) |
 			((((u32)sizeBit - 1) & 0x1fu) << 1);
@@ -75,20 +75,20 @@ static u32 mpu_regionAttrs(u32 attr, unsigned int enable)
 }
 
 
-static int mpu_checkOverlap(hal_syspage_prog_t *progHal, unsigned int idx, u32 start, u32 end)
+static int mpu_checkOverlap(hal_syspage_part_t *partHal, unsigned int idx, u32 start, u32 end)
 {
 	unsigned int i, j;
 	u32 srStart, srEnd;
 	u8 sizeBit, subregions;
 	end -= 1;
 	for (i = 0; i < idx; i++) {
-		if (((progHal->mpu.table[i].rbar & 0x10u) == 0) || ((progHal->mpu.table[i].rasr & 0x1u) == 0)) {
+		if (((partHal->mpu.table[i].rbar & 0x10u) == 0) || ((partHal->mpu.table[i].rasr & 0x1u) == 0)) {
 			continue;
 		}
 
-		sizeBit = ((progHal->mpu.table[i].rasr >> 1) & 0x1fu) + 1;
-		srStart = progHal->mpu.table[i].rbar & ~((1u << sizeBit) - 1);
-		subregions = (progHal->mpu.table[i].rasr >> 8) & 0xffu;
+		sizeBit = ((partHal->mpu.table[i].rasr >> 1) & 0x1fu) + 1;
+		srStart = partHal->mpu.table[i].rbar & ~((1u << sizeBit) - 1);
+		subregions = (partHal->mpu.table[i].rasr >> 8) & 0xffu;
 		for (j = 0; j < 8; j++) {
 			srEnd = srStart + (1u << (sizeBit - 3)) - 1;
 			if (((subregions & 1u) == 0) && (start <= srEnd) && (srStart <= end)) {
@@ -104,7 +104,7 @@ static int mpu_checkOverlap(hal_syspage_prog_t *progHal, unsigned int idx, u32 s
 }
 
 
-static int mpu_regionCalculateAndSet(hal_syspage_prog_t *progHal, unsigned int *idx, addr_t start, addr_t end, u8 sizeBit, u32 rasrAttr)
+static int mpu_regionCalculateAndSet(hal_syspage_part_t *partHal, unsigned int *idx, addr_t start, addr_t end, u8 sizeBit, u32 rasrAttr)
 {
 	u8 srdMask;
 	/* RBAR contains all MSBs that are the same */
@@ -115,12 +115,12 @@ static int mpu_regionCalculateAndSet(hal_syspage_prog_t *progHal, unsigned int *
 	srEnd = (srEnd == 0) ? 8 : srEnd;
 	/* Bit set means disable region - negate result */
 	srdMask = ~(((1u << srEnd) - 1) & (0xffu << srStart));
-	return mpu_regionSet(progHal, idx, baseAddr, srdMask, sizeBit, rasrAttr);
+	return mpu_regionSet(partHal, idx, baseAddr, srdMask, sizeBit, rasrAttr);
 }
 
 
 /* Create up to 2 regions that will represent a given map */
-static int mpu_regionGenerate(hal_syspage_prog_t *progHal, unsigned int *idx, addr_t start, addr_t end, u32 rasrAttr)
+static int mpu_regionGenerate(hal_syspage_part_t *partHal, unsigned int *idx, addr_t start, addr_t end, u32 rasrAttr)
 {
 	int res;
 	int commonTrailingZeroes, sigBits;
@@ -137,7 +137,7 @@ static int mpu_regionGenerate(hal_syspage_prog_t *progHal, unsigned int *idx, ad
 	/* Check if size is power of 2 and start is aligned - necessary for handling
 	   small regions (below 256 bytes) */
 	if (size == 0) {
-		return mpu_regionSet(progHal, idx, 0, 0, 32, rasrAttr);
+		return mpu_regionSet(partHal, idx, 0, 0, 32, rasrAttr);
 	}
 
 	if ((size == (1u << __builtin_ctz(size))) && ((start & (size - 1)) == 0)) {
@@ -146,7 +146,7 @@ static int mpu_regionGenerate(hal_syspage_prog_t *progHal, unsigned int *idx, ad
 			return -EPERM;
 		}
 
-		return mpu_regionSet(progHal, idx, start, 0, __builtin_ctz(size), rasrAttr);
+		return mpu_regionSet(partHal, idx, start, 0, __builtin_ctz(size), rasrAttr);
 	}
 
 	commonTrailingZeroes = __builtin_ctz(start | end);
@@ -160,15 +160,15 @@ static int mpu_regionGenerate(hal_syspage_prog_t *progHal, unsigned int *idx, ad
 	if (sigBits <= 3) {
 		/* Can be represented with one region + 8 subregions */
 		sizeBit = commonTrailingZeroes + 3;
-		return mpu_regionCalculateAndSet(progHal, idx, start, end, sizeBit, rasrAttr);
+		return mpu_regionCalculateAndSet(partHal, idx, start, end, sizeBit, rasrAttr);
 	}
 	else if (sigBits == 4) {
 		/* Can be represented with 2 regions + up to 8 subregions each */
 		sizeBit = commonTrailingZeroes + 3;
 		diffMask = (1u << sizeBit) - 1;
 		reg1End = (start & (~diffMask)) + diffMask + 1;
-		res = mpu_regionCalculateAndSet(progHal, idx, start, reg1End, sizeBit, rasrAttr);
-		return (res == EOK) ? mpu_regionCalculateAndSet(progHal, idx, reg1End, end, sizeBit, rasrAttr) : res;
+		res = mpu_regionCalculateAndSet(partHal, idx, start, reg1End, sizeBit, rasrAttr);
+		return (res == EOK) ? mpu_regionCalculateAndSet(partHal, idx, reg1End, end, sizeBit, rasrAttr) : res;
 	}
 	else if (rasrAttr == HOLE_ATTR(rasrAttr)) {
 		/* Cannot attempt another cutout - we are already trying to make a hole */
@@ -197,50 +197,50 @@ static int mpu_regionGenerate(hal_syspage_prog_t *progHal, unsigned int *idx, ad
 	}
 
 	/* First check if our "hole" overrides any existing mappings. This would lead to unintuitive behaviors. */
-	if (mpu_checkOverlap(progHal, *idx, holeStart, holeEnd) != 0) {
+	if (mpu_checkOverlap(partHal, *idx, holeStart, holeEnd) != 0) {
 		return -EPERM;
 	}
 
-	res = mpu_regionCalculateAndSet(progHal, idx, alignedStart, alignedEnd, commonMsb, rasrAttr);
-	return (res == EOK) ? mpu_regionGenerate(progHal, idx, holeStart, holeEnd, HOLE_ATTR(rasrAttr)) : res;
+	res = mpu_regionCalculateAndSet(partHal, idx, alignedStart, alignedEnd, commonMsb, rasrAttr);
+	return (res == EOK) ? mpu_regionGenerate(partHal, idx, holeStart, holeEnd, HOLE_ATTR(rasrAttr)) : res;
 }
 
 
 /* Invalidate range of regions */
-static void mpu_regionInvalidate(hal_syspage_prog_t *progHal, u8 first, u8 last)
+static void mpu_regionInvalidate(hal_syspage_part_t *partHal, u8 first, u8 last)
 {
 	unsigned int i;
 
 	for (i = first; i < last && i < mpu_common.regMax; i++) {
 		/* set multi-map to none */
-		progHal->mpu.map[i] = (u32)-1;
+		partHal->mpu.map[i] = (u32)-1;
 
 		/* mark i-th region as invalid */
-		progHal->mpu.table[i].rbar = i & 0xfu;
+		partHal->mpu.table[i].rbar = i & 0xfu;
 
 		/* set exec never and mark whole region as disabled */
-		progHal->mpu.table[i].rasr = (1u << 28) | (0x1fu << 1);
+		partHal->mpu.table[i].rasr = (1u << 28) | (0x1fu << 1);
 	}
 }
 
 
 /* Assign range of regions a multi-map id */
-static void mpu_regionAssignMap(hal_syspage_prog_t *progHal, u8 first, u8 last, u32 mapId)
+static void mpu_regionAssignMap(hal_syspage_part_t *partHal, u8 first, u8 last, u32 mapId)
 {
 	unsigned int i;
 
 	for (i = first; i < last && i < mpu_common.regMax; i++) {
-		progHal->mpu.map[i] = mapId;
+		partHal->mpu.map[i] = mapId;
 	}
 }
 
 
-static int mpu_isMapAlloced(hal_syspage_prog_t *progHal, u32 mapId)
+static int mpu_isMapAlloced(hal_syspage_part_t *partHal, u32 mapId)
 {
 	unsigned int i;
 
-	for (i = 0; i < progHal->mpu.allocCnt; i++) {
-		if (progHal->mpu.map[i] == mapId) {
+	for (i = 0; i < partHal->mpu.allocCnt; i++) {
+		if (partHal->mpu.map[i] == mapId) {
 			return 1;
 		}
 	}
@@ -249,30 +249,30 @@ static int mpu_isMapAlloced(hal_syspage_prog_t *progHal, u32 mapId)
 }
 
 
-static int mpu_regionAlloc(hal_syspage_prog_t *progHal, addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int enable)
+static int mpu_regionAlloc(hal_syspage_part_t *partHal, addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int enable)
 {
 	int res;
-	unsigned int regCur = progHal->mpu.allocCnt;
+	unsigned int regCur = partHal->mpu.allocCnt;
 	u32 rasrAttr = mpu_regionAttrs(attr, enable);
 
-	res = mpu_regionGenerate(progHal, &regCur, addr, end, rasrAttr);
+	res = mpu_regionGenerate(partHal, &regCur, addr, end, rasrAttr);
 	if (res != EOK) {
-		mpu_regionInvalidate(progHal, progHal->mpu.allocCnt, regCur);
+		mpu_regionInvalidate(partHal, partHal->mpu.allocCnt, regCur);
 		return res;
 	}
 
-	mpu_regionAssignMap(progHal, progHal->mpu.allocCnt, regCur, mapId);
+	mpu_regionAssignMap(partHal, partHal->mpu.allocCnt, regCur, mapId);
 
-	progHal->mpu.allocCnt = regCur;
+	partHal->mpu.allocCnt = regCur;
 
 	return EOK;
 }
 
 
-static void mpu_initPart(hal_syspage_prog_t *progHal)
+static void mpu_initPart(hal_syspage_part_t *partHal)
 {
-	hal_memset(progHal, 0, sizeof(hal_syspage_prog_t));
-	progHal->mpu.allocCnt = 0;
+	hal_memset(partHal, 0, sizeof(hal_syspage_part_t));
+	partHal->mpu.allocCnt = 0;
 }
 
 
@@ -302,7 +302,7 @@ unsigned int mpu_getMaxRegionsCount(void)
 }
 
 
-static int mpu_mapsAlloc(hal_syspage_prog_t *progHal, const char *maps, size_t cnt)
+static int mpu_mapsAlloc(hal_syspage_part_t *partHal, const char *maps, size_t cnt)
 {
 	int i, res;
 	addr_t start, end;
@@ -313,7 +313,7 @@ static int mpu_mapsAlloc(hal_syspage_prog_t *progHal, const char *maps, size_t c
 		if ((res = syspage_mapNameResolve(maps, &id)) < 0) {
 			return res;
 		}
-		if (mpu_isMapAlloced(progHal, id) != 0) {
+		if (mpu_isMapAlloced(partHal, id) != 0) {
 			maps += hal_strlen(maps) + 1; /* name + '\0' */
 			continue;
 		}
@@ -323,7 +323,7 @@ static int mpu_mapsAlloc(hal_syspage_prog_t *progHal, const char *maps, size_t c
 		if ((res = syspage_mapAttrResolve(maps, &attr)) < 0) {
 			return res;
 		}
-		if ((res = mpu_regionAlloc(progHal, start, end, attr, id, 1)) < 0) {
+		if ((res = mpu_regionAlloc(partHal, start, end, attr, id, 1)) < 0) {
 			log_error("\nCan't allocate MPU region for %s", maps);
 			return res;
 		}
@@ -333,22 +333,22 @@ static int mpu_mapsAlloc(hal_syspage_prog_t *progHal, const char *maps, size_t c
 }
 
 
-extern int mpu_getHalProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int mpu_getHalPartData(hal_syspage_part_t *hal, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	int ret;
 
-	mpu_initPart(&prog->hal);
+	mpu_initPart(hal);
 
-	ret = mpu_mapsAlloc(&prog->hal, imaps, imapSz);
+	ret = mpu_mapsAlloc(hal, imaps, imapSz);
 	if (ret != EOK) {
 		return ret;
 	}
-	ret = mpu_mapsAlloc(&prog->hal, dmaps, dmapSz);
+	ret = mpu_mapsAlloc(hal, dmaps, dmapSz);
 	if (ret != EOK) {
 		return ret;
 	}
 
-	mpu_regionInvalidate(&prog->hal, prog->hal.mpu.allocCnt, mpu_common.regMax);
+	mpu_regionInvalidate(hal, hal->mpu.allocCnt, mpu_common.regMax);
 
 	return EOK;
 }

--- a/hal/armv7r/mpu.c
+++ b/hal/armv7r/mpu.c
@@ -15,9 +15,14 @@
 
 #include <lib/errno.h>
 #include "mpu.h"
+#include "lib/log.h"
+#include "syspage.h"
 
 
-static mpu_common_t mpu_common;
+static struct {
+	u32 type;
+	u32 regMax;
+} mpu_common;
 
 
 /* Removes all RASR attribute bits except ENABLE */
@@ -25,18 +30,18 @@ static mpu_common_t mpu_common;
 
 
 /* Setup single MPU region entry in a local MPU context */
-static int mpu_regionSet(unsigned int *idx, u32 baseAddr, u8 srdMask, u8 sizeBit, u32 rasrAttr)
+static int mpu_regionSet(hal_syspage_prog_t *progHal, unsigned int *idx, u32 baseAddr, u8 srdMask, u8 sizeBit, u32 rasrAttr)
 {
 	if ((sizeBit < 5) || (*idx >= mpu_common.regMax)) {
 		return -EPERM;
 	}
 
-	mpu_common.region[*idx].rbar =
+	progHal->mpu.table[*idx].rbar =
 			baseAddr |
 			(1u << 4) | /* mark region as valid */
 			(*idx & 0xfu);
 
-	mpu_common.region[*idx].rasr =
+	progHal->mpu.table[*idx].rasr =
 			rasrAttr |
 			(((u32)srdMask) << 8) |
 			((((u32)sizeBit - 1) & 0x1fu) << 1);
@@ -70,20 +75,20 @@ static u32 mpu_regionAttrs(u32 attr, unsigned int enable)
 }
 
 
-static int mpu_checkOverlap(unsigned int idx, u32 start, u32 end)
+static int mpu_checkOverlap(hal_syspage_prog_t *progHal, unsigned int idx, u32 start, u32 end)
 {
 	unsigned int i, j;
 	u32 srStart, srEnd;
 	u8 sizeBit, subregions;
 	end -= 1;
 	for (i = 0; i < idx; i++) {
-		if (((mpu_common.region[i].rbar & 0x10u) == 0) || ((mpu_common.region[i].rasr & 0x1u) == 0)) {
+		if (((progHal->mpu.table[i].rbar & 0x10u) == 0) || ((progHal->mpu.table[i].rasr & 0x1u) == 0)) {
 			continue;
 		}
 
-		sizeBit = ((mpu_common.region[i].rasr >> 1) & 0x1fu) + 1;
-		srStart = mpu_common.region[i].rbar & ~((1u << sizeBit) - 1);
-		subregions = (mpu_common.region[i].rasr >> 8) & 0xffu;
+		sizeBit = ((progHal->mpu.table[i].rasr >> 1) & 0x1fu) + 1;
+		srStart = progHal->mpu.table[i].rbar & ~((1u << sizeBit) - 1);
+		subregions = (progHal->mpu.table[i].rasr >> 8) & 0xffu;
 		for (j = 0; j < 8; j++) {
 			srEnd = srStart + (1u << (sizeBit - 3)) - 1;
 			if (((subregions & 1u) == 0) && (start <= srEnd) && (srStart <= end)) {
@@ -99,7 +104,7 @@ static int mpu_checkOverlap(unsigned int idx, u32 start, u32 end)
 }
 
 
-static int mpu_regionCalculateAndSet(unsigned int *idx, addr_t start, addr_t end, u8 sizeBit, u32 rasrAttr)
+static int mpu_regionCalculateAndSet(hal_syspage_prog_t *progHal, unsigned int *idx, addr_t start, addr_t end, u8 sizeBit, u32 rasrAttr)
 {
 	u8 srdMask;
 	/* RBAR contains all MSBs that are the same */
@@ -110,12 +115,12 @@ static int mpu_regionCalculateAndSet(unsigned int *idx, addr_t start, addr_t end
 	srEnd = (srEnd == 0) ? 8 : srEnd;
 	/* Bit set means disable region - negate result */
 	srdMask = ~(((1u << srEnd) - 1) & (0xffu << srStart));
-	return mpu_regionSet(idx, baseAddr, srdMask, sizeBit, rasrAttr);
+	return mpu_regionSet(progHal, idx, baseAddr, srdMask, sizeBit, rasrAttr);
 }
 
 
 /* Create up to 2 regions that will represent a given map */
-static int mpu_regionGenerate(unsigned int *idx, addr_t start, addr_t end, u32 rasrAttr)
+static int mpu_regionGenerate(hal_syspage_prog_t *progHal, unsigned int *idx, addr_t start, addr_t end, u32 rasrAttr)
 {
 	int res;
 	int commonTrailingZeroes, sigBits;
@@ -132,7 +137,7 @@ static int mpu_regionGenerate(unsigned int *idx, addr_t start, addr_t end, u32 r
 	/* Check if size is power of 2 and start is aligned - necessary for handling
 	   small regions (below 256 bytes) */
 	if (size == 0) {
-		return mpu_regionSet(idx, 0, 0, 32, rasrAttr);
+		return mpu_regionSet(progHal, idx, 0, 0, 32, rasrAttr);
 	}
 
 	if ((size == (1u << __builtin_ctz(size))) && ((start & (size - 1)) == 0)) {
@@ -141,7 +146,7 @@ static int mpu_regionGenerate(unsigned int *idx, addr_t start, addr_t end, u32 r
 			return -EPERM;
 		}
 
-		return mpu_regionSet(idx, start, 0, __builtin_ctz(size), rasrAttr);
+		return mpu_regionSet(progHal, idx, start, 0, __builtin_ctz(size), rasrAttr);
 	}
 
 	commonTrailingZeroes = __builtin_ctz(start | end);
@@ -155,15 +160,15 @@ static int mpu_regionGenerate(unsigned int *idx, addr_t start, addr_t end, u32 r
 	if (sigBits <= 3) {
 		/* Can be represented with one region + 8 subregions */
 		sizeBit = commonTrailingZeroes + 3;
-		return mpu_regionCalculateAndSet(idx, start, end, sizeBit, rasrAttr);
+		return mpu_regionCalculateAndSet(progHal, idx, start, end, sizeBit, rasrAttr);
 	}
 	else if (sigBits == 4) {
 		/* Can be represented with 2 regions + up to 8 subregions each */
 		sizeBit = commonTrailingZeroes + 3;
 		diffMask = (1u << sizeBit) - 1;
 		reg1End = (start & (~diffMask)) + diffMask + 1;
-		res = mpu_regionCalculateAndSet(idx, start, reg1End, sizeBit, rasrAttr);
-		return (res == EOK) ? mpu_regionCalculateAndSet(idx, reg1End, end, sizeBit, rasrAttr) : res;
+		res = mpu_regionCalculateAndSet(progHal, idx, start, reg1End, sizeBit, rasrAttr);
+		return (res == EOK) ? mpu_regionCalculateAndSet(progHal, idx, reg1End, end, sizeBit, rasrAttr) : res;
 	}
 	else if (rasrAttr == HOLE_ATTR(rasrAttr)) {
 		/* Cannot attempt another cutout - we are already trying to make a hole */
@@ -192,49 +197,82 @@ static int mpu_regionGenerate(unsigned int *idx, addr_t start, addr_t end, u32 r
 	}
 
 	/* First check if our "hole" overrides any existing mappings. This would lead to unintuitive behaviors. */
-	if (mpu_checkOverlap(*idx, holeStart, holeEnd) != 0) {
+	if (mpu_checkOverlap(progHal, *idx, holeStart, holeEnd) != 0) {
 		return -EPERM;
 	}
 
-	res = mpu_regionCalculateAndSet(idx, alignedStart, alignedEnd, commonMsb, rasrAttr);
-	return (res == EOK) ? mpu_regionGenerate(idx, holeStart, holeEnd, HOLE_ATTR(rasrAttr)) : res;
+	res = mpu_regionCalculateAndSet(progHal, idx, alignedStart, alignedEnd, commonMsb, rasrAttr);
+	return (res == EOK) ? mpu_regionGenerate(progHal, idx, holeStart, holeEnd, HOLE_ATTR(rasrAttr)) : res;
 }
 
 
 /* Invalidate range of regions */
-static void mpu_regionInvalidate(u8 first, u8 last)
+static void mpu_regionInvalidate(hal_syspage_prog_t *progHal, u8 first, u8 last)
 {
 	unsigned int i;
 
 	for (i = first; i < last && i < mpu_common.regMax; i++) {
 		/* set multi-map to none */
-		mpu_common.mapId[i] = (u32)-1;
+		progHal->mpu.map[i] = (u32)-1;
 
 		/* mark i-th region as invalid */
-		mpu_common.region[i].rbar = i & 0xfu;
+		progHal->mpu.table[i].rbar = i & 0xfu;
 
 		/* set exec never and mark whole region as disabled */
-		mpu_common.region[i].rasr = (1u << 28) | (0x1fu << 1);
+		progHal->mpu.table[i].rasr = (1u << 28) | (0x1fu << 1);
 	}
 }
 
 
 /* Assign range of regions a multi-map id */
-static void mpu_regionAssignMap(u8 first, u8 last, u32 mapId)
+static void mpu_regionAssignMap(hal_syspage_prog_t *progHal, u8 first, u8 last, u32 mapId)
 {
 	unsigned int i;
 
 	for (i = first; i < last && i < mpu_common.regMax; i++) {
-		/* assign map only if region is valid */
-		if (mpu_common.region[i].rbar & (1u << 4))
-			mpu_common.mapId[i] = mapId;
+		progHal->mpu.map[i] = mapId;
 	}
 }
 
 
-const mpu_common_t *const mpu_getCommon(void)
+static int mpu_isMapAlloced(hal_syspage_prog_t *progHal, u32 mapId)
 {
-	return &mpu_common;
+	unsigned int i;
+
+	for (i = 0; i < progHal->mpu.allocCnt; i++) {
+		if (progHal->mpu.map[i] == mapId) {
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+
+static int mpu_regionAlloc(hal_syspage_prog_t *progHal, addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int enable)
+{
+	int res;
+	unsigned int regCur = progHal->mpu.allocCnt;
+	u32 rasrAttr = mpu_regionAttrs(attr, enable);
+
+	res = mpu_regionGenerate(progHal, &regCur, addr, end, rasrAttr);
+	if (res != EOK) {
+		mpu_regionInvalidate(progHal, progHal->mpu.allocCnt, regCur);
+		return res;
+	}
+
+	mpu_regionAssignMap(progHal, progHal->mpu.allocCnt, regCur, mapId);
+
+	progHal->mpu.allocCnt = regCur;
+
+	return EOK;
+}
+
+
+static void mpu_initPart(hal_syspage_prog_t *progHal)
+{
+	hal_memset(progHal, 0, sizeof(hal_syspage_prog_t));
+	progHal->mpu.allocCnt = 0;
 }
 
 
@@ -245,45 +283,72 @@ void mpu_init(void)
 	__asm__ volatile("mrc p15, 0, %0, c0, c0, 4" : "=r"(mpu_type));
 	mpu_common.type = mpu_type;
 	mpu_common.regMax = (u8)(mpu_common.type >> 8);
-	mpu_common.regCnt = mpu_common.mapCnt = 0;
-
-	mpu_regionInvalidate(0, sizeof(mpu_common.region) / sizeof(mpu_common.region[0]));
-}
-
-
-int mpu_regionAlloc(addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int enable)
-{
-	int res;
-	unsigned int regCur = mpu_common.regCnt;
-	u32 rasrAttr = mpu_regionAttrs(attr, enable);
-
-	res = mpu_regionGenerate(&regCur, addr, end, rasrAttr);
-	if (res != EOK) {
-		mpu_regionInvalidate(mpu_common.regCnt, regCur);
-		return res;
+	/* Hardware may support more regions than can be stored in our code. */
+	if (mpu_common.regMax > MPU_MAX_REGIONS) {
+		mpu_common.regMax = MPU_MAX_REGIONS;
 	}
-
-	mpu_regionAssignMap(mpu_common.regCnt, regCur, mapId);
-
-	mpu_common.regCnt = regCur;
-	mpu_common.mapCnt++;
-
-	return EOK;
 }
 
 
 void mpu_getHalData(hal_syspage_t *hal)
 {
-	unsigned int i;
+	hal->mpuType = mpu_common.type;
+}
 
-	mpu_regionInvalidate(mpu_common.regCnt, mpu_common.regMax);
 
-	hal->mpu.type = mpu_common.type;
-	hal->mpu.allocCnt = mpu_common.regCnt;
+unsigned int mpu_getMaxRegionsCount(void)
+{
+	return mpu_common.regMax;
+}
 
-	for (i = 0; i < sizeof(hal->mpu.table) / sizeof(hal->mpu.table[0]); i++) {
-		hal->mpu.table[i].rbar = mpu_common.region[i].rbar;
-		hal->mpu.table[i].rasr = mpu_common.region[i].rasr;
-		hal->mpu.map[i] = mpu_common.mapId[i];
+
+static int mpu_mapsAlloc(hal_syspage_prog_t *progHal, const char *maps, size_t cnt)
+{
+	int i, res;
+	addr_t start, end;
+	u32 attr;
+	u8 id;
+
+	for (i = 0; i < cnt; i++) {
+		if ((res = syspage_mapNameResolve(maps, &id)) < 0) {
+			return res;
+		}
+		if (mpu_isMapAlloced(progHal, id) != 0) {
+			maps += hal_strlen(maps) + 1; /* name + '\0' */
+			continue;
+		}
+		if ((res = syspage_mapRangeResolve(maps, &start, &end)) < 0) {
+			return res;
+		}
+		if ((res = syspage_mapAttrResolve(maps, &attr)) < 0) {
+			return res;
+		}
+		if ((res = mpu_regionAlloc(progHal, start, end, attr, id, 1)) < 0) {
+			log_error("\nCan't allocate MPU region for %s", maps);
+			return res;
+		}
+		maps += hal_strlen(maps) + 1; /* name + '\0' */
 	}
+	return EOK;
+}
+
+
+extern int mpu_getHalProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+{
+	int ret;
+
+	mpu_initPart(&prog->hal);
+
+	ret = mpu_mapsAlloc(&prog->hal, imaps, imapSz);
+	if (ret != EOK) {
+		return ret;
+	}
+	ret = mpu_mapsAlloc(&prog->hal, dmaps, dmapSz);
+	if (ret != EOK) {
+		return ret;
+	}
+
+	mpu_regionInvalidate(&prog->hal, prog->hal.mpu.allocCnt, mpu_common.regMax);
+
+	return EOK;
 }

--- a/hal/armv7r/mpu.h
+++ b/hal/armv7r/mpu.h
@@ -18,36 +18,20 @@
 
 #include <hal/hal.h>
 
-typedef struct {
-	u32 rbar;
-	u32 rasr;
-} mpu_region_t;
 
-
-typedef struct {
-	u32 type;
-	u32 regCnt;
-	u32 regMax;
-	u32 mapCnt;
-	mpu_region_t region[16] __attribute__((aligned(8)));
-	u32 mapId[16];
-} mpu_common_t;
-
-
-/* Get const pointer to read only mpu_common structure */
-extern const mpu_common_t *const mpu_getCommon(void);
+extern unsigned int mpu_getMaxRegionsCount(void);
 
 
 /* Reset structures and detect MPU type */
 extern void mpu_init(void);
 
 
-/* Allocate MPU sub-regions and link with a map */
-extern int mpu_regionAlloc(addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int enable);
-
-
-/* Get MPU regions setup into hal_syspage_t structure */
+/* Get MPU info into hal_syspage_t structure */
 extern void mpu_getHalData(hal_syspage_t *hal);
+
+
+/* Get MPU regions setup into syspage_prog_t structure */
+extern int mpu_getHalProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz);
 
 
 #endif

--- a/hal/armv7r/mpu.h
+++ b/hal/armv7r/mpu.h
@@ -30,8 +30,8 @@ extern void mpu_init(void);
 extern void mpu_getHalData(hal_syspage_t *hal);
 
 
-/* Get MPU regions setup into syspage_prog_t structure */
-extern int mpu_getHalProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz);
+/* Get MPU regions setup into syspage_part_t structure */
+extern int mpu_getHalPartData(hal_syspage_part_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz);
 
 
 #endif

--- a/hal/armv7r/tda4vm/hal.c
+++ b/hal/armv7r/tda4vm/hal.c
@@ -105,9 +105,9 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
-	return mpu_regionAlloc(start, end, attr, mapId, 1);
+	return mpu_getHalProgData(prog, imaps, imapSz, dmaps, dmapSz);
 }
 
 

--- a/hal/armv7r/tda4vm/hal.c
+++ b/hal/armv7r/tda4vm/hal.c
@@ -105,9 +105,9 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
-	return mpu_getHalProgData(prog, imaps, imapSz, dmaps, dmapSz);
+	return mpu_getHalPartData(part, imaps, imapSz, dmaps, dmapSz);
 }
 
 

--- a/hal/armv7r/zynqmp/hal.c
+++ b/hal/armv7r/zynqmp/hal.c
@@ -107,9 +107,9 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
-	return mpu_regionAlloc(start, end, attr, mapId, 1);
+	return mpu_getHalProgData(prog, imaps, imapSz, dmaps, dmapSz);
 }
 
 

--- a/hal/armv7r/zynqmp/hal.c
+++ b/hal/armv7r/zynqmp/hal.c
@@ -107,9 +107,9 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
-	return mpu_getHalProgData(prog, imaps, imapSz, dmaps, dmapSz);
+	return mpu_getHalPartData(part, imaps, imapSz, dmaps, dmapSz);
 }
 
 

--- a/hal/armv8m/mcx/hal.c
+++ b/hal/armv8m/mcx/hal.c
@@ -98,12 +98,13 @@ void hal_kernelGetEntryPointOffset(addr_t *off, int *indirect)
 void hal_kernelEntryPoint(addr_t addr)
 {
 	hal_common.entry = addr;
+	mpu_kernelEntryPoint(addr);
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
-	return mpu_regionAlloc(start, end, attr, mapId, 1);
+	return mpu_getHalProgData(prog, imaps, imapSz, dmaps, dmapSz);
 }
 
 

--- a/hal/armv8m/mcx/hal.c
+++ b/hal/armv8m/mcx/hal.c
@@ -102,9 +102,9 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
-	return mpu_getHalProgData(prog, imaps, imapSz, dmaps, dmapSz);
+	return mpu_getHalPartData(part, imaps, imapSz, dmaps, dmapSz);
 }
 
 

--- a/hal/armv8m/mpu.c
+++ b/hal/armv8m/mpu.c
@@ -16,12 +16,21 @@
 #include <lib/errno.h>
 #include <board_config.h>
 #include "mpu.h"
+#include "lib/log.h"
+#include "syspage.h"
 
 #ifndef DISABLE_MPU
 #define DISABLE_MPU 0
 #endif
 
-static mpu_common_t mpu_common;
+#define MPU_BASE ((void *)0xe000ed90)
+
+
+static struct {
+	u32 type;
+	u32 regMax;
+	addr_t kernelEntryPoint;
+} mpu_common;
 
 
 enum {
@@ -77,7 +86,7 @@ static u32 mpu_regionAttrsRbar(u32 attr)
 
 
 /* Setup single MPU region entry in local MPU context */
-static int mpu_regionSet(unsigned int *idx, addr_t start, addr_t end, u32 rbarAttr, u32 rlarAttr, u32 mapId)
+static int mpu_regionSet(hal_syspage_prog_t *progHal, unsigned int *idx, addr_t start, addr_t end, u32 rbarAttr, u32 rlarAttr, u32 mapId)
 {
 	/* Allow end == 0, this means end of address range */
 	const size_t size = (end - start) & 0xffffffffu;
@@ -101,35 +110,29 @@ static int mpu_regionSet(unsigned int *idx, addr_t start, addr_t end, u32 rbarAt
 		return -EPERM;
 	}
 
-	mpu_common.region[*idx].rbar = (start & ~0x1f) | rbarAttr;
-	mpu_common.region[*idx].rlar = (limit & ~0x1f) | rlarAttr;
-	mpu_common.mapId[*idx] = mapId;
+	progHal->mpu.table[*idx].rbar = (start & ~0x1f) | rbarAttr;
+	progHal->mpu.table[*idx].rlar = (limit & ~0x1f) | rlarAttr;
+	progHal->mpu.map[*idx] = mapId;
 
 	*idx += 1;
 	return EOK;
 }
 
 
-const mpu_common_t *const mpu_getCommon(void)
-{
-	return &mpu_common;
-}
-
-
 /* Invalidate range of regions */
-static void mpu_regionInvalidate(u8 first, u8 last)
+static void mpu_regionInvalidate(hal_syspage_prog_t *progHal, u8 first, u8 last)
 {
 	unsigned int i;
 
 	for (i = first; (i < last) && (i < mpu_common.regMax); i++) {
 		/* set multi-map to none */
-		mpu_common.mapId[i] = (u32)-1;
+		progHal->mpu.map[i] = (u32)-1;
 
 		/* mark i-th region as disabled */
-		mpu_common.region[i].rlar = 0;
+		progHal->mpu.table[i].rlar = 0;
 
 		/* set exec never */
-		mpu_common.region[i].rbar = 1;
+		progHal->mpu.table[i].rbar = 1;
 	}
 }
 
@@ -162,17 +165,33 @@ void mpu_init(void)
 		*(mpu_base + mpu_mair0) = 0xee04aa00;
 	}
 #endif
-	mpu_common.regCnt = 0;
-	mpu_common.mapCnt = 0;
+	mpu_common.kernelEntryPoint = (addr_t)-1;
+}
 
-	mpu_regionInvalidate(0, MPU_MAX_REGIONS);
+void mpu_kernelEntryPoint(addr_t addr)
+{
+	mpu_common.kernelEntryPoint = addr;
 }
 
 
-int mpu_regionAlloc(addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int enable)
+static int mpu_isMapAlloced(hal_syspage_prog_t *progHal, u32 mapId)
+{
+	unsigned int i;
+
+	for (i = 0; i < progHal->mpu.allocCnt; i++) {
+		if (progHal->mpu.map[i] == mapId) {
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+
+static int mpu_regionAlloc(hal_syspage_prog_t *progHal, addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int enable)
 {
 	int res;
-	unsigned int regCur = mpu_common.regCnt;
+	unsigned int regCur = progHal->mpu.allocCnt;
 	u32 rbarAttr, rlarAttr;
 
 	if (mpu_common.regMax == 0) {
@@ -184,45 +203,123 @@ int mpu_regionAlloc(addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int e
 	rbarAttr = mpu_regionAttrsRbar(attr);
 	rlarAttr = mpu_regionAttrsRlar(attr, enable);
 
-	res = mpu_regionSet(&regCur, addr, end, rbarAttr, rlarAttr, mapId);
+	res = mpu_regionSet(progHal, &regCur, addr, end, rbarAttr, rlarAttr, mapId);
 	if (res != EOK) {
-		mpu_regionInvalidate(mpu_common.regCnt, regCur);
+		mpu_regionInvalidate(progHal, progHal->mpu.allocCnt, regCur);
 		return res;
 	}
 
-	mpu_common.regCnt = regCur;
-	mpu_common.mapCnt++;
+	progHal->mpu.allocCnt = regCur;
 
 	return EOK;
 }
 
+
+static int mpu_allocKernelMap(hal_syspage_prog_t *progHal)
+{
+	addr_t start, end;
+	u32 attr;
+	u8 id;
+	int res;
+	const char *kcodemap = NULL;
+
+	start = mpu_common.kernelEntryPoint;
+	if (start == (addr_t)-1) {
+		log_error("\nMissing kernel entry point!");
+		return -EINVAL;
+	}
+	if ((res = syspage_mapAddrResolve(start, &kcodemap)) < 0) {
+		return res;
+	}
+	if ((res = syspage_mapNameResolve(kcodemap, &id)) < 0) {
+		return res;
+	}
+	if ((res = syspage_mapRangeResolve(kcodemap, &start, &end)) < 0) {
+		return res;
+	}
+	if ((res = syspage_mapAttrResolve(kcodemap, &attr)) < 0) {
+		return res;
+	}
+	if ((res = mpu_regionAlloc(progHal, start, end, attr, id, 1)) < 0) {
+		log_error("\nCan't allocate MPU region for kernel code map (%s)", kcodemap);
+		return res;
+	}
+	return EOK;
+}
+
+
+static void mpu_initPart(hal_syspage_prog_t *progHal)
+{
+	hal_memset(progHal, 0, sizeof(hal_syspage_prog_t));
+	progHal->mpu.allocCnt = 0;
+}
+
+
 void mpu_getHalData(hal_syspage_t *hal)
 {
-	const unsigned int syspageTableSize = sizeof(hal->mpu.table) / sizeof(hal->mpu.table[0]);
-	unsigned int i;
+	hal->mpuType = mpu_common.type;
+}
 
-	mpu_regionInvalidate(mpu_common.regCnt, mpu_common.regMax);
 
-	if (mpu_common.regCnt > syspageTableSize) {
-		/* TODO: We need a way to handle errors here that can happen due to misconfiguration
-		 * (size of table in syspage too small). This way to do it silently truncates the list
-		 * which may cause undesired behaviors. */
-		mpu_common.regCnt = syspageTableSize;
+static int mpu_mapsAlloc(hal_syspage_prog_t *progHal, const char *maps, size_t cnt)
+{
+	int i, res;
+	addr_t start, end;
+	u32 attr;
+	u8 id;
+
+	for (i = 0; i < cnt; i++) {
+		if ((res = syspage_mapNameResolve(maps, &id)) < 0) {
+			return res;
+		}
+		if (mpu_isMapAlloced(progHal, id) != 0) {
+			maps += hal_strlen(maps) + 1; /* name + '\0' */
+			continue;
+		}
+		if ((res = syspage_mapRangeResolve(maps, &start, &end)) < 0) {
+			return res;
+		}
+		if ((res = syspage_mapAttrResolve(maps, &attr)) < 0) {
+			return res;
+		}
+		if ((res = mpu_regionAlloc(progHal, start, end, attr, id, 1)) < 0) {
+			log_error("\nCan't allocate MPU region for %s", maps);
+			return res;
+		}
+		maps += hal_strlen(maps) + 1; /* name + '\0' */
+	}
+	return EOK;
+}
+
+
+extern int mpu_getHalProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+{
+	int ret;
+
+	mpu_initPart(&prog->hal);
+
+	/* FIXME HACK
+	 * allow all programs to execute (and read) kernel code map.
+	 * Needed because of hal_jmp, syscalls handler and signals handler.
+	 * In these functions we need to switch to the user mode when still
+	 * executing kernel code. This will cause memory management fault
+	 * if the application does not have access to the kernel instruction
+	 * map. Possible fix - place return to the user code in the separate
+	 * region and allow this region instead. */
+	ret = mpu_allocKernelMap(&prog->hal);
+	if (ret != EOK) {
+		return ret;
+	}
+	ret = mpu_mapsAlloc(&prog->hal, imaps, imapSz);
+	if (ret != EOK) {
+		return ret;
+	}
+	ret = mpu_mapsAlloc(&prog->hal, dmaps, dmapSz);
+	if (ret != EOK) {
+		return ret;
 	}
 
-	hal->mpu.type = mpu_common.type;
-	hal->mpu.allocCnt = mpu_common.regCnt;
+	mpu_regionInvalidate(&prog->hal, prog->hal.mpu.allocCnt, mpu_common.regMax);
 
-	for (i = 0; i < mpu_common.regCnt; i++) {
-		hal->mpu.table[i].rbar = mpu_common.region[i].rbar;
-		hal->mpu.table[i].rlar = mpu_common.region[i].rlar;
-		hal->mpu.map[i] = mpu_common.mapId[i];
-	}
-
-	/* Ensure all entries are initialized if mpu_common.regCnt or mpu_common.regMax is smaller than syspageTableSize */
-	for (; i < syspageTableSize; i++) {
-		hal->mpu.map[i] = (u32)-1;  /* set multi-map to none */
-		hal->mpu.table[i].rlar = 0; /* mark i-th region as disabled */
-		hal->mpu.table[i].rbar = 1; /* set exec never */
-	}
+	return EOK;
 }

--- a/hal/armv8m/mpu.c
+++ b/hal/armv8m/mpu.c
@@ -86,7 +86,7 @@ static u32 mpu_regionAttrsRbar(u32 attr)
 
 
 /* Setup single MPU region entry in local MPU context */
-static int mpu_regionSet(hal_syspage_prog_t *progHal, unsigned int *idx, addr_t start, addr_t end, u32 rbarAttr, u32 rlarAttr, u32 mapId)
+static int mpu_regionSet(hal_syspage_part_t *partHal, unsigned int *idx, addr_t start, addr_t end, u32 rbarAttr, u32 rlarAttr, u32 mapId)
 {
 	/* Allow end == 0, this means end of address range */
 	const size_t size = (end - start) & 0xffffffffu;
@@ -110,9 +110,9 @@ static int mpu_regionSet(hal_syspage_prog_t *progHal, unsigned int *idx, addr_t 
 		return -EPERM;
 	}
 
-	progHal->mpu.table[*idx].rbar = (start & ~0x1f) | rbarAttr;
-	progHal->mpu.table[*idx].rlar = (limit & ~0x1f) | rlarAttr;
-	progHal->mpu.map[*idx] = mapId;
+	partHal->mpu.table[*idx].rbar = (start & ~0x1f) | rbarAttr;
+	partHal->mpu.table[*idx].rlar = (limit & ~0x1f) | rlarAttr;
+	partHal->mpu.map[*idx] = mapId;
 
 	*idx += 1;
 	return EOK;
@@ -120,19 +120,19 @@ static int mpu_regionSet(hal_syspage_prog_t *progHal, unsigned int *idx, addr_t 
 
 
 /* Invalidate range of regions */
-static void mpu_regionInvalidate(hal_syspage_prog_t *progHal, u8 first, u8 last)
+static void mpu_regionInvalidate(hal_syspage_part_t *partHal, u8 first, u8 last)
 {
 	unsigned int i;
 
 	for (i = first; (i < last) && (i < mpu_common.regMax); i++) {
 		/* set multi-map to none */
-		progHal->mpu.map[i] = (u32)-1;
+		partHal->mpu.map[i] = (u32)-1;
 
 		/* mark i-th region as disabled */
-		progHal->mpu.table[i].rlar = 0;
+		partHal->mpu.table[i].rlar = 0;
 
 		/* set exec never */
-		progHal->mpu.table[i].rbar = 1;
+		partHal->mpu.table[i].rbar = 1;
 	}
 }
 
@@ -174,12 +174,12 @@ void mpu_kernelEntryPoint(addr_t addr)
 }
 
 
-static int mpu_isMapAlloced(hal_syspage_prog_t *progHal, u32 mapId)
+static int mpu_isMapAlloced(hal_syspage_part_t *partHal, u32 mapId)
 {
 	unsigned int i;
 
-	for (i = 0; i < progHal->mpu.allocCnt; i++) {
-		if (progHal->mpu.map[i] == mapId) {
+	for (i = 0; i < partHal->mpu.allocCnt; i++) {
+		if (partHal->mpu.map[i] == mapId) {
 			return 1;
 		}
 	}
@@ -188,10 +188,10 @@ static int mpu_isMapAlloced(hal_syspage_prog_t *progHal, u32 mapId)
 }
 
 
-static int mpu_regionAlloc(hal_syspage_prog_t *progHal, addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int enable)
+static int mpu_regionAlloc(hal_syspage_part_t *partHal, addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int enable)
 {
 	int res;
-	unsigned int regCur = progHal->mpu.allocCnt;
+	unsigned int regCur = partHal->mpu.allocCnt;
 	u32 rbarAttr, rlarAttr;
 
 	if (mpu_common.regMax == 0) {
@@ -203,19 +203,19 @@ static int mpu_regionAlloc(hal_syspage_prog_t *progHal, addr_t addr, addr_t end,
 	rbarAttr = mpu_regionAttrsRbar(attr);
 	rlarAttr = mpu_regionAttrsRlar(attr, enable);
 
-	res = mpu_regionSet(progHal, &regCur, addr, end, rbarAttr, rlarAttr, mapId);
+	res = mpu_regionSet(partHal, &regCur, addr, end, rbarAttr, rlarAttr, mapId);
 	if (res != EOK) {
-		mpu_regionInvalidate(progHal, progHal->mpu.allocCnt, regCur);
+		mpu_regionInvalidate(partHal, partHal->mpu.allocCnt, regCur);
 		return res;
 	}
 
-	progHal->mpu.allocCnt = regCur;
+	partHal->mpu.allocCnt = regCur;
 
 	return EOK;
 }
 
 
-static int mpu_allocKernelMap(hal_syspage_prog_t *progHal)
+static int mpu_allocKernelMap(hal_syspage_part_t *partHal)
 {
 	addr_t start, end;
 	u32 attr;
@@ -240,7 +240,7 @@ static int mpu_allocKernelMap(hal_syspage_prog_t *progHal)
 	if ((res = syspage_mapAttrResolve(kcodemap, &attr)) < 0) {
 		return res;
 	}
-	if ((res = mpu_regionAlloc(progHal, start, end, attr, id, 1)) < 0) {
+	if ((res = mpu_regionAlloc(partHal, start, end, attr, id, 1)) < 0) {
 		log_error("\nCan't allocate MPU region for kernel code map (%s)", kcodemap);
 		return res;
 	}
@@ -248,10 +248,10 @@ static int mpu_allocKernelMap(hal_syspage_prog_t *progHal)
 }
 
 
-static void mpu_initPart(hal_syspage_prog_t *progHal)
+static void mpu_initPart(hal_syspage_part_t *partHal)
 {
-	hal_memset(progHal, 0, sizeof(hal_syspage_prog_t));
-	progHal->mpu.allocCnt = 0;
+	hal_memset(partHal, 0, sizeof(hal_syspage_part_t));
+	partHal->mpu.allocCnt = 0;
 }
 
 
@@ -261,7 +261,7 @@ void mpu_getHalData(hal_syspage_t *hal)
 }
 
 
-static int mpu_mapsAlloc(hal_syspage_prog_t *progHal, const char *maps, size_t cnt)
+static int mpu_mapsAlloc(hal_syspage_part_t *partHal, const char *maps, size_t cnt)
 {
 	int i, res;
 	addr_t start, end;
@@ -272,7 +272,7 @@ static int mpu_mapsAlloc(hal_syspage_prog_t *progHal, const char *maps, size_t c
 		if ((res = syspage_mapNameResolve(maps, &id)) < 0) {
 			return res;
 		}
-		if (mpu_isMapAlloced(progHal, id) != 0) {
+		if (mpu_isMapAlloced(partHal, id) != 0) {
 			maps += hal_strlen(maps) + 1; /* name + '\0' */
 			continue;
 		}
@@ -282,7 +282,7 @@ static int mpu_mapsAlloc(hal_syspage_prog_t *progHal, const char *maps, size_t c
 		if ((res = syspage_mapAttrResolve(maps, &attr)) < 0) {
 			return res;
 		}
-		if ((res = mpu_regionAlloc(progHal, start, end, attr, id, 1)) < 0) {
+		if ((res = mpu_regionAlloc(partHal, start, end, attr, id, 1)) < 0) {
 			log_error("\nCan't allocate MPU region for %s", maps);
 			return res;
 		}
@@ -292,11 +292,11 @@ static int mpu_mapsAlloc(hal_syspage_prog_t *progHal, const char *maps, size_t c
 }
 
 
-extern int mpu_getHalProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int mpu_getHalPartData(hal_syspage_part_t *hal, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	int ret;
 
-	mpu_initPart(&prog->hal);
+	mpu_initPart(hal);
 
 	/* FIXME HACK
 	 * allow all programs to execute (and read) kernel code map.
@@ -306,20 +306,20 @@ extern int mpu_getHalProgData(syspage_prog_t *prog, const char *imaps, size_t im
 	 * if the application does not have access to the kernel instruction
 	 * map. Possible fix - place return to the user code in the separate
 	 * region and allow this region instead. */
-	ret = mpu_allocKernelMap(&prog->hal);
+	ret = mpu_allocKernelMap(hal);
 	if (ret != EOK) {
 		return ret;
 	}
-	ret = mpu_mapsAlloc(&prog->hal, imaps, imapSz);
+	ret = mpu_mapsAlloc(hal, imaps, imapSz);
 	if (ret != EOK) {
 		return ret;
 	}
-	ret = mpu_mapsAlloc(&prog->hal, dmaps, dmapSz);
+	ret = mpu_mapsAlloc(hal, dmaps, dmapSz);
 	if (ret != EOK) {
 		return ret;
 	}
 
-	mpu_regionInvalidate(&prog->hal, prog->hal.mpu.allocCnt, mpu_common.regMax);
+	mpu_regionInvalidate(hal, hal->mpu.allocCnt, mpu_common.regMax);
 
 	return EOK;
 }

--- a/hal/armv8m/mpu.h
+++ b/hal/armv8m/mpu.h
@@ -19,41 +19,19 @@
 #include <hal/hal.h>
 
 
-#define MPU_BASE ((void *)0xe000ed90)
-
-#define MPU_MAX_REGIONS 16
-
-
-typedef struct {
-	u32 rbar;
-	u32 rlar;
-} mpu_region_t;
-
-
-typedef struct {
-	u32 type;
-	u32 regCnt;
-	u32 regMax;
-	u32 mapCnt;
-	mpu_region_t region[MPU_MAX_REGIONS] __attribute__((aligned(8)));
-	u32 mapId[MPU_MAX_REGIONS];
-} mpu_common_t;
-
-
-/* Get const pointer to read only mpu_common structure */
-extern const mpu_common_t *const mpu_getCommon(void);
-
-
 /* Reset structures and detect MPU type */
 extern void mpu_init(void);
 
 
-/* Allocate MPU sub-regions and link with a map */
-extern int mpu_regionAlloc(addr_t addr, addr_t end, u32 attr, u32 mapId, unsigned int enable);
+extern void mpu_kernelEntryPoint(addr_t addr);
 
 
-/* Get MPU regions setup into hal_syspage_t structure */
+/* Get MPU info into hal_syspage_t structure */
 extern void mpu_getHalData(hal_syspage_t *hal);
+
+
+/* Get MPU regions setup into syspage_prog_t structure */
+extern int mpu_getHalProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz);
 
 
 #endif

--- a/hal/armv8m/mpu.h
+++ b/hal/armv8m/mpu.h
@@ -30,8 +30,8 @@ extern void mpu_kernelEntryPoint(addr_t addr);
 extern void mpu_getHalData(hal_syspage_t *hal);
 
 
-/* Get MPU regions setup into syspage_prog_t structure */
-extern int mpu_getHalProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz);
+/* Get MPU regions setup into syspage_part_t structure */
+extern int mpu_getHalPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz);
 
 
 #endif

--- a/hal/armv8m/nrf/hal.c
+++ b/hal/armv8m/nrf/hal.c
@@ -94,12 +94,13 @@ void hal_kernelGetEntryPointOffset(addr_t *off, int *indirect)
 void hal_kernelEntryPoint(addr_t addr)
 {
 	hal_common.entry = addr;
+	mpu_kernelEntryPoint(addr);
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
-	return mpu_regionAlloc(start, end, attr, mapId, 1);
+	return mpu_getHalProgData(prog, imaps, imapSz, dmaps, dmapSz);
 }
 
 

--- a/hal/armv8m/nrf/hal.c
+++ b/hal/armv8m/nrf/hal.c
@@ -98,9 +98,9 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
-	return mpu_getHalProgData(prog, imaps, imapSz, dmaps, dmapSz);
+	return mpu_getHalPartData(part, imaps, imapSz, dmaps, dmapSz);
 }
 
 

--- a/hal/armv8m/stm32/hal.c
+++ b/hal/armv8m/stm32/hal.c
@@ -125,12 +125,13 @@ void hal_kernelGetEntryPointOffset(addr_t *off, int *indirect)
 void hal_kernelEntryPoint(addr_t addr)
 {
 	hal_common.entry = addr;
+	mpu_kernelEntryPoint(addr);
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
-	return mpu_regionAlloc(start, end, attr, mapId, 1);
+	return mpu_getHalProgData(prog, imaps, imapSz, dmaps, dmapSz);
 }
 
 

--- a/hal/armv8m/stm32/hal.c
+++ b/hal/armv8m/stm32/hal.c
@@ -129,9 +129,9 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
-	return mpu_getHalProgData(prog, imaps, imapSz, dmaps, dmapSz);
+	return mpu_getHalPartData(part, imaps, imapSz, dmaps, dmapSz);
 }
 
 

--- a/hal/armv8r/mps3an536/hal.c
+++ b/hal/armv8r/mps3an536/hal.c
@@ -88,7 +88,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/armv8r/mps3an536/hal.c
+++ b/hal/armv8r/mps3an536/hal.c
@@ -88,7 +88,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/hal.h
+++ b/hal/hal.h
@@ -62,8 +62,8 @@ extern void hal_kernelEntryPoint(addr_t addr);
 extern void hal_kernelGetEntryPointOffset(addr_t *off, int *indirect);
 
 
-/* Function validates and add memory map at hal region level */
-extern int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId);
+/* Function validates and adds program memory maps at hal region level */
+extern int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz);
 
 
 /* Function returns entry located near the start of the declared memory */

--- a/hal/hal.h
+++ b/hal/hal.h
@@ -62,8 +62,8 @@ extern void hal_kernelEntryPoint(addr_t addr);
 extern void hal_kernelGetEntryPointOffset(addr_t *off, int *indirect);
 
 
-/* Function validates and adds program memory maps at hal region level */
-extern int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz);
+/* Function validates and adds partition memory maps at hal region level */
+extern int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz);
 
 
 /* Function returns entry located near the start of the declared memory */

--- a/hal/ia32/memory.c
+++ b/hal/ia32/memory.c
@@ -269,7 +269,7 @@ static int memory_enableA20(void)
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/ia32/memory.c
+++ b/hal/ia32/memory.c
@@ -269,7 +269,7 @@ static int memory_enableA20(void)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/riscv64/gaisler/hal.c
+++ b/hal/riscv64/gaisler/hal.c
@@ -90,7 +90,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/riscv64/gaisler/hal.c
+++ b/hal/riscv64/gaisler/hal.c
@@ -90,7 +90,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/riscv64/generic/hal.c
+++ b/hal/riscv64/generic/hal.c
@@ -89,7 +89,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/riscv64/generic/hal.c
+++ b/hal/riscv64/generic/hal.c
@@ -89,7 +89,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/sparcv8leon/gaisler/generic/hal.c
+++ b/hal/sparcv8leon/gaisler/generic/hal.c
@@ -97,7 +97,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/sparcv8leon/gaisler/generic/hal.c
+++ b/hal/sparcv8leon/gaisler/generic/hal.c
@@ -97,7 +97,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/sparcv8leon/gaisler/gr712rc/hal.c
+++ b/hal/sparcv8leon/gaisler/gr712rc/hal.c
@@ -98,7 +98,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/sparcv8leon/gaisler/gr712rc/hal.c
+++ b/hal/sparcv8leon/gaisler/gr712rc/hal.c
@@ -98,7 +98,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/sparcv8leon/gaisler/gr716/hal.c
+++ b/hal/sparcv8leon/gaisler/gr716/hal.c
@@ -100,7 +100,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/sparcv8leon/gaisler/gr716/hal.c
+++ b/hal/sparcv8leon/gaisler/gr716/hal.c
@@ -100,7 +100,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/sparcv8leon/gaisler/gr740/hal.c
+++ b/hal/sparcv8leon/gaisler/gr740/hal.c
@@ -99,7 +99,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_memoryAddMap(addr_t start, addr_t end, u32 attr, u32 mapId)
+int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/hal/sparcv8leon/gaisler/gr740/hal.c
+++ b/hal/sparcv8leon/gaisler/gr740/hal.c
@@ -99,7 +99,7 @@ void hal_kernelEntryPoint(addr_t addr)
 }
 
 
-int hal_getProgData(syspage_prog_t *prog, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
+int hal_getPartData(hal_syspage_part_t *part, const char *imaps, size_t imapSz, const char *dmaps, size_t dmapSz)
 {
 	return 0;
 }

--- a/syspage.c
+++ b/syspage.c
@@ -285,10 +285,6 @@ int syspage_mapAdd(const char *name, addr_t start, addr_t end, const char *attr)
 		syspage_sortedInsert(map, entry);
 		start = entry->end;
 	}
-	res = hal_memoryAddMap(map->start, map->end, map->attr, map->id);
-	if (res < 0) {
-		return res;
-	}
 
 	return EOK;
 }
@@ -465,6 +461,28 @@ unsigned int syspage_mapRangeCheck(addr_t start, addr_t end, unsigned int *attrO
 }
 
 
+int syspage_mapAddrResolve(addr_t addr, const char **name)
+{
+	const syspage_map_t *map = syspage_common.syspage->maps;
+
+	if (map == NULL) {
+		log_error("\nsyspage: %x does not match any map", addr);
+		return -EINVAL;
+	}
+
+	do {
+		if ((addr < map->end) && (addr >= map->start)) {
+			*name = map->name;
+			return EOK;
+		}
+		map = map->next;
+	} while (map != syspage_common.syspage->maps);
+
+	log_error("\nsyspage: %x does not match any map", addr);
+	return -EINVAL;
+}
+
+
 const char *syspage_mapName(u8 id)
 {
 	const syspage_map_t *map = syspage_common.syspage->maps;
@@ -529,6 +547,11 @@ syspage_prog_t *syspage_progAdd(const char *argv, u32 flags)
 	return prog;
 }
 
+
+syspage_prog_t *syspage_progsGet(void)
+{
+	return syspage_common.syspage->progs;
+}
 
 
 /* Set console */

--- a/syspage.c
+++ b/syspage.c
@@ -27,14 +27,18 @@ struct {
 
 	void *heapTop;
 	void *heapEnd;
+
+	int defaultScheduler;
 } syspage_common;
+
+
+static syspage_sched_t *syspage_schedulerCreateDefault(void);
 
 
 /* General functions */
 
 void syspage_init(void)
 {
-	syspage_sched_window_t *schedWindow;
 	syspage_part_t *partition;
 
 	syspage_common.syspage = (syspage_t *)__heap_base;
@@ -42,7 +46,6 @@ void syspage_init(void)
 	syspage_common.syspage->maps = NULL;
 	syspage_common.syspage->partitions = NULL;
 	syspage_common.syspage->progs = NULL;
-	syspage_common.syspage->schedWindows = NULL;
 	syspage_common.syspage->console = console_default;
 
 	syspage_common.heapTop = (void *)ALIGN_ADDR((addr_t)__heap_base + sizeof(syspage_t), sizeof(long long));
@@ -52,19 +55,6 @@ void syspage_init(void)
 
 	hal_syspageSet(&syspage_common.syspage->hs);
 
-	/* Initialize background scheduler window */
-	schedWindow = (syspage_sched_window_t *)syspage_alloc(sizeof(syspage_sched_window_t));
-	if (schedWindow != NULL) {
-		schedWindow->next = schedWindow;
-		schedWindow->prev = schedWindow;
-		schedWindow->stop = 0;
-		schedWindow->id = 0;
-		syspage_common.syspage->schedWindows = schedWindow;
-	}
-	else {
-		log_error("\nsyspage: Cannot allocate memory for background scheduler window");
-	}
-
 	/* Initialize background partition */
 	partition = syspage_alloc(sizeof(syspage_part_t) + sizeof(NAME_PART_DEFAULT) + 1U);
 	if (partition != NULL) {
@@ -73,15 +63,18 @@ void syspage_init(void)
 		partition->name = (char *)partition + sizeof(syspage_part_t);
 		hal_strcpy(partition->name, NAME_PART_DEFAULT);
 		partition->availableMem = (size_t)-1;
-		partition->schedWindowsMask = 1U;
+		partition->schedWindow = 0U;
 		partition->hal = NULL;
 		partition->id = 0U;
 		hal_memset(partition->maps, 0xff, sizeof(partition->maps));
 		syspage_common.syspage->partitions = partition;
 	}
 	else {
-		log_error("\nsyspage: Cannot allocate memory for background partition");
+		log_error("\nsyspage: Cannot allocate memory for default partition");
 	}
+
+	syspage_common.syspage->sched = syspage_schedulerCreateDefault();
+	syspage_common.defaultScheduler = 1;
 }
 
 
@@ -538,46 +531,44 @@ const char *syspage_mapName(u8 id)
 
 /* Scheduler's functions */
 
-syspage_sched_window_t *syspage_schedWindowAdd(void)
+int syspage_schedulerConfigSet(syspage_sched_t *config)
 {
-	syspage_sched_window_t *window;
+	if (syspage_common.defaultScheduler == 0) {
+		return -EEXIST;
+	}
+	syspage_common.syspage->sched = config;
+	syspage_common.defaultScheduler = 0;
+	return EOK;
+}
 
-	window = syspage_alloc(sizeof(syspage_sched_window_t));
-	if (window == NULL) {
+
+static syspage_sched_t *syspage_schedulerCreateDefault(void)
+{
+	syspage_sched_t *config = syspage_alloc(sizeof(*config) + sizeof(syspage_sched_cycle_t) * 1);
+	if (config == NULL) {
+		log_error("\nCannot allocate memory for default scheduler configuration");
 		return NULL;
 	}
-
-	if (syspage_common.syspage->schedWindows == NULL) {
-		window->next = window;
-		window->prev = window;
-		syspage_common.syspage->schedWindows = window;
+	config->windowCnt = 0; /* Use kernel threads window */
+	config->cycleCnt = 1;
+	config->flags = sFlagCommonCycle;
+	config->cycles[0] = syspage_alloc(sizeof(syspage_sched_cycle_t));
+	if (config->cycles[0] == NULL) {
+		log_error("\nCannot allocate memory for default scheduler configuration");
+		return NULL;
 	}
-	else {
-		window->prev = syspage_common.syspage->schedWindows->prev;
-		syspage_common.syspage->schedWindows->prev->next = window;
-		window->next = syspage_common.syspage->schedWindows;
-		syspage_common.syspage->schedWindows->prev = window;
-	}
+	config->cycles[0]->bgId = 0U;
+	config->cycles[0]->len = 0U;
 
-	return window;
+	return config;
 }
 
-size_t syspage_schedulerWindowCount(void)
+
+syspage_sched_t *syspage_schedulerConfigGet(void)
 {
-	size_t count = 0;
-	syspage_sched_window_t *window = syspage_common.syspage->schedWindows;
-
-	if (window == NULL) {
-		return 0;
-	}
-
-	do {
-		count++;
-		window = window->next;
-	} while (window != syspage_common.syspage->schedWindows);
-
-	return count;
+	return syspage_common.syspage->sched;
 }
+
 
 /* Partition's functions */
 

--- a/syspage.c
+++ b/syspage.c
@@ -34,10 +34,15 @@ struct {
 
 void syspage_init(void)
 {
+	syspage_sched_window_t *schedWindow;
+	syspage_part_t *partition;
+
 	syspage_common.syspage = (syspage_t *)__heap_base;
 
 	syspage_common.syspage->maps = NULL;
+	syspage_common.syspage->partitions = NULL;
 	syspage_common.syspage->progs = NULL;
+	syspage_common.syspage->schedWindows = NULL;
 	syspage_common.syspage->console = console_default;
 
 	syspage_common.heapTop = (void *)ALIGN_ADDR((addr_t)__heap_base + sizeof(syspage_t), sizeof(long long));
@@ -46,6 +51,37 @@ void syspage_init(void)
 	syspage_common.syspage->size = (size_t)(syspage_common.heapTop - (void *)syspage_common.syspage);
 
 	hal_syspageSet(&syspage_common.syspage->hs);
+
+	/* Initialize background scheduler window */
+	schedWindow = (syspage_sched_window_t *)syspage_alloc(sizeof(syspage_sched_window_t));
+	if (schedWindow != NULL) {
+		schedWindow->next = schedWindow;
+		schedWindow->prev = schedWindow;
+		schedWindow->stop = 0;
+		schedWindow->id = 0;
+		syspage_common.syspage->schedWindows = schedWindow;
+	}
+	else {
+		log_error("\nsyspage: Cannot allocate memory for background scheduler window");
+	}
+
+	/* Initialize background partition */
+	partition = syspage_alloc(sizeof(syspage_part_t) + sizeof(NAME_PART_DEFAULT) + 1U);
+	if (partition != NULL) {
+		partition->next = partition;
+		partition->prev = partition;
+		partition->name = (char *)partition + sizeof(syspage_part_t);
+		hal_strcpy(partition->name, NAME_PART_DEFAULT);
+		partition->availableMem = (size_t)-1;
+		partition->schedWindowsMask = 1U;
+		partition->hal = NULL;
+		partition->id = 0U;
+		hal_memset(partition->maps, 0xff, sizeof(partition->maps));
+		syspage_common.syspage->partitions = partition;
+	}
+	else {
+		log_error("\nsyspage: Cannot allocate memory for background partition");
+	}
 }
 
 
@@ -500,6 +536,101 @@ const char *syspage_mapName(u8 id)
 }
 
 
+/* Scheduler's functions */
+
+syspage_sched_window_t *syspage_schedWindowAdd(void)
+{
+	syspage_sched_window_t *window;
+
+	window = syspage_alloc(sizeof(syspage_sched_window_t));
+	if (window == NULL) {
+		return NULL;
+	}
+
+	if (syspage_common.syspage->schedWindows == NULL) {
+		window->next = window;
+		window->prev = window;
+		syspage_common.syspage->schedWindows = window;
+	}
+	else {
+		window->prev = syspage_common.syspage->schedWindows->prev;
+		syspage_common.syspage->schedWindows->prev->next = window;
+		window->next = syspage_common.syspage->schedWindows;
+		syspage_common.syspage->schedWindows->prev = window;
+	}
+
+	return window;
+}
+
+size_t syspage_schedulerWindowCount(void)
+{
+	size_t count = 0;
+	syspage_sched_window_t *window = syspage_common.syspage->schedWindows;
+
+	if (window == NULL) {
+		return 0;
+	}
+
+	do {
+		count++;
+		window = window->next;
+	} while (window != syspage_common.syspage->schedWindows);
+
+	return count;
+}
+
+/* Partition's functions */
+
+syspage_part_t *syspage_partAdd(void)
+{
+	syspage_part_t *part;
+
+	part = syspage_alloc(sizeof(syspage_part_t));
+	if (part == NULL) {
+		return NULL;
+	}
+
+	/* syspage heap is not zeroed - mark all access map slots as unused */
+	hal_memset(part->maps, 0xff, sizeof(part->maps));
+
+	part->prev = syspage_common.syspage->partitions->prev;
+	syspage_common.syspage->partitions->prev->next = part;
+	part->next = syspage_common.syspage->partitions;
+	syspage_common.syspage->partitions->prev = part;
+	part->id = part->prev->id + 1;
+
+	return part;
+}
+
+
+int syspage_partResolve(const char *name, syspage_part_t **result)
+{
+	syspage_part_t *part = syspage_common.syspage->partitions;
+
+	*result = NULL;
+
+	if (part == NULL) {
+		return -EINVAL;
+	}
+
+	do {
+		if (hal_strcmp(name, part->name) == 0) {
+			*result = part;
+			return EOK;
+		}
+		part = part->next;
+	} while (part != syspage_common.syspage->partitions);
+
+	return -EINVAL;
+}
+
+
+syspage_part_t *syspage_partsGet(void)
+{
+	return syspage_common.syspage->partitions;
+}
+
+
 /* Program's functions */
 
 syspage_prog_t *syspage_progAdd(const char *argv, u32 flags)
@@ -545,12 +676,6 @@ syspage_prog_t *syspage_progAdd(const char *argv, u32 flags)
 	}
 
 	return prog;
-}
-
-
-syspage_prog_t *syspage_progsGet(void)
-{
-	return syspage_common.syspage->progs;
 }
 
 

--- a/syspage.c
+++ b/syspage.c
@@ -70,6 +70,7 @@ void syspage_init(void)
 		partition->schedWindow = 0U;
 		partition->hal = NULL;
 		partition->id = 0U;
+		partition->flags = pFlagIntr | pFlagTime | pFlagPctl | pFlagPerf | pFlagAllMem;
 		hal_memset(partition->maps, 0xff, sizeof(partition->maps));
 		syspage_common.syspage->partitions = partition;
 	}

--- a/syspage.c
+++ b/syspage.c
@@ -19,6 +19,8 @@
 
 #define ALIGN_ADDR(addr, align) (align ? ((addr + (align - 1)) & ~(align - 1)) : addr)
 
+#define PART_ID_MAX (sizeof(unsigned int) * 8 - 1)
+
 extern char __heap_base[], __heap_limit[];
 
 
@@ -40,11 +42,13 @@ static syspage_sched_t *syspage_schedulerCreateDefault(void);
 void syspage_init(void)
 {
 	syspage_part_t *partition;
+	syspage_named_port_t *port;
 
 	syspage_common.syspage = (syspage_t *)__heap_base;
 
 	syspage_common.syspage->maps = NULL;
 	syspage_common.syspage->partitions = NULL;
+	syspage_common.syspage->namedPorts = NULL;
 	syspage_common.syspage->progs = NULL;
 	syspage_common.syspage->console = console_default;
 
@@ -75,6 +79,14 @@ void syspage_init(void)
 
 	syspage_common.syspage->sched = syspage_schedulerCreateDefault();
 	syspage_common.defaultScheduler = 1;
+
+	port = syspage_namedPortAdd();
+	if (port != NULL) {
+		port->name = (char *)syspage_alloc(sizeof(USRV_PORT_NAME) + 1);
+		hal_strcpy(port->name, USRV_PORT_NAME);
+		port->recvMask = 0U;  /* Only kernel can receive */
+		port->sendMask = ~0U; /* All partitions can send */
+	}
 }
 
 
@@ -589,6 +601,10 @@ syspage_part_t *syspage_partAdd(void)
 	part->next = syspage_common.syspage->partitions;
 	syspage_common.syspage->partitions->prev = part;
 	part->id = part->prev->id + 1;
+	if (part->id > PART_ID_MAX) {
+		log_error("\nsyspage: Too many partitions!");
+		return NULL;
+	}
 
 	return part;
 }
@@ -619,6 +635,33 @@ int syspage_partResolve(const char *name, syspage_part_t **result)
 syspage_part_t *syspage_partsGet(void)
 {
 	return syspage_common.syspage->partitions;
+}
+
+
+/* Named Port's functions */
+
+syspage_named_port_t *syspage_namedPortAdd(void)
+{
+	syspage_named_port_t *port;
+
+	port = syspage_alloc(sizeof(syspage_named_port_t));
+	if (port == NULL) {
+		return NULL;
+	}
+
+	if (syspage_common.syspage->namedPorts == NULL) {
+		port->next = port;
+		port->prev = port;
+		syspage_common.syspage->namedPorts = port;
+	}
+	else {
+		port->prev = syspage_common.syspage->namedPorts->prev;
+		syspage_common.syspage->namedPorts->prev->next = port;
+		port->next = syspage_common.syspage->namedPorts;
+		syspage_common.syspage->namedPorts->prev = port;
+	}
+
+	return port;
 }
 
 

--- a/syspage.h
+++ b/syspage.h
@@ -57,6 +57,9 @@ extern int syspage_mapRangeResolve(const char *name, addr_t *start, addr_t *end)
 extern unsigned int syspage_mapRangeCheck(addr_t start, addr_t end, unsigned int *attrOut);
 
 
+extern int syspage_mapAddrResolve(addr_t addr, const char **name);
+
+
 extern const char *syspage_mapName(u8 id);
 
 
@@ -78,6 +81,9 @@ extern syspage_prog_t *syspage_progAdd(const char *argv, u32 flags);
  * Caller can then write desired contents into the memory pointed by the return pointer.
  */
 extern void *syspage_progAllocateAndAdd(const char *map, size_t size, const char *argv, u32 flags, int allowOverwrite);
+
+
+extern syspage_prog_t *syspage_progsGet(void);
 
 
 extern void syspage_progShow(void);

--- a/syspage.h
+++ b/syspage.h
@@ -89,6 +89,8 @@ extern syspage_part_t *syspage_partsGet(void);
 extern int syspage_partResolve(const char *partName, syspage_part_t **result);
 
 
+extern syspage_named_port_t *syspage_namedPortAdd(void);
+
 /* Program's functions */
 extern syspage_prog_t *syspage_progAdd(const char *argv, u32 flags);
 

--- a/syspage.h
+++ b/syspage.h
@@ -19,7 +19,12 @@
 #include <hal/hal.h>
 
 
+#define NAME_PART_DEFAULT "default"
+
+
+/* clang-format off */
 enum { flagSyspageExec = 0x01, flagSyspageNoCopy = 0x02 };
+/* clang-format on */
 
 
 typedef struct {
@@ -68,6 +73,21 @@ extern void syspage_mapShow(void);
 
 extern mapent_t *syspage_entryAdd(const char *mapName, addr_t start, size_t size, unsigned int align);
 
+/* Scheduler's functions */
+extern syspage_sched_window_t *syspage_schedWindowAdd(void);
+
+
+extern size_t syspage_schedulerWindowCount(void);
+
+/* Partition's functions */
+extern syspage_part_t *syspage_partAdd(void);
+
+
+extern syspage_part_t *syspage_partsGet(void);
+
+
+extern int syspage_partResolve(const char *partName, syspage_part_t **result);
+
 
 /* Program's functions */
 extern syspage_prog_t *syspage_progAdd(const char *argv, u32 flags);
@@ -81,9 +101,6 @@ extern syspage_prog_t *syspage_progAdd(const char *argv, u32 flags);
  * Caller can then write desired contents into the memory pointed by the return pointer.
  */
 extern void *syspage_progAllocateAndAdd(const char *map, size_t size, const char *argv, u32 flags, int allowOverwrite);
-
-
-extern syspage_prog_t *syspage_progsGet(void);
 
 
 extern void syspage_progShow(void);

--- a/syspage.h
+++ b/syspage.h
@@ -74,10 +74,10 @@ extern void syspage_mapShow(void);
 extern mapent_t *syspage_entryAdd(const char *mapName, addr_t start, size_t size, unsigned int align);
 
 /* Scheduler's functions */
-extern syspage_sched_window_t *syspage_schedWindowAdd(void);
+extern int syspage_schedulerConfigSet(syspage_sched_t *config);
 
 
-extern size_t syspage_schedulerWindowCount(void);
+extern syspage_sched_t *syspage_schedulerConfigGet(void);
 
 /* Partition's functions */
 extern syspage_part_t *syspage_partAdd(void);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add loader-side support for kernel partitioning.

Key changes:
- Introduce `part` command for creating partitions with configurable memory maps (allocable and accessible) and flags (e.g. IPC permission)
- Introduce `sched` command for scheduler temporal windows configuration
- Rework `mpu` command to show per-app MPU configuration
- Move MPU configuration originally somewhat dynamicly created inside kernel to plo-created `syspage_part_t`
- Add optional partition name argument to `app` command
backward-compatible default partition is created by each app without partition specified.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is the companion change to the kernel partitioning support. Currently system configuration mechanisms are based on plo-scripts, so partitioning configuration follows that convetion.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
