### PR TITLE
hal/stm32n6: initialize dtcm

### DIFF
--- a/hal/armv8m/stm32/n6/stm32n6.c
+++ b/hal/armv8m/stm32/n6/stm32n6.c
@@ -1038,6 +1038,22 @@ static void _stm32_initSRAM(void)
 }
 
 
+/* Zero out contents of DTCM using word size writes - this initializes ECC values in the memory */
+static void _stm32_initDTCM(void)
+{
+	u32 cfgdtcmsz, size, i;
+
+	volatile u32 *const dtcm = (volatile u32 *)0x30000000;
+
+	cfgdtcmsz = (*(stm32_common.syscfg + syscfg_cm55tcmcr) >> 4) & 0xf;
+	size = 1 << (cfgdtcmsz + 9);
+
+	for (i = 0; i < size / 4; i++) {
+		dtcm[i] = 0U;
+	}
+}
+
+
 void _stm32_initHalOnly(void)
 {
 	stm32_common.iwdg = IWDG_BASE;
@@ -1108,6 +1124,7 @@ void _stm32_init(void)
 	_stm32_rccSetDevClock(dev_per, 0);
 
 	_stm32_initSRAM();
+	_stm32_initDTCM();
 
 	/* Enable independent power supplies for GPIOs. */
 	_stm32_pwrSupplyInit(pwr_supply_vddio2); /* PO[5:0], PP[15:0] */


### PR DESCRIPTION
TASK: PP-473

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change initializes DTCM memory during startup of armv8m55-stm32n6
<!--- Describe your changes shortly -->

## Motivation and Context
This change is required to allow moving kernel data to DTCM, which has great performance benefits. The DTCM memory needs to be fully cleared before it can be used because otherwise access causes bus faults due to ECC errors.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m55-stm32n6.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
