### PR TITLE
hal/armv7r/zynqmp/zynqmp.c: update reboot reason lockstep and wdt

### DIFF
--- a/hal/armv7r/zynqmp/zynqmp.c
+++ b/hal/armv7r/zynqmp/zynqmp.c
@@ -882,6 +882,7 @@ unsigned int hal_getBootReason(void)
 void _zynqmp_init(void)
 {
 	int ret;
+	u32 reg;
 	zynq_common.csu = (void *)CSU_BASE_ADDRESS;
 	zynq_common.csudma = (void *)CSUDMA_BASE_ADDRESS;
 	zynq_common.pmu_global = (void *)PMU_GLOBAL_BASE_ADDRESS;
@@ -893,6 +894,18 @@ void _zynqmp_init(void)
 	/* Read and clear reset flags */
 	zynq_common.resetFlags = *(zynq_common.crl_apb + crl_apb_reset_reason) & 0x7f;
 	*(zynq_common.crl_apb + crl_apb_reset_reason) = zynq_common.resetFlags;
+
+	/* Store and clear latched PMU error status registers */
+	/* Only RPU lock step (bits 7:6) and LPD_SWD (bit 12) are supported*/
+	reg = *(zynq_common.pmu_global + pmu_global_error_status_1);
+	if ((reg & PMU_ERR_RPU_LS) != 0) {
+		zynq_common.resetFlags |= ZYNQ_RESET_REASON_R5_LS; /* R5 lockstep error */
+	}
+	else if ((reg & PMU_ERR_LPD_SWDT) != 0) {
+		zynq_common.resetFlags |= ZYNQ_RESET_REASON_LPD_SWDT; /* LPD SWD error */
+	}
+	*(zynq_common.pmu_global + pmu_global_error_status_1) = 0xffffffff;
+	*(zynq_common.pmu_global + pmu_global_error_status_2) = 0xffffffff;
 
 	_zynqmp_pllInit();
 

--- a/hal/armv7r/zynqmp/zynqmp.h
+++ b/hal/armv7r/zynqmp/zynqmp.h
@@ -19,6 +19,16 @@
 
 #include "hal/armv7r/types.h"
 
+#define PMU_ERR_DDR_ECC  (0x1U)
+#define PMU_ERR_OCM_ECC  (0x1U << 1)
+#define PMU_ERR_RPU0_RAM (0x1U << 2)
+#define PMU_ERR_RPU1_RAM (0x1U << 3)
+#define PMU_ERR_LPD_TMP  (0x1U << 4)
+#define PMU_ERR_FPD_TMP  (0x1U << 5)
+#define PMU_ERR_RPU_LS   (0x3U << 6)
+#define PMU_ERR_RPU_CCF  (0x1UL << 9)
+#define PMU_ERR_LPD_SWDT (0x1UL << 12)
+#define PMU_ERR_FPD_SWDT (0x1UL << 13)
 
 #define ZYNQ_RESET_REASON_EXT_POR   (1 << 0)
 #define ZYNQ_RESET_REASON_INT_POR   (1 << 1)
@@ -27,6 +37,10 @@
 #define ZYNQ_RESET_REASON_EXT_SRST  (1 << 4)
 #define ZYNQ_RESET_REASON_SOFT_SRST (1 << 5)
 #define ZYNQ_RESET_REASON_DEBUG     (1 << 6)
+
+/* R5 specific reset reasons, stored in the same reset reason variable passed to kernel */
+#define ZYNQ_RESET_REASON_R5_LS    (1 << 16)
+#define ZYNQ_RESET_REASON_LPD_SWDT (1 << 17)
 
 
 /* clang-format off */


### PR DESCRIPTION
This PR introduces better reboot reason investigation for ZynqMP RPU (ARMV7r) target. 

## Description
PMU_ERROR_STATUS registers are examined during reboot reason investigation. 
Once read both regs are clear to ensure erroneous reset is not trigger during lock step or watchdog configuration.

## Motivation and Context
Change is introduced to ensure Watchdog handlers for ZynqMP RPU are properly configures. 
There was also intention to ensure the lock step vs watchdog reboot info is also available to user.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: (list targets here).

Tests are described in:
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/789

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [X] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.

https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/789